### PR TITLE
Implement MACP and final agent template

### DIFF
--- a/agent_forge/final_agent_template.py
+++ b/agent_forge/final_agent_template.py
@@ -1,0 +1,30 @@
+from typing import Dict, Any, Callable
+from langroid import ChatAgent, ChatAgentConfig
+from communications import MultiAgentCommunicationProtocol, Message, MessageType
+
+class FinalAgent:
+    """Template agent using Langroid and MACP for communication and tool use."""
+
+    def __init__(self, name: str, model: str, protocol: MultiAgentCommunicationProtocol):
+        config = ChatAgentConfig(name=name, llm=dict(chat_model=model))
+        self.agent = ChatAgent(config)
+        self.name = name
+        self.protocol = protocol
+        self.protocol.subscribe(self.name, self.handle_message)
+        self.tools: Dict[str, Callable[[Dict[str, Any]], Any]] = {}
+
+    def add_tool(self, name: str, handler: Callable[[Dict[str, Any]], Any]):
+        self.tools[name] = handler
+        self.protocol.register_tool(name, handler)
+
+    async def handle_message(self, message: Message):
+        if message.type == MessageType.QUERY:
+            tool_name = message.content.get("tool")
+            params = message.content.get("params", {})
+            if tool_name and tool_name in self.tools:
+                result = await self.tools[tool_name](params)
+                response = Message(type=MessageType.RESPONSE, sender=self.name, receiver=message.sender, content=result, parent_id=message.id)
+                await self.protocol.send_message(response)
+
+    async def query_agent(self, agent_id: str, tool: str, params: Dict[str, Any]) -> Any:
+        return await self.protocol.request_tool(self.name, agent_id, tool, params)

--- a/agent_forge/main.py
+++ b/agent_forge/main.py
@@ -98,6 +98,16 @@ def main(config_file: str, output_dir: str):
         enhanced_model.tokenizer.save_pretrained(trained_model_path)
         print(f"Trained model saved to: {trained_model_path}")
 
+        # Initialize final agent template using MACP
+        from communications import MultiAgentCommunicationProtocol
+        from agent_forge.final_agent_template import FinalAgent
+        protocol = MultiAgentCommunicationProtocol()
+        final_agent = FinalAgent("forge_agent", trained_model_path, protocol)
+        final_agent_path = os.path.join(output_dir, "final_agent")
+        os.makedirs(final_agent_path, exist_ok=True)
+        enhanced_model.model.save_pretrained(final_agent_path)
+        enhanced_model.tokenizer.save_pretrained(final_agent_path)
+
         # Log training completion
         wandb.log({"step": "model_training", "trained_model_path": trained_model_path})
 

--- a/communications/init.py
+++ b/communications/init.py
@@ -1,5 +1,6 @@
 from .protocol import StandardCommunicationProtocol
+from .macp import MultiAgentCommunicationProtocol
 from .message import Message, MessageType, Priority
 from .queue import MessageQueue
 
-__all__ = ['StandardCommunicationProtocol', 'Message', 'MessageType', 'Priority', 'MessageQueue']
+__all__ = ['StandardCommunicationProtocol', 'MultiAgentCommunicationProtocol', 'Message', 'MessageType', 'Priority', 'MessageQueue']

--- a/communications/macp.py
+++ b/communications/macp.py
@@ -1,0 +1,30 @@
+from typing import Dict, Any, Callable, Coroutine, List, Set
+from .protocol import StandardCommunicationProtocol, Message, MessageType, Priority
+
+class MultiAgentCommunicationProtocol(StandardCommunicationProtocol):
+    """Extended protocol supporting group messaging and tool requests."""
+
+    def __init__(self):
+        super().__init__()
+        self.groups: Dict[str, Set[str]] = {}
+        self.tool_registry: Dict[str, Callable[[Dict[str, Any]], Any]] = {}
+
+    def register_tool(self, name: str, handler: Callable[[Dict[str, Any]], Any]):
+        self.tool_registry[name] = handler
+
+    async def request_tool(self, sender: str, receiver: str, tool_name: str, params: Dict[str, Any]) -> Any:
+        content = {"tool": tool_name, "params": params}
+        msg = Message(type=MessageType.QUERY, sender=sender, receiver=receiver, content=content)
+        await self.send_message(msg)
+        response = await self.receive_message(sender)
+        return response.content
+
+    def create_group(self, group_id: str, members: List[str]):
+        self.groups[group_id] = set(members)
+        for member in members:
+            self.subscribe(group_id, self.subscribers.get(member, lambda m: None))
+
+    async def broadcast(self, sender: str, message_type: MessageType, content: Dict[str, Any], priority: Priority = Priority.MEDIUM):
+        for agent_id in self.subscribers.keys():
+            msg = Message(type=message_type, sender=sender, receiver=agent_id, content=content, priority=priority)
+            await self.send_message(msg)


### PR DESCRIPTION
## Summary
- add MultiAgentCommunicationProtocol for group communication and tool usage
- export new protocol in communications package
- create a final agent template leveraging Langroid and MACP
- integrate template creation step in agent forge pipeline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684ba676d314832c934c6f6c1aa49770