### PR TITLE
Fix constructors for retrieval stores

### DIFF
--- a/rag_system/retrieval/graph_store.py
+++ b/rag_system/retrieval/graph_store.py
@@ -1,12 +1,20 @@
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple, Optional
 import networkx as nx
 from datetime import datetime
 from ..core.config import UnifiedConfig
 from ..core.structures import RetrievalResult
 
 class GraphStore:
-    def __init__(self, config: UnifiedConfig):
-        self.config = config
+    def __init__(self, config: Optional[UnifiedConfig] = None):
+        """Create a GraphStore.
+
+        Similar to :class:`VectorStore`, older code instantiated ``GraphStore``
+        without providing a configuration object which caused a ``TypeError``
+        after the constructor signature changed.  The configuration parameter is
+        now optional and defaults to a new :class:`UnifiedConfig` instance.
+        """
+
+        self.config = config or UnifiedConfig()
         self.graph = nx.Graph()
         self.driver = None  # This should be initialized with a proper Neo4j driver
         self.causal_edges = {}

--- a/rag_system/retrieval/vector_store.py
+++ b/rag_system/retrieval/vector_store.py
@@ -7,9 +7,20 @@ import os
 from ..core.config import UnifiedConfig
 from ..core.structures import RetrievalResult
 
+DEFAULT_DIMENSION = 768
+
 class VectorStore:
-    def __init__(self, config: UnifiedConfig, dimension: int):
-        self.config = config
+    def __init__(self, config: Optional[UnifiedConfig] = None, dimension: int = DEFAULT_DIMENSION):
+        """Create a VectorStore.
+
+        The previous version of :class:`VectorStore` required ``config`` and
+        ``dimension`` arguments.  Many parts of the codebase still instantiate
+        this class without any parameters which resulted in ``TypeError`` being
+        raised at runtime.  To maintain backwards compatibility we allow both
+        arguments to be optional and provide sensible defaults.
+        """
+
+        self.config = config or UnifiedConfig()
         self.dimension = dimension
         self.index = faiss.IndexFlatL2(dimension)
         self.documents: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- allow `VectorStore` and `GraphStore` to be created without arguments
- document default behaviour in new docstrings

## Testing
- `python -m pytest tests/test_unified_config.py -q`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ba512bc48832ca27f57a0eaeff297