### PR TITLE
fix: finalize RetrievalPlan definition

### DIFF
--- a/rag_system/core/structures.py
+++ b/rag_system/core/structures.py
@@ -36,4 +36,6 @@ class RetrievalPlan:
     query: str
     strategy: str
     filters: Dict[str, Any]
+    use_linearization: bool
     timestamp: datetime
+    version: int


### PR DESCRIPTION
## Summary
- complete the `RetrievalPlan` dataclass
- add missing newline at the end of the file

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684e6891627c832c9b8621551323054f