### PR TITLE
Fix duplicate DPO method

### DIFF
--- a/agents/unified_base_agent.py
+++ b/agents/unified_base_agent.py
@@ -326,10 +326,6 @@ class DecisionMakingLayer:
     def simulate(self, task: LangroidTask, context: str, option: str) -> float:
         return random.random()
 
-    async def direct_preference_optimization(self, task: LangroidTask, context: Any) -> str:
-        # Implement DPO logic
-        return "DPO placeholder result"
-
     async def direct_preference_optimization(self, task: LangroidTask, context: str) -> str:
         options = ["Approach X", "Approach Y", "Approach Z"]
         preferences = await self.get_preferences(task, context, options)


### PR DESCRIPTION
## Summary
- remove placeholder `direct_preference_optimization` method

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'torch', 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684e68938bd0832cb73dbdc8737d3904