### PR TITLE
Allow RAG pipeline configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,12 @@ Example:
 from agents.king.king_agent import KingAgent, KingAgentConfig
 from your_communication_protocol import CommunicationProtocol
 from rag_system.core.pipeline import EnhancedRAGPipeline
+from rag_system.core.config import UnifiedConfig
 
 # Initialize dependencies
 comm_protocol = CommunicationProtocol()
-rag_system = EnhancedRAGPipeline()
+rag_config = UnifiedConfig()
+rag_system = EnhancedRAGPipeline(rag_config)
 
 # Create KingAgent
 config = KingAgentConfig(name="KingAgent", description="Main coordinator for AI Village", model="gpt-4")

--- a/agents/king/README.md
+++ b/agents/king/README.md
@@ -90,10 +90,12 @@ Example:
 from agents.king.king_agent import KingAgent, KingAgentConfig
 from your_communication_protocol import CommunicationProtocol
 from your_rag_system import RAGSystem
+from rag_system.core.config import UnifiedConfig
 
 # Initialize dependencies
 comm_protocol = CommunicationProtocol()
-rag_system = RAGSystem()
+rag_config = UnifiedConfig()
+rag_system = RAGSystem(rag_config)
 
 # Create KingAgent
 config = KingAgentConfig(name="KingAgent", description="Main coordinator for AI Village", model="gpt-4")

--- a/agents/king/demo.py
+++ b/agents/king/demo.py
@@ -3,6 +3,7 @@ import logging
 from agents.king.king_agent import KingAgent, KingAgentConfig
 from communications.protocol import StandardCommunicationProtocol, Message, MessageType
 from rag_system.core.pipeline import EnhancedRAGPipeline as RAGSystem
+from rag_system.core.config import UnifiedConfig
 from agents.sage.sage_agent import SageAgent
 from agents.magi.magi_agent import MagiAgent
 from agents.utils.exceptions import AIVillageException
@@ -16,7 +17,8 @@ async def run_demo():
         # Initialize components
         logger.info("Initializing components...")
         communication_protocol = StandardCommunicationProtocol()
-        rag_system = RAGSystem()
+        rag_config = UnifiedConfig()
+        rag_system = RAGSystem(rag_config)
         
         # Create KingAgent
         logger.info("Creating KingAgent...")

--- a/agents/king/king_agent.py
+++ b/agents/king/king_agent.py
@@ -22,7 +22,7 @@ class KingAgent(UnifiedBaseAgent):
     ):
         super().__init__(config, communication_protocol)
         self.vector_store = vector_store
-        self.rag_pipeline = EnhancedRAGPipeline()  # Initialize the RAG pipeline
+        self.rag_pipeline = EnhancedRAGPipeline(config.rag_config)  # Initialize the RAG pipeline
         self.coordinator = KingCoordinator(config, communication_protocol)
         self.unified_planning_and_management = UnifiedPlanningAndManagement(communication_protocol, self.rag_pipeline, self)
         self.unified_analytics = UnifiedAnalytics()

--- a/rag_system/core/pipeline.py
+++ b/rag_system/core/pipeline.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any
 from rag_system.core.unified_config import unified_config
 from rag_system.core.base_component import BaseComponent
+from rag_system.core.config import UnifiedConfig
 from rag_system.core.latent_space_activation import LatentSpaceActivation
 from rag_system.retrieval.hybrid_retriever import HybridRetriever
 from rag_system.processing.reasoning_engine import UncertaintyAwareReasoningEngine
@@ -12,8 +13,9 @@ from rag_system.retrieval.bayes_net import BayesNet
 shared_bayes_net = BayesNet()
 
 class EnhancedRAGPipeline(BaseComponent):
-    def __init__(self):
-        self.config = unified_config
+    def __init__(self, config: UnifiedConfig | None = None):
+        """Initialize the RAG pipeline with an optional configuration."""
+        self.config = config or unified_config
         self.latent_space_activation = LatentSpaceActivation()
         self.hybrid_retriever = HybridRetriever(self.config)
         self.reasoning_engine = UncertaintyAwareReasoningEngine(self.config)

--- a/rag_system/main.py
+++ b/rag_system/main.py
@@ -50,7 +50,7 @@ async def initialize_components() -> Dict[str, Any]:
         "hybrid_retriever": HybridRetriever(unified_config),
         "reasoning_engine": UncertaintyAwareReasoningEngine(unified_config),
         "cognitive_nexus": CognitiveNexus(),
-        "pipeline": EnhancedRAGPipeline(),
+        "pipeline": EnhancedRAGPipeline(unified_config),
         "communication_protocol": communication_protocol,
         "king_agent": KingAgent(king_agent_config, communication_protocol, vector_store),
         "knowledge_tracker": UnifiedKnowledgeTracker(vector_store, graph_store),


### PR DESCRIPTION
## Summary
- inject `UnifiedConfig` into `EnhancedRAGPipeline`
- pass configuration object when creating the pipeline in KingAgent, main module and demo
- update documentation snippets to use the new signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError / ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_684e68947b20832caacf2a41c2534789