### PR TITLE
Implement embedding and keyword extraction

### DIFF
--- a/rag_system/agents/dynamic_knowledge_integration_agent.py
+++ b/rag_system/agents/dynamic_knowledge_integration_agent.py
@@ -18,5 +18,22 @@ class DynamicKnowledgeIntegrationAgent(AgentInterface):
         Args:
             new_relations (Dict[str, Any]): New relations to be added to the knowledge graph.
         """
-        # TODO: Implement logic to update the knowledge graph with new relations
-        self.graph_store.add_relations(new_relations)
+        # ``new_relations`` is expected to be a mapping describing edges to add
+        # to the underlying :class:`GraphStore`.  Each entry should contain a
+        # source node, a target node and a relation type.  The method gracefully
+        # handles missing nodes by creating them on-the-fly.
+
+        relations = new_relations.get("relations", [])
+        for rel in relations:
+            source = rel.get("source")
+            target = rel.get("target")
+            relation_type = rel.get("relation")
+            if not source or not target:
+                continue
+
+            if not self.graph_store.graph.has_node(source):
+                self.graph_store.graph.add_node(source)
+            if not self.graph_store.graph.has_node(target):
+                self.graph_store.graph.add_node(target)
+
+            self.graph_store.graph.add_edge(source, target, relation=relation_type)

--- a/rag_system/agents/key_concept_extractor.py
+++ b/rag_system/agents/key_concept_extractor.py
@@ -32,5 +32,33 @@ class KeyConceptExtractorAgent(AgentInterface):
         }
 
     def _extract_keywords_from_embeddings(self, embeddings) -> List[str]:
-        # TODO: Implement keyword extraction logic using embeddings
-        return []
+        """Derive simple keywords from token embeddings.
+
+        The ``BERTEmbeddingModel.encode`` method returns a tuple of tokens and
+        the corresponding embedding tensor.  This helper identifies tokens that
+        are most similar to the mean sentence embedding and returns them as
+        keywords.  Special tokens are ignored.
+        """
+
+        tokens, token_embeddings = embeddings
+
+        if len(tokens) == 0:
+            return []
+
+        import torch.nn.functional as F
+
+        sentence_emb = token_embeddings.mean(dim=0)
+        similarities = F.cosine_similarity(token_embeddings, sentence_emb.unsqueeze(0), dim=1)
+        topk = similarities.topk(min(5, len(tokens))).indices.tolist()
+
+        keywords = []
+        for idx in topk:
+            token = tokens[idx]
+            if token.startswith("[") and token.endswith("]"):
+                continue
+            if token.startswith("##"):
+                token = token[2:]
+            keywords.append(token)
+            if len(keywords) == 5:
+                break
+        return keywords

--- a/rag_system/utils/embedding.py
+++ b/rag_system/utils/embedding.py
@@ -1,4 +1,37 @@
+from typing import Tuple, List
+import torch
+from transformers import AutoTokenizer, AutoModel
+
+
 class BERTEmbeddingModel:
-    def encode(self, text: str):
-        # Implement BERT encoding logic
-        pass
+    """Simple wrapper around a BERT model for embedding extraction."""
+
+    def __init__(self, model_name: str = "bert-base-uncased") -> None:
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModel.from_pretrained(model_name)
+        self.model.eval()
+
+    def encode(self, text: str) -> Tuple[List[str], torch.Tensor]:
+        """Encode text into token embeddings.
+
+        The method returns the list of tokens and the corresponding embedding
+        tensor with shape ``(seq_len, hidden_size)``.  The embeddings are
+        obtained from the last hidden state of the model without any pooling.
+
+        Parameters
+        ----------
+        text: str
+            Input text to encode.
+
+        Returns
+        -------
+        Tuple[List[str], torch.Tensor]
+            The tokens and their embeddings.
+        """
+
+        inputs = self.tokenizer(text, return_tensors="pt")
+        with torch.no_grad():
+            outputs = self.model(**inputs)
+        token_embeddings = outputs.last_hidden_state.squeeze(0)
+        tokens = self.tokenizer.convert_ids_to_tokens(inputs["input_ids"].squeeze(0))
+        return tokens, token_embeddings


### PR DESCRIPTION
## Summary
- support graph relation insertion in `DynamicKnowledgeIntegrationAgent`
- add keyword extraction from token embeddings in `KeyConceptExtractorAgent`
- implement `BERTEmbeddingModel.encode` using `transformers`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ee13aeee4832cb6674d9083707a61