### PR TITLE
Fix King agent import paths

### DIFF
--- a/agents/king/dynamic_knowledge_integration_agent.py
+++ b/agents/king/dynamic_knowledge_integration_agent.py
@@ -1,0 +1,3 @@
+from rag_system.agents.dynamic_knowledge_integration_agent import DynamicKnowledgeIntegrationAgent
+
+__all__ = ["DynamicKnowledgeIntegrationAgent"]

--- a/agents/king/key_concept_extractor.py
+++ b/agents/king/key_concept_extractor.py
@@ -1,0 +1,3 @@
+from .input.key_concept_extractor import KeyConceptExtractor
+
+__all__ = ["KeyConceptExtractor"]

--- a/agents/king/knowledge_graph_agent.py
+++ b/agents/king/knowledge_graph_agent.py
@@ -1,0 +1,3 @@
+from agents.sage.knowledge_graph_agent import KnowledgeGraphAgent
+
+__all__ = ["KnowledgeGraphAgent"]

--- a/agents/king/problem_analyzer.py
+++ b/agents/king/problem_analyzer.py
@@ -1,0 +1,3 @@
+from .planning.problem_analyzer import ProblemAnalyzer
+
+__all__ = ["ProblemAnalyzer"]

--- a/agents/king/reasoning_agent.py
+++ b/agents/king/reasoning_agent.py
@@ -1,0 +1,3 @@
+from agents.sage.reasoning_agent import ReasoningAgent
+
+__all__ = ["ReasoningAgent"]

--- a/agents/king/task_planning_agent.py
+++ b/agents/king/task_planning_agent.py
@@ -1,0 +1,7 @@
+from rag_system.agents.task_planning_agent import TaskPlanningAgent as _BaseTaskPlanningAgent
+
+class TaskPlanningAgent(_BaseTaskPlanningAgent):
+    def generate_task_plan(self, *args, **kwargs):
+        return super().plan_tasks(*args, **kwargs)
+
+__all__ = ["TaskPlanningAgent"]

--- a/agents/king/tests/test_integration.py
+++ b/agents/king/tests/test_integration.py
@@ -5,7 +5,8 @@ from agents.king.quality_assurance_layer import QualityAssuranceLayer
 from agents.king.planning_and_task_management.unified_decision_maker import UnifiedDecisionMaker
 from agents.king.problem_analyzer import ProblemAnalyzer
 from agents.king.continuous_learner import ContinuousLearner
-from agents.king.king_agent import KingAgent, KingAgentConfig
+from agents.king.king_agent import KingAgent
+from agents.unified_base_agent import UnifiedAgentConfig as KingAgentConfig
 from agents.utils.task import Task as LangroidTask
 from rag_system.core.pipeline import EnhancedRAGPipeline
 from communications.protocol import StandardCommunicationProtocol

--- a/agents/king/unified_task_manager.py
+++ b/agents/king/unified_task_manager.py
@@ -1,0 +1,3 @@
+from .task_management.unified_task_manager import UnifiedTaskManager
+
+__all__ = ["UnifiedTaskManager"]

--- a/agents/king/user_intent_interpreter.py
+++ b/agents/king/user_intent_interpreter.py
@@ -1,0 +1,3 @@
+from .input.user_intent_interpreter import UserIntentInterpreter
+
+__all__ = ["UserIntentInterpreter"]

--- a/tests/test_king_agent.py
+++ b/tests/test_king_agent.py
@@ -1,7 +1,8 @@
 import unittest
 import asyncio
 from unittest.mock import MagicMock, patch
-from agents.king.king_agent import KingAgent, KingAgentConfig
+from agents.king.king_agent import KingAgent
+from agents.unified_base_agent import UnifiedAgentConfig as KingAgentConfig
 from rag_system.core.config import RAGConfig
 from langroid.vector_store.base import VectorStore
 from communications.protocol import StandardCommunicationProtocol


### PR DESCRIPTION
## Summary
- add simple wrappers under `agents.king` that forward to actual modules
- expose `KingAgentConfig` alias
- implement minimal `process_user_input` for KingAgent
- update tests to import `UnifiedAgentConfig`

## Testing
- `python -m py_compile agents/king/king_agent.py agents/king/key_concept_extractor.py agents/king/user_intent_interpreter.py agents/king/task_planning_agent.py agents/king/knowledge_graph_agent.py agents/king/reasoning_agent.py agents/king/dynamic_knowledge_integration_agent.py agents/king/unified_task_manager.py agents/king/problem_analyzer.py tests/test_king_agent.py agents/king/tests/test_integration.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ee1894730832cade74a0b420e9077