### PR TITLE
Fix KingAgent test imports

### DIFF
--- a/tests/test_king_agent.py
+++ b/tests/test_king_agent.py
@@ -1,6 +1,13 @@
 import unittest
 import asyncio
 from unittest.mock import MagicMock, patch
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the Python path so that the ``agents``
+# package imports correctly when running this test in isolation.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from agents.king.king_agent import KingAgent
 from agents.unified_base_agent import UnifiedAgentConfig as KingAgentConfig
 from rag_system.core.config import RAGConfig


### PR DESCRIPTION
## Summary
- add repository root to `sys.path` in `tests/test_king_agent.py`

## Testing
- `pytest -q tests/test_king_agent.py` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684ee8c265c0832cb008b2579833b7ee