### PR TITLE
Implement env-based Settings config

### DIFF
--- a/agents/utils/configuration.py
+++ b/agents/utils/configuration.py
@@ -1,8 +1,43 @@
 # agents/langroid/utils/configuration.py
 
-class Settings:
-    def __init__(self):
-        # Initialize configuration settings
-        pass
+"""Utility classes for handling application configuration."""
 
-    # Add configuration methods and attributes as needed
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables or a file."""
+
+    openai_api_key: str = ""
+    neo4j_uri: str = "bolt://localhost:7687"
+    neo4j_user: str = "neo4j"
+    neo4j_password: str = "password"
+
+    class Config:
+        env_prefix = ""
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "Settings":
+        """Create a :class:`Settings` instance from a YAML or JSON file."""
+
+        file_path = Path(path)
+        data: Dict[str, Any] = {}
+
+        if file_path.exists():
+            with open(file_path, "r", encoding="utf-8") as f:
+                if file_path.suffix in {".yaml", ".yml"}:
+                    data = yaml.safe_load(f) or {}
+                elif file_path.suffix == ".json":
+                    data = json.load(f)
+
+        return cls(**data)


### PR DESCRIPTION
## Summary
- add a pydantic `Settings` class that loads defaults from a `.env` file or YAML/JSON config

## Testing
- `python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'langroid')*

------
https://chatgpt.com/codex/tasks/task_e_684ee8bd40b0832ca3f2e3ce33d75c3d