### PR TITLE
Implement simple NamedEntityRecognizer

### DIFF
--- a/rag_system/utils/named_entity_recognition.py
+++ b/rag_system/utils/named_entity_recognition.py
@@ -1,4 +1,73 @@
+"""Simple named entity recognition utilities."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import List, Dict
+
+
+logger = logging.getLogger(__name__)
+
+
 class NamedEntityRecognizer:
-    def recognize(self, text: str):
-        # Implement named entity recognition logic
-        pass
+    """A lightweight named entity recognizer.
+
+    The implementation attempts to use ``spaCy`` with the ``en_core_web_sm``
+    model when available.  If spaCy or the model cannot be loaded, a
+    simplistic regex based approach is used as a fall back.  The ``recognize``
+    method returns a list of dictionaries where each dictionary has the keys
+    ``"text"`` and ``"label"``.
+    """
+
+    def __init__(self) -> None:
+        try:
+            import spacy  # type: ignore
+
+            self._nlp = spacy.load("en_core_web_sm")
+            logger.debug("spaCy model loaded for NER")
+        except Exception:  # pragma: no cover - best effort to load spaCy
+            self._nlp = None
+            logger.warning(
+                "spaCy model not available; falling back to regex based NER"
+            )
+
+        # Regex matches sequences of capitalised words as a naive entity
+        self._regex = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b")
+        self._stop_words = {"The", "A", "An"}
+
+    def recognize(self, text: str) -> List[Dict[str, str]]:
+        """Extract entities from ``text``.
+
+        Parameters
+        ----------
+        text: str
+            The input text from which to extract entities.
+
+        Returns
+        -------
+        List[Dict[str, str]]
+            A list of recognised entities.  Each entity is represented as a
+            dictionary with ``text`` and ``label`` keys.
+        """
+
+        if not text:
+            return []
+
+        # Use spaCy when available for more robust entity extraction
+        if self._nlp is not None:
+            doc = self._nlp(text)
+            return [
+                {"text": ent.text, "label": ent.label_}
+                for ent in doc.ents
+            ]
+
+        # Fallback regex based entity recognition
+        entities = []
+        for match in self._regex.finditer(text):
+            ent_text = match.group(0)
+            if ent_text in self._stop_words:
+                continue
+            entities.append({"text": ent_text, "label": "ENTITY"})
+        return entities
+

--- a/tests/test_named_entity_recognition.py
+++ b/tests/test_named_entity_recognition.py
@@ -1,0 +1,19 @@
+import unittest
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from rag_system.utils.named_entity_recognition import NamedEntityRecognizer
+
+
+class TestNamedEntityRecognizer(unittest.TestCase):
+    def test_simple_regex_entities(self):
+        text = "John Doe visited New York City yesterday."
+        ner = NamedEntityRecognizer()
+        entities = ner.recognize(text)
+        texts = [e["text"] for e in entities]
+        self.assertIn("John Doe", texts)
+        self.assertIn("New York City", texts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `NamedEntityRecognizer` with optional spaCy support
- fall back to regex-based entity extraction if spaCy is unavailable
- add unit test for the recognizer

## Testing
- `pytest -q tests/test_named_entity_recognition.py`
- `pytest -q` *(fails: ModuleNotFoundError for heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ee8b15be0832ca47457144fb1c235