### PR TITLE
Add placeholder logic and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ The tokenizer file `rag_system/utils/token_data/cl100k_base.tiktoken` is bundled
 python -m unittest discover tests
 ```
 
+## Testing
+
+After installing the heavy dependencies you can execute the full test suite:
+
+```bash
+pytest
+```
+
+
 
 ## Running the System
 

--- a/agents/king/coordinator.py
+++ b/agents/king/coordinator.py
@@ -66,7 +66,8 @@ class KingCoordinator:
             await self.task_manager.assign_task(message.content)
         else:
             # Handle other message types if needed
-            pass
+            logger.warning(f"Unhandled message type: {message.type}")
+            raise NotImplementedError(f"Message type {message.type} not supported")
 
     async def _implement_decision(self, decision_result: Dict[str, Any]):
         try:

--- a/agents/king/planning/unified_decision_maker.py
+++ b/agents/king/planning/unified_decision_maker.py
@@ -617,5 +617,5 @@ class UnifiedDecisionMaker:
             raise AIVillageException(f"Error creating implementation plan: {str(e)}")
 
 if __name__ == "__main__":
-    # This section can be used for testing or running the UnifiedDecisionMaker independently
-    pass
+    raise SystemExit(
+        "Run 'agents/orchestration.py' to start the decision making subsystem.")

--- a/agents/king/planning/unified_planning.py
+++ b/agents/king/planning/unified_planning.py
@@ -385,5 +385,5 @@ class UnifiedPlanningAndManagement:
             raise AIVillageException(f"Error in introspect: {str(e)}")
 
 if __name__ == "__main__":
-    # This section can be used for testing or running the UnifiedPlanningAndManagement independently
-    pass
+    raise SystemExit(
+        "Run 'agents/orchestration.py' to start the planning subsystem.")

--- a/agents/king/task_management/unified_task_manager.py
+++ b/agents/king/task_management/unified_task_manager.py
@@ -373,5 +373,5 @@ class UnifiedManagement:
             raise AIVillageException(f"Error in introspection: {str(e)}")
 
 if __name__ == "__main__":
-    # This section can be used for testing or running the UnifiedManagement independently
-    pass
+    raise SystemExit(
+        "Run 'agents/orchestration.py' to start the task manager.")

--- a/agents/sage/research_capabilities.py
+++ b/agents/sage/research_capabilities.py
@@ -68,5 +68,5 @@ class ResearchCapabilities:
         }
 
     async def evolve_research_capabilities(self):
-        # Implement logic to evolve research capabilities based on recent performance and learnings
-        pass
+        """Placeholder for adaptive logic."""
+        raise NotImplementedError("Research capability evolution not implemented")

--- a/agents/sage/response_generator.py
+++ b/agents/sage/response_generator.py
@@ -5,8 +5,9 @@ logger = logging.getLogger(__name__)
 
 class ResponseGenerator:
     def __init__(self):
-        # Initialize any necessary components or models
-        pass
+        """Set up placeholders for future NLP models."""
+        self.model = None
+        logger.debug("ResponseGenerator initialized")
 
     async def generate_response(self, query: str, rag_result: Dict[str, Any], intent: Dict[str, Any]) -> str:
         """

--- a/agents/sage/user_intent_interpreter.py
+++ b/agents/sage/user_intent_interpreter.py
@@ -5,8 +5,9 @@ logger = logging.getLogger(__name__)
 
 class UserIntentInterpreter:
     def __init__(self):
-        # Initialize any necessary components or models
-        pass
+        """Initialize interpreter state."""
+        self.model = None
+        logger.debug("UserIntentInterpreter initialized")
 
     async def interpret_intent(self, query: str) -> Dict[str, Any]:
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-asyncio
+requests
+numpy


### PR DESCRIPTION
## Summary
- add minimal initialisation to `ResponseGenerator` and `UserIntentInterpreter`
- make research capability evolution a `NotImplementedError`
- signal unsupported messages in `KingCoordinator`
- prevent direct execution of planning modules
- document heavy dependency setup and how to run tests
- add lightweight `requirements-dev.txt`

## Testing
- `python -m unittest tests.test_bayesnet.TestBayesNetIntegration.test_shared_instance`
- `python -m pytest tests/test_bayesnet.py::TestBayesNetIntegration::test_shared_instance -q`

Some tests failed due to missing dependencies and blocked network access when running the full suite.

------
https://chatgpt.com/codex/tasks/task_e_684f1e1a3c98832cb0e63567c543f169