### PR TITLE
Add FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ pytest
 
 ## Running the System
 
-Execute the main script:
+Start the API server:
 
 ```
-python agents/orchestration.py
+python server.py
 ```
 
-This will start the AI Village system, initializing all agents and the self-evolving components.
+This will start a FastAPI application that initializes the RAG pipeline and exposes the HTTP endpoints.
 
 ## Extending the System
 
@@ -125,7 +125,7 @@ To provide your AI Village with a starting base of information, you can manually
 
 2. Start the AI Village server if it's not already running:
    ```
-   python agents/orchestration.py
+   python server.py
    ```
 
 3. Use the `/upload` endpoint to add each paper to the knowledge base:
@@ -203,7 +203,7 @@ By following these steps, you can manually feed several dozen academic papers in
 
 1. Start the AI Village server:
    ```
-   python agents/orchestration.py
+   python server.py
    ```
 
 2. The server will start running on `http://localhost:8000`. You can now use the following endpoints:

--- a/server.py
+++ b/server.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI, UploadFile, File
+from pydantic import BaseModel
+
+from rag_system.core.pipeline import EnhancedRAGPipeline
+
+app = FastAPI()
+
+rag_pipeline = EnhancedRAGPipeline()
+vector_store = rag_pipeline.hybrid_retriever.vector_store
+
+class QueryRequest(BaseModel):
+    query: str
+
+@app.on_event("startup")
+async def startup_event():
+    await rag_pipeline.initialize()
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    await rag_pipeline.shutdown()
+
+@app.post("/query")
+async def query_endpoint(request: QueryRequest):
+    result = await rag_pipeline.process(request.query)
+    return result
+
+@app.post("/upload")
+async def upload_endpoint(file: UploadFile = File(...)):
+    content = await file.read()
+    text = content.decode("utf-8", errors="ignore")
+    await vector_store.add_texts([text])
+    return {"status": "uploaded"}


### PR DESCRIPTION
## Summary
- create a FastAPI server with query and upload endpoints
- document how to run the new server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest tests/test_bayesnet.py -q`
- `PYTHONPATH=. pytest tests/test_protocol.py -q` *(fails: circular import)*

------
https://chatgpt.com/codex/tasks/task_e_684f3a87bc38832ca311b6539e7b6051