### PR TITLE
Fix task interface and add layer test

### DIFF
--- a/agents/king/tests/test_king_agent.py
+++ b/agents/king/tests/test_king_agent.py
@@ -2,6 +2,7 @@ import unittest
 import asyncio
 from unittest.mock import Mock, patch
 from agents.king.king_agent import KingAgent, UnifiedAgentConfig
+from agents.utils.task import Task as LangroidTask
 from communications.protocol import StandardCommunicationProtocol, Message, MessageType
 from rag_system.retrieval.vector_store import VectorStore
 
@@ -21,7 +22,8 @@ class TestKingAgent(unittest.IsolatedAsyncioTestCase):
         mock_get_status.side_effect = ['IN_PROGRESS', 'IN_PROGRESS', 'COMPLETED']
         mock_get_result.return_value = {'success': True, 'result': 'Task completed'}
 
-        result = await self.king_agent.execute_task({'description': 'Test task'})
+        task = LangroidTask(None, 'Test task')
+        result = await self.king_agent.execute_task(task)
 
         self.assertTrue(result['success'])
         self.assertEqual(result['result'], 'Task completed')

--- a/agents/orchestration.py
+++ b/agents/orchestration.py
@@ -110,7 +110,14 @@ async def run_task(self_evolving_system: SelfEvolvingSystem, rag_pipeline: Enhan
 
 async def orchestrate_agents(agents: List[UnifiedBaseAgent], task: Dict[str, Any]) -> Dict[str, Any]:
     king_agent = next(agent for agent in agents if isinstance(agent, KingAgent))
-    result = await king_agent.execute_task(task)
+    langroid_task = LangroidTask(
+        king_agent,
+        task.get("content"),
+        task.get("id", ""),
+        task.get("priority", 1),
+    )
+    langroid_task.type = task.get("type", "general")
+    result = await king_agent.execute_task(langroid_task)
     return result
 
 async def main():

--- a/agents/sage/collaboration.py
+++ b/agents/sage/collaboration.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Any
 from communications.protocol import Message, MessageType
+from agents.utils.task import Task as LangroidTask
 import logging
 
 logger = logging.getLogger(__name__)
@@ -40,8 +41,15 @@ class CollaborationManager:
 
     async def delegate_task(self, message: Message):
         try:
-            task = message.content.get('task')
-            result = await self.agent.execute_task(task)
+            task_dict = message.content.get('task')
+            langroid_task = LangroidTask(
+                self.agent,
+                task_dict.get('content'),
+                task_dict.get('id', ''),
+                task_dict.get('priority', 1),
+            )
+            langroid_task.type = task_dict.get('type', 'general')
+            result = await self.agent.execute_task(langroid_task)
             response = Message(
                 type=MessageType.TASK_RESULT,
                 sender=self.agent.name,

--- a/agents/unified_base_agent.py
+++ b/agents/unified_base_agent.py
@@ -408,21 +408,6 @@ class DecisionMakingLayer:
         reasoning_result = await self.rag_pipeline.reason(query, retrieval_results)
         return reasoning_result
 
-    async def execute_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
-        # Implement task execution logic here
-        task_type = task.get("type", "default")
-        task_content = task.get("content", "")
-
-        if task_type == "query":
-            return await self.process_query(task_content)
-        elif task_type == "analysis":
-            # Implement analysis logic
-            pass
-        elif task_type == "generation":
-            # Implement generation logic
-            pass
-        else:
-            raise ValueError(f"Unknown task type: {task_type}")
 
 
 class MCTSConfig:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from typing import Dict, Any
+from agents.utils.task import Task as LangroidTask
 from agents.king.king_agent import KingAgent
 from agents.sage.sage_agent import SageAgent
 from agents.magi.magi_agent import MagiAgent
@@ -41,7 +42,14 @@ class AIVillageSystem:
     @safe_execute
     async def process_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
         logger.info(f"Processing task: {task}")
-        result = await self.king_agent.execute_task(task)
+        langroid_task = LangroidTask(
+            self.king_agent,
+            task.get("content"),
+            task.get("id", ""),
+            task.get("priority", 1),
+        )
+        langroid_task.type = task.get("type", "general")
+        result = await self.king_agent.execute_task(langroid_task)
         logger.info(f"Task result: {result}")
         return result
 

--- a/rag_system/main.py
+++ b/rag_system/main.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime
 from typing import Dict, Any
+from agents.utils.task import Task as LangroidTask
 
 from rag_system.core.unified_config import unified_config
 from rag_system.core.pipeline import EnhancedRAGPipeline
@@ -77,24 +78,20 @@ async def initialize_components() -> Dict[str, Any]:
 @log_and_handle_errors
 async def process_user_query(components: Dict[str, Any], query: str) -> Dict[str, Any]:
     king_agent = components["king_agent"]
-    task = {
-        "type": "query",
-        "content": query,
-        "timestamp": datetime.now().isoformat()
-    }
+    task = LangroidTask(king_agent, query, datetime.now().isoformat(), 1)
+    task.type = "query"
     return await king_agent.execute_task(task)
 
 @log_and_handle_errors
 async def run_creative_exploration(components: Dict[str, Any], start_node: str, end_node: str):
     king_agent = components["king_agent"]
-    task = {
-        "type": "creative_exploration",
-        "content": {
-            "start_node": start_node,
-            "end_node": end_node
-        },
-        "timestamp": datetime.now().isoformat()
-    }
+    task = LangroidTask(
+        king_agent,
+        {"start_node": start_node, "end_node": end_node},
+        datetime.now().isoformat(),
+        1,
+    )
+    task.type = "creative_exploration"
     return await king_agent.execute_task(task)
 
 @log_and_handle_errors

--- a/tests/test_layer_sequence.py
+++ b/tests/test_layer_sequence.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from agents.unified_base_agent import UnifiedBaseAgent, UnifiedAgentConfig
+from communications.protocol import StandardCommunicationProtocol
+from agents.utils.task import Task as LangroidTask
+
+class DummyAgent(UnifiedBaseAgent):
+    async def _process_task(self, task: LangroidTask):
+        return {"step": "processed"}
+
+def build_agent():
+    config = UnifiedAgentConfig(
+        name="dummy",
+        description="dummy",
+        capabilities=["general"],
+        rag_config=MagicMock(),
+        vector_store=MagicMock(),
+        model="gpt-4",
+        instructions=""
+    )
+    protocol = MagicMock(spec=StandardCommunicationProtocol)
+    return DummyAgent(config, protocol)
+
+class TestLayerSequence(unittest.IsolatedAsyncioTestCase):
+    async def test_layers_run(self):
+        agent = build_agent()
+        task = LangroidTask(agent, "do something", "1", 1)
+        task.type = "general"
+        with patch.object(agent.quality_assurance_layer, 'check_task_safety', return_value=True) as qa_mock, \
+             patch.object(agent.foundational_layer, 'process_task', AsyncMock(return_value=task)) as f_mock, \
+             patch.object(agent.agent_architecture_layer, 'process_result', AsyncMock(return_value={"ok": True})) as arch_mock, \
+             patch.object(agent.decision_making_layer, 'make_decision', AsyncMock(return_value="done")) as dm_mock, \
+             patch.object(agent.continuous_learning_layer, 'update', AsyncMock()) as cl_mock:
+            result = await agent.execute_task(task)
+        qa_mock.assert_called_once_with(task)
+        f_mock.assert_called_once_with(task)
+        arch_mock.assert_called_once()
+        dm_mock.assert_called_once_with(task, {"ok": True})
+        cl_mock.assert_called_once_with(task, "done")
+        self.assertEqual(result, {"result": "done"})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove obsolete `execute_task` definition from `UnifiedBaseAgent`
- ensure calls pass a `LangroidTask` instance
- update KingAgent and Coordinator to work with `LangroidTask`
- adjust Sage components for new task format
- update tests and add new check that agent layers execute

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684f3a8a2808832cafae23e26b5ad069