### PR TITLE
Implement task planning analysis logic

### DIFF
--- a/nlp/__init__.py
+++ b/nlp/__init__.py
@@ -1,0 +1,1 @@
+# NLP utilities package

--- a/nlp/named_entity_recognition.py
+++ b/nlp/named_entity_recognition.py
@@ -1,0 +1,3 @@
+from rag_system.utils.named_entity_recognition import NamedEntityRecognizer
+
+__all__ = ["NamedEntityRecognizer"]

--- a/rag_system/agents/user_intent_interpreter.py
+++ b/rag_system/agents/user_intent_interpreter.py
@@ -1,0 +1,12 @@
+from typing import Dict, Any
+
+class UserIntentInterpreterAgent:
+    """Basic interpreter returning a simple intent structure."""
+
+    def interpret_intent(self, query: str) -> Dict[str, Any]:
+        # Minimal placeholder implementation
+        return {
+            "type": "information_request",
+            "topic": query,
+            "primary_intent": query,
+        }

--- a/tests/test_task_planning_agent.py
+++ b/tests/test_task_planning_agent.py
@@ -1,0 +1,62 @@
+import unittest
+import sys
+from pathlib import Path
+import types
+
+# Ensure repository root is on path and provide dummy torch module to avoid
+# heavy dependency import failures when loading the agent modules.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+if 'torch' not in sys.modules:
+    fake_torch = types.ModuleType('torch')
+    fake_torch.Tensor = type('Tensor', (), {})
+    fake_torch.randn = lambda *args, **kwargs: 0
+    sys.modules['torch'] = fake_torch
+
+from rag_system.agents.task_planning_agent import TaskPlanningAgent
+
+
+class DummyPlanningAgent(TaskPlanningAgent):
+    def __init__(self):
+        pass
+
+    async def generate(self, prompt: str):
+        return ""
+
+    async def get_embedding(self, text: str):
+        return []
+
+    async def rerank(self, query, results, k):
+        return results
+
+    async def introspect(self):
+        return {}
+
+    async def communicate(self, message, recipient):
+        return ""
+
+    async def activate_latent_space(self, query):
+        return "", ""
+
+class TestTaskPlanningAgent(unittest.TestCase):
+    def setUp(self):
+        self.agent = DummyPlanningAgent()
+
+    def test_generate_task_plan_basic(self):
+        intent = {"primary_intent": "Summarize research"}
+        concepts = {
+            "keywords": ["machine", "learning"],
+            "entities": [{"text": "AI", "label": "TECH"}]
+        }
+        plan = self.agent._generate_task_plan(intent, concepts)
+        self.assertIn("steps", plan)
+        self.assertEqual(plan["analysis"]["primary_intent"], "Summarize research")
+        self.assertIn("retrieve_information", [s["action"] for s in plan["steps"]])
+        self.assertIn("summarize_information", [s["action"] for s in plan["steps"]])
+
+    def test_generate_task_plan_empty_inputs(self):
+        plan = self.agent._generate_task_plan({}, {})
+        self.assertIsInstance(plan["steps"], list)
+        self.assertEqual(plan["steps"][0]["parameters"], [])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utility package

--- a/utils/embedding.py
+++ b/utils/embedding.py
@@ -1,0 +1,3 @@
+from rag_system.utils.embedding import BERTEmbeddingModel
+
+__all__ = ["BERTEmbeddingModel"]


### PR DESCRIPTION
## Summary
- analyze user intent and concepts to build richer task plans
- stub out missing modules for isolated testing
- add unit tests for task planning logic

## Testing
- `pytest -q tests/test_task_planning_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684f3a8effd0832c9e9916b8334d7936