### PR TITLE
Update testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,21 @@ python -m unittest discover tests
 
 ## Testing
 
-After installing the heavy dependencies you can execute the full test suite:
+Before running the tests ensure that **all** dependencies are installed. The
+main `requirements.txt` file contains heavy packages such as `torch` and
+`numpy` that are required by the tests:
+
+```bash
+pip install -r requirements.txt
+```
+
+Install the additional test-only packages from `requirements-dev.txt`:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+After installing these dependencies you can execute the full test suite:
 
 ```bash
 pytest


### PR DESCRIPTION
## Summary
- clarify test prerequisites in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684f5999c258832c84f484f149ee93c7