### PR TITLE
Add process_query wrapper and update docs

### DIFF
--- a/docs/rag_system_explainer.txt
+++ b/docs/rag_system_explainer.txt
@@ -7,8 +7,8 @@ Based on the provided code and folder structure, here's how the system pipeline 
 1. Configuration Setup
 RAGConfig (from core.config): Manages configuration settings, including paths, model parameters, and other essential settings required for the system's operation.
 2. Query Processing Pipeline
-RAGPipeline (from core.pipeline): The primary component responsible for processing queries submitted by agents.
-The process_query(query) method likely follows these steps:
+EnhancedRAGPipeline (from core.pipeline): The primary component responsible for processing queries submitted by agents.
+The process(query) method (or its process_query wrapper) likely follows these steps:
 
 a. Input Processing
 Input Pipeline (from input_pipeline/):
@@ -124,18 +124,18 @@ Agents interact with the RAG system by importing the necessary modules and submi
 Code Example
 import asyncio
 from core.config import RAGConfig
-from core.pipeline import RAGPipeline
+from core.pipeline import EnhancedRAGPipeline
 
 async def agent_query():
     # Initialize configuration and pipeline
     config = RAGConfig()
-    pipeline = RAGPipeline(config)
+    pipeline = EnhancedRAGPipeline(config)
     
     # Define the query
     query = "What festivals does the village celebrate each year?"
     
     # Process the query
-    result = await pipeline.process_query(query)
+    result = await pipeline.process(query)
     
     # Access the results
     answer = result.get('answer')
@@ -155,11 +155,11 @@ async def agent_query():
 if __name__ == "__main__":
     asyncio.run(agent_query())
 Explanation
-Initialization: Agents create instances of RAGConfig and RAGPipeline to set up the system.
+Initialization: Agents create instances of RAGConfig and EnhancedRAGPipeline to set up the system.
 
 Submitting a Query: Agents define their query as a string.
 
-Processing the Query: Use await pipeline.process_query(query) to process the query asynchronously.
+Processing the Query: Use await pipeline.process(query) (or pipeline.process_query) to process the query asynchronously.
 
 Handling the Result: Extract the answer, confidence_score, source_documents, and metadata from the result.
 

--- a/rag_system/core/pipeline.py
+++ b/rag_system/core/pipeline.py
@@ -51,6 +51,11 @@ class EnhancedRAGPipeline(BaseComponent):
             "integrated_result": integrated_result
         }
 
+    # Compatibility wrapper for legacy calls
+    async def process_query(self, query: str) -> Dict[str, Any]:
+        """Backward compatible wrapper around :meth:`process`."""
+        return await self.process(query)
+
     @log_and_handle_errors
     async def shutdown(self) -> None:
         await self.latent_space_activation.shutdown()

--- a/rag_system/processing/self_referential_query_processor.py
+++ b/rag_system/processing/self_referential_query_processor.py
@@ -1,17 +1,17 @@
 # rag_system/processing/self_referential_query_processor.py
 
 from typing import Dict, Any
-from ..core.pipeline import RAGPipeline
+from ..core.pipeline import EnhancedRAGPipeline
 
 class SelfReferentialQueryProcessor:
-    def __init__(self, rag_system: RAGPipeline):
+    def __init__(self, rag_system: EnhancedRAGPipeline):
         self.rag_system = rag_system
 
     async def process_self_query(self, query: str) -> str:
         if query.startswith("SELF:"):
             return await self._process_internal_query(query[5:])
         else:
-            return await self.rag_system.process_query(query)
+            return await self.rag_system.process(query)
 
     async def _process_internal_query(self, query: str) -> str:
         # Implement logic to query system's internal state, knowledge, or history


### PR DESCRIPTION
## Summary
- extend `EnhancedRAGPipeline` with a compatibility wrapper `process_query`
- switch `SelfReferentialQueryProcessor` to `EnhancedRAGPipeline` and use `.process`
- update RAG system docs examples to use `EnhancedRAGPipeline` and `process`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch, numpy, httpx)*

------
https://chatgpt.com/codex/tasks/task_e_684f5da7d670832cb1de719b6dc443e4