### PR TITLE
Improve communication protocol

### DIFF
--- a/communications/protocol.py
+++ b/communications/protocol.py
@@ -1,8 +1,14 @@
-from typing import Dict, Any, Callable, Coroutine, List
+from typing import Dict, Any, Callable, Coroutine, List, Optional
 from abc import ABC, abstractmethod
 import asyncio
 from .message import Message, MessageType, Priority
-from agents.utils.exceptions import AIVillageException
+from .queue import MessageQueue
+try:
+    from agents.utils.exceptions import AIVillageException
+except Exception:  # pragma: no cover - fallback if agents package isn't available
+    class AIVillageException(Exception):
+        """Custom exception class for AI Village-specific errors."""
+        pass
 
 class CommunicationProtocol(ABC):
     @abstractmethod
@@ -14,7 +20,13 @@ class CommunicationProtocol(ABC):
         pass
 
     @abstractmethod
-    async def query(self, sender: str, receiver: str, content: Dict[str, Any]) -> Any:
+    async def query(
+        self,
+        sender: str,
+        receiver: str,
+        content: Dict[str, Any],
+        priority: Priority = Priority.MEDIUM,
+    ) -> Any:
         pass
 
     @abstractmethod
@@ -27,28 +39,46 @@ class CommunicationProtocol(ABC):
 
 class StandardCommunicationProtocol(CommunicationProtocol):
     def __init__(self):
-        self.message_queue: Dict[str, List[Message]] = {}
-        self.subscribers: Dict[str, Callable[[Message], Coroutine[Any, Any, None]]] = {}
+        self.message_queues: Dict[str, MessageQueue] = {}
+        self.subscribers: Dict[str, List[Callable[[Message], Coroutine[Any, Any, None]]]] = {}
+
+    def enqueue(self, message: Message) -> None:
+        if message.receiver not in self.message_queues:
+            self.message_queues[message.receiver] = MessageQueue()
+        self.message_queues[message.receiver].enqueue(message)
+
+    def dequeue(self, agent_id: str) -> Optional[Message]:
+        if agent_id in self.message_queues:
+            return self.message_queues[agent_id].dequeue()
+        return None
+
+    async def _notify_subscribers(self, message: Message) -> None:
+        for callback in self.subscribers.get(message.receiver, []):
+            await callback(message)
 
     async def send_message(self, message: Message) -> None:
-        if message.receiver not in self.message_queue:
-            self.message_queue[message.receiver] = []
-        self.message_queue[message.receiver].append(message)
-
-        if message.receiver in self.subscribers:
-            await self.subscribers[message.receiver](message)
+        self.enqueue(message)
+        await self._notify_subscribers(message)
 
     async def receive_message(self, agent_id: str) -> Message:
-        if agent_id not in self.message_queue or not self.message_queue[agent_id]:
+        message = self.dequeue(agent_id)
+        if message is None:
             raise AIVillageException(f"No messages for agent {agent_id}")
-        return self.message_queue[agent_id].pop(0)
+        return message
 
-    async def query(self, sender: str, receiver: str, content: Dict[str, Any]) -> Any:
+    async def query(
+        self,
+        sender: str,
+        receiver: str,
+        content: Dict[str, Any],
+        priority: Priority = Priority.MEDIUM,
+    ) -> Any:
         query_message = Message(
             type=MessageType.QUERY,
             sender=sender,
             receiver=receiver,
-            content=content
+            content=content,
+            priority=priority,
         )
         await self.send_message(query_message)
         response = await self.receive_message(sender)
@@ -60,14 +90,39 @@ class StandardCommunicationProtocol(CommunicationProtocol):
         elapsed = 0.0
         poll_interval = 0.1
         while elapsed < timeout:
-            if message.sender in self.message_queue:
-                queue = self.message_queue[message.sender]
-                for idx, resp in enumerate(queue):
+            if message.sender in self.message_queues:
+                queue = self.message_queues[message.sender]
+                for idx, resp in enumerate(queue.get_all_messages()):
                     if resp.parent_id == message.id or resp.id == message.id:
-                        return queue.pop(idx)
+                        # remove specific response from queue
+                        self.message_queues[message.sender]._queues[resp.priority].remove(resp)
+                        return resp
             await asyncio.sleep(poll_interval)
             elapsed += poll_interval
         raise AIVillageException("Response timeout")
 
     def subscribe(self, agent_id: str, callback: Callable[[Message], Coroutine[Any, Any, None]]) -> None:
-        self.subscribers[agent_id] = callback
+        self.subscribers.setdefault(agent_id, []).append(callback)
+
+    def unsubscribe(self, agent_id: str, callback: Callable[[Message], Coroutine[Any, Any, None]]) -> None:
+        if agent_id in self.subscribers:
+            self.subscribers[agent_id] = [cb for cb in self.subscribers[agent_id] if cb != callback]
+            if not self.subscribers[agent_id]:
+                del self.subscribers[agent_id]
+
+    async def broadcast(
+        self,
+        sender: str,
+        message_type: MessageType,
+        content: Dict[str, Any],
+        priority: Priority = Priority.MEDIUM,
+    ) -> None:
+        for agent_id in list(self.subscribers.keys()):
+            msg = Message(
+                type=message_type,
+                sender=sender,
+                receiver=agent_id,
+                content=content,
+                priority=priority,
+            )
+            await self.send_message(msg)

--- a/docs/communication_explainer.txt
+++ b/docs/communication_explainer.txt
@@ -47,7 +47,7 @@ Purpose: Defines the StandardCommunicationProtocol class, managing message sendi
 
 StandardCommunicationProtocol Class:
 Attributes:
-message_queue: Instance of MessageQueue.
+message_queues: Dictionary mapping agent IDs to MessageQueue instances.
 subscribers: Dictionary mapping agent IDs to lists of callback functions.
 Methods:
 send_message(message):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,7 +1,7 @@
 import unittest
 import asyncio
 
-from communications.protocol import StandardCommunicationProtocol, Message, MessageType
+from communications.protocol import StandardCommunicationProtocol, Message, MessageType, Priority
 
 class TestProtocol(unittest.IsolatedAsyncioTestCase):
     async def test_send_and_wait(self):
@@ -22,6 +22,34 @@ class TestProtocol(unittest.IsolatedAsyncioTestCase):
         request = Message(type=MessageType.QUERY, sender="sender", receiver="receiver", content={"ping": True})
         response = await protocol.send_and_wait(request)
         self.assertEqual(response.content["echo"], True)
+
+    async def test_priority_order(self):
+        protocol = StandardCommunicationProtocol()
+        low = Message(type=MessageType.NOTIFICATION, sender="s", receiver="r", content={}, priority=Priority.LOW)
+        high = Message(type=MessageType.NOTIFICATION, sender="s", receiver="r", content={}, priority=Priority.CRITICAL)
+        medium = Message(type=MessageType.NOTIFICATION, sender="s", receiver="r", content={}, priority=Priority.MEDIUM)
+        await protocol.send_message(low)
+        await protocol.send_message(high)
+        await protocol.send_message(medium)
+        msg1 = await protocol.receive_message("r")
+        msg2 = await protocol.receive_message("r")
+        msg3 = await protocol.receive_message("r")
+        self.assertEqual([msg1.priority, msg2.priority, msg3.priority], [Priority.CRITICAL, Priority.MEDIUM, Priority.LOW])
+
+    async def test_broadcast_and_unsubscribe(self):
+        protocol = StandardCommunicationProtocol()
+        received = []
+
+        async def cb(msg: Message):
+            received.append(msg.receiver)
+
+        protocol.subscribe("a", cb)
+        protocol.subscribe("b", cb)
+        protocol.unsubscribe("b", cb)
+
+        await protocol.broadcast(sender="sys", message_type=MessageType.NOTIFICATION, content={"msg": 1})
+        await asyncio.sleep(0)
+        self.assertEqual(received, ["a"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- integrate `MessageQueue` in `StandardCommunicationProtocol`
- support priority enqueue/dequeue and broadcast
- document updated protocol behavior
- expand protocol tests to cover priority and broadcast

## Testing
- `PYTHONPATH=. pytest tests/test_protocol.py -q`
- `PYTHONPATH=. pytest -k protocol -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_684f5dab21bc832ca7ab4bfb24483999