### PR TITLE
Add get_count methods and update processor

### DIFF
--- a/rag_system/processing/self_referential_query_processor.py
+++ b/rag_system/processing/self_referential_query_processor.py
@@ -1,10 +1,10 @@
 # rag_system/processing/self_referential_query_processor.py
 
 from typing import Dict, Any
-from ..core.pipeline import RAGPipeline
+from ..core.pipeline import EnhancedRAGPipeline
 
 class SelfReferentialQueryProcessor:
-    def __init__(self, rag_system: RAGPipeline):
+    def __init__(self, rag_system: EnhancedRAGPipeline):
         self.rag_system = rag_system
 
     async def process_self_query(self, query: str) -> str:

--- a/rag_system/retrieval/graph_store.py
+++ b/rag_system/retrieval/graph_store.py
@@ -158,3 +158,7 @@ class GraphStore:
         if self.graph.has_node(doc_id):
             return self.graph.nodes[doc_id]
         return None
+
+    async def get_count(self) -> int:
+        """Return the number of nodes stored in the graph."""
+        return self.graph.number_of_nodes()

--- a/rag_system/retrieval/vector_store.py
+++ b/rag_system/retrieval/vector_store.py
@@ -88,6 +88,10 @@ class VectorStore:
     def get_size(self) -> int:
         return len(self.documents)
 
+    async def get_count(self) -> int:
+        """Return the number of stored vector documents."""
+        return len(self.documents)
+
     def save(self, file_path: str):
         with open(file_path, 'wb') as f:
             pickle.dump({

--- a/tests/test_store_counts.py
+++ b/tests/test_store_counts.py
@@ -1,0 +1,58 @@
+import unittest
+from datetime import datetime
+import numpy as np
+import sys
+from pathlib import Path
+
+import types
+
+fake_faiss = types.ModuleType("faiss")
+fake_faiss.IndexFlatL2 = lambda *args, **kwargs: object()
+sys.modules.setdefault("faiss", fake_faiss)
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from rag_system.retrieval.vector_store import VectorStore
+from rag_system.retrieval.graph_store import GraphStore
+
+class TestStoreCounts(unittest.IsolatedAsyncioTestCase):
+    async def test_vector_store_get_count(self):
+        store = VectorStore()
+        class DummyIndex:
+            def add(self, x):
+                pass
+            def search(self, x, k):
+                return (np.zeros((1, k), dtype="float32"), np.zeros((1, k), dtype=int))
+            def remove_ids(self, x):
+                pass
+        store.index = DummyIndex()
+        docs = [
+            {
+                "id": "1",
+                "content": "a",
+                "embedding": np.zeros(store.dimension).astype('float32'),
+                "timestamp": datetime.now(),
+            },
+            {
+                "id": "2",
+                "content": "b",
+                "embedding": np.zeros(store.dimension).astype('float32'),
+                "timestamp": datetime.now(),
+            },
+        ]
+        store.add_documents(docs)
+        count = await store.get_count()
+        self.assertEqual(count, 2)
+
+    async def test_graph_store_get_count(self):
+        store = GraphStore()
+        docs = [
+            {"id": "1", "content": "a"},
+            {"id": "2", "content": "b"},
+        ]
+        store.add_documents(docs)
+        count = await store.get_count()
+        self.assertEqual(count, 2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use `EnhancedRAGPipeline` in `self_referential_query_processor`
- add async `get_count()` to `VectorStore` and `GraphStore`
- test store count APIs

## Testing
- `pytest -q tests/test_store_counts.py`

------
https://chatgpt.com/codex/tasks/task_e_684f5daec600832cb0b8d8d3c96df98a