### PR TITLE
Add default RAG config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ initialization without network access.
    - Create a `.env` file in the project root
    - Add your OpenAI API key: `OPENAI_API_KEY=your_api_key_here`
 
+5. Review the default Retrieval-Augmented Generation configuration:
+   - The file `configs/rag_config.yaml` contains the default settings used by
+     the RAG pipeline. Edit this file if you need to customize the behaviour.
+
 ## Installing Heavy Dependencies
 
 Some features rely on large libraries such as `numpy`, `torch` and `faiss`. These packages may need to be installed separately, especially when GPU support is desired. Example commands:

--- a/configs/rag_config.yaml
+++ b/configs/rag_config.yaml
@@ -1,0 +1,19 @@
+model_name: gpt-3.5-turbo
+temperature: 0.7
+max_tokens: 1000
+embedding_model: bert-base-uncased
+vector_store_type: faiss
+graph_store_type: networkx
+retriever_type: hybrid
+reasoning_engine_type: uncertainty_aware
+agent_name: SageAgent
+agent_description: A research and analysis agent equipped with advanced reasoning and NLP capabilities.
+MAX_RESULTS: 10
+FEEDBACK_ITERATIONS: 3
+TEMPORAL_GRANULARITY: 86400  # seconds
+top_k: 5
+chunk_size: 1000
+chunk_overlap: 200
+extra_params: {}
+num_documents: 5
+reranker_model: cross-encoder/ms-marco-MiniLM-L-6-v2


### PR DESCRIPTION
## Summary
- add a YAML config file in `configs/` with the default RAG settings
- update the README setup instructions to mention the config file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684f5db41058832c9b00005bad64124a