### PR TITLE
Add YAML config loader

### DIFF
--- a/rag_system/core/config.py
+++ b/rag_system/core/config.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, Field
 from typing import Dict, Any
 from datetime import timedelta
+from pathlib import Path
+import yaml
 
 class UnifiedConfig(BaseModel):
     # Add common configuration parameters here
@@ -50,3 +52,25 @@ class RAGConfig(UnifiedConfig):
     reranker_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 
 # You can add more specific config classes as needed
+
+
+def load_from_yaml(config_path: str) -> RAGConfig:
+    """Load configuration from a YAML file.
+
+    Parameters
+    ----------
+    config_path: str
+        Path to the YAML configuration file.
+
+    Returns
+    -------
+    RAGConfig
+        Configuration populated with values from the YAML file.
+    """
+    path = Path(config_path)
+    data = {}
+    if path.is_file():
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    return RAGConfig(**data)
+

--- a/rag_system/main.py
+++ b/rag_system/main.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Dict, Any
 from agents.utils.task import Task as LangroidTask
 
-from rag_system.core.config import UnifiedConfig
+from rag_system.core.config import UnifiedConfig, load_from_yaml
 from rag_system.core.pipeline import EnhancedRAGPipeline
 from rag_system.tracking.unified_knowledge_tracker import UnifiedKnowledgeTracker
 from rag_system.utils.embedding import BERTEmbeddingModel
@@ -98,8 +98,9 @@ async def run_creative_exploration(components: Dict[str, Any], start_node: str, 
 @log_and_handle_errors
 async def main():
     # Load configuration
-    config_path = "config/rag_config.json"
-    rag_config.load_config(config_path)
+    config_path = "configs/rag_config.yaml"
+    global rag_config
+    rag_config = load_from_yaml(config_path)
 
     components = await initialize_components()
 


### PR DESCRIPTION
## Summary
- add `load_from_yaml` helper to `rag_system/core/config.py`
- use the new helper in `rag_system/main.py` to load `configs/rag_config.yaml`

## Testing
- `pytest tests/test_unified_config.py -q`
- `pytest tests/test_server.py tests/test_unified_config.py -q` *(fails: Client.__init__() got unexpected keyword argument 'app')*


------
https://chatgpt.com/codex/tasks/task_e_685386598558832c9c4ce3d27a13f5f1