### PR TITLE
Handle optional dependencies gracefully

### DIFF
--- a/tests/test_self_evolving_system.py
+++ b/tests/test_self_evolving_system.py
@@ -1,4 +1,7 @@
-import unittest
+import importlib.util, unittest
+if importlib.util.find_spec("numpy") is None:
+    raise unittest.SkipTest("Required dependency not installed")
+
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 import numpy as np

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,7 @@
-import unittest
+import importlib.util, unittest
+if importlib.util.find_spec("httpx") is None:
+    raise unittest.SkipTest("Required dependency not installed")
+
 from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock, patch
 import sys

--- a/tests/test_store_counts.py
+++ b/tests/test_store_counts.py
@@ -1,4 +1,7 @@
-import unittest
+import importlib.util, unittest
+if importlib.util.find_spec("numpy") is None:
+    raise unittest.SkipTest("Required dependency not installed")
+
 from datetime import datetime
 import numpy as np
 import sys


### PR DESCRIPTION
## Summary
- allow tests to run without `numpy` or `httpx` installed
- skip tests that explicitly require those packages if missing
- ensure stub modules report as missing to `find_spec`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853896aad28832c885305244d57dc95