### PR TITLE
Fix imports and indentation

### DIFF
--- a/agents/king/analytics/analytics_manager.py
+++ b/agents/king/analytics/analytics_manager.py
@@ -1,4 +1,6 @@
 import logging
+import matplotlib.pyplot as plt
+import asyncio
 from typing import Dict, Any, List
 from .base_analytics import BaseAnalytics
 from rag_system.error_handling.error_handler import error_handler, safe_execute, AIVillageException

--- a/agents/king/planning/reasoning_engine.py
+++ b/agents/king/planning/reasoning_engine.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Any
 import torch.nn as nn
+from agents.utils.exceptions import AIVillageException
 
 logger = logging.getLogger(__name__)
 

--- a/agents/king/tests/test_quality_assurance_layer.py
+++ b/agents/king/tests/test_quality_assurance_layer.py
@@ -1,6 +1,7 @@
 import unittest
 import asyncio
 import importlib.util
+import numpy as np
 
 # Skip if PyTorch is not installed since the QA layer relies on transformer
 # models that require torch.

--- a/agents/sage/task_execution.py
+++ b/agents/sage/task_execution.py
@@ -92,20 +92,20 @@ class TaskExecutor:
             subgoals = await self.generate_subgoals(task['content'])
             results = []
             for subgoal in subgoals:
-            subtask = {
-                'type': task['type'],
-                'content': subgoal,
-                'priority': task.get('priority', 1),
-                'id': task.get('id', ''),
-            }
-            langroid_subtask = LangroidTask(
-                self.agent,
-                subtask['content'],
-                subtask['id'],
-                subtask['priority'],
-            )
-            langroid_subtask.type = subtask['type']
-            subtask_result = await self.execute_task(langroid_subtask)
+                subtask = {
+                    'type': task['type'],
+                    'content': subgoal,
+                    'priority': task.get('priority', 1),
+                    'id': task.get('id', ''),
+                }
+                langroid_subtask = LangroidTask(
+                    self.agent,
+                    subtask['content'],
+                    subtask['id'],
+                    subtask['priority'],
+                )
+                langroid_subtask.type = subtask['type']
+                subtask_result = await self.execute_task(langroid_subtask)
                 results.append(subtask_result)
             final_result = await self.summarize_results(task, subgoals, results)
             return final_result


### PR DESCRIPTION
## Summary
- add plotting and asyncio imports in `analytics_manager`
- handle custom exception in `ReasoningEngine`
- add numpy import in QA test
- fix subgoal loop indentation in `TaskExecutor`
- run `flake8` to ensure no F821/E999 errors

## Testing
- `flake8 agents/ > /tmp/flake8.log`
- `grep -n "F821" -n /tmp/flake8.log | wc -l`
- `grep -n "E999" -n /tmp/flake8.log | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_6853896cf8e8832cbbd084147142b6d9