### PR TITLE
Refactor reasoning result construction

### DIFF
--- a/rag_system/processing/reasoning_engine.py
+++ b/rag_system/processing/reasoning_engine.py
@@ -15,17 +15,34 @@ class UncertaintyAwareReasoningEngine:
         # Each node is expected to contain at least a ``content`` field
         self.graph = nx.Graph()
 
-    async def reason(self, query: str, retrieved_info: List[RetrievalResult], activated_knowledge: Dict[str, Any]) -> Dict[str, Any]:
-        """Return a reasoning result summarizing provided information."""
-        reasoning_result = {
+    async def reason(
+        self,
+        query: str,
+        retrieved_info: List[RetrievalResult],
+        activated_knowledge: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Summarize retrieved info and activated knowledge."""
+
+        evidence_texts = [r.content for r in retrieved_info]
+        knowledge_keys = list(activated_knowledge.keys())
+
+        summary_parts = []
+        if evidence_texts:
+            summary_parts.append(" ".join(evidence_texts[:2]))
+        if knowledge_keys:
+            summary_parts.append(
+                f"Key concepts: {', '.join(knowledge_keys[:3])}"
+            )
+        conclusion = " ".join(summary_parts) if summary_parts else "No evidence available"
+
+        return {
             "query": query,
-            "conclusion": "This is a placeholder conclusion.",
+            "conclusion": conclusion,
             "confidence": 0.8,
             "uncertainty": 0.2,
-            "supporting_evidence": [result.content for result in retrieved_info[:3]],
-            "activated_concepts": list(activated_knowledge.keys())[:5],
+            "supporting_evidence": evidence_texts[:3],
+            "activated_concepts": knowledge_keys[:5],
         }
-        return reasoning_result
 
     def update_causal_strength(self, source: str, target: str, observed_probability: float):
         edge = self.causal_edges.get((source, target))
@@ -83,16 +100,6 @@ class UncertaintyAwareReasoningEngine:
         if not self.graph.has_node(entity):
             return []
         return list(self.graph.neighbors(entity))
-
-        reasoning_result = {
-            "query": query,
-            "conclusion": "This is a placeholder conclusion.",
-            "confidence": 0.8,
-            "uncertainty": 0.2,
-            "supporting_evidence": [result.content for result in retrieved_info[:3]],
-            "activated_concepts": list(activated_knowledge.keys())[:5]
-        }
-        return reasoning_result
 
     def estimate_uncertainty(self, reasoning_result: Dict[str, Any]) -> float:
         # Implement uncertainty estimation logic

--- a/rag_system/processing/reasoning_engine.py
+++ b/rag_system/processing/reasoning_engine.py
@@ -16,50 +16,16 @@ class UncertaintyAwareReasoningEngine:
         self.graph = nx.Graph()
 
     async def reason(self, query: str, retrieved_info: List[RetrievalResult], activated_knowledge: Dict[str, Any]) -> Dict[str, Any]:
-        with self.driver.session() as session:
-            if timestamp:
-                result = session.run(
-                    """
-                        CALL db.index.fulltext.queryNodes("nodeContent", $query) 
-                    YIELD node, score
-                        MATCH (node)-[:VERSION]->(v:NodeVersion)
-                        WHERE v.timestamp <= $timestamp
-                        WITH node, score, v
-                        ORDER BY v.timestamp DESC, score DESC
-                    LIMIT $k
-                        RETURN id(node) as id, v.content as content, score, 
-                            v.uncertainty as uncertainty, v.timestamp as timestamp, 
-                            v.version as version
-                    """,
-                        query=query, timestamp=timestamp, k=k
-                    )
-            else:
-                result = session.run(
-                    """
-                    CALL db.index.fulltext.queryNodes("nodeContent", $query) 
-                    YIELD node, score
-                    MATCH (node)-[:VERSION]->(v:NodeVersion)
-                    WITH node, score, v
-                    ORDER BY v.timestamp DESC, score DESC
-                    LIMIT $k
-                    RETURN id(node) as id, v.content as content, score, 
-                        v.uncertainty as uncertainty, v.timestamp as timestamp, 
-                        v.version as version
-                    """,
-                    query=query, k=k
-                )
-
-        return [
-            RetrievalResult(
-                id=record["id"],
-                content=record["content"],
-                score=record["score"],
-                uncertainty=record["uncertainty"],
-                timestamp=record["timestamp"],
-                version=record["version"]
-            )
-            for record in result
-        ]
+        """Return a reasoning result summarizing provided information."""
+        reasoning_result = {
+            "query": query,
+            "conclusion": "This is a placeholder conclusion.",
+            "confidence": 0.8,
+            "uncertainty": 0.2,
+            "supporting_evidence": [result.content for result in retrieved_info[:3]],
+            "activated_concepts": list(activated_knowledge.keys())[:5],
+        }
+        return reasoning_result
 
     def update_causal_strength(self, source: str, target: str, observed_probability: float):
         edge = self.causal_edges.get((source, target))


### PR DESCRIPTION
## Summary
- simplify `UncertaintyAwareReasoningEngine.reason`
- drop unused db access and build a dictionary result from given info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ee786ec0832ca0ae0d8dc01b01da