### PR TITLE
Fix driver close safeguard

### DIFF
--- a/rag_system/processing/reasoning_engine.py
+++ b/rag_system/processing/reasoning_engine.py
@@ -68,7 +68,8 @@ class UncertaintyAwareReasoningEngine:
             edge.strength = (1 - learning_rate) * edge.strength + learning_rate * observed_probability
     
     def close(self):
-        self.driver.close()
+        if self.driver:
+            self.driver.close()
 
     async def get_snapshot(self, timestamp: datetime) -> Dict[str, Any]:
         # Implement logic to return a snapshot of the graph store at the given timestamp


### PR DESCRIPTION
## Summary
- avoid calling `.close()` on a nonexistent driver in `UncertaintyAwareReasoningEngine`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853fa681c38832c8c3051bd17031158