### PR TITLE
Update ReasoningEngine import

### DIFF
--- a/rag_system/processing/cognitive_nexus.py
+++ b/rag_system/processing/cognitive_nexus.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, Any, List
 from ..core.agent_interface import AgentInterface
-from ..processing.reasoning_engine import ReasoningEngine
+from ..core.interface import ReasoningEngine
 from ..processing.self_referential_query_processor import SelfReferentialQueryProcessor
 
 class CognitiveNexus:


### PR DESCRIPTION
## Summary
- fix import path for `ReasoningEngine` in `cognitive_nexus`

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6853fa6900b4832c972a8572045bfbc7