### PR TITLE
Implement async lifecycle stubs

### DIFF
--- a/rag_system/processing/reasoning_engine.py
+++ b/rag_system/processing/reasoning_engine.py
@@ -18,15 +18,14 @@ class UncertaintyAwareReasoningEngine:
     async def initialize(self) -> None:
         """Initialize underlying resources for the reasoning engine.
 
-        This default implementation simply returns as there are no
-        mandatory resources to initialize yet.  Subclasses can override
-        this method to set up database connections or language models.
+        The base implementation performs no work.  Subclasses may
+        override this method to set up database or model connections.
         """
-        return None
+        pass
 
     async def shutdown(self) -> None:
         """Release any resources held by the reasoning engine."""
-        return None
+        pass
 
     async def get_status(self) -> Dict[str, Any]:
         """Return a basic status dictionary for monitoring purposes."""


### PR DESCRIPTION
## Summary
- add simple async lifecycle methods to reasoning engine
- minimal docstrings and placeholder implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853fea9d8c8832c8421d68e8875a9b3