### PR TITLE
Add PyYAML dependency and update test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Run unit tests
+        pip install -r requirements-dev.txt
+    - name: Run test suite
       run: |
-        python -m unittest discover -v -s agents/king/tests -p "test_*.py"
-    - name: Run integration tests
-      run: |
-        python -m unittest agents/king/tests/test_integration.py
+        pytest -vv
 
   lint:
     runs-on: ubuntu-latest
@@ -59,10 +57,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r requirements-dev.txt
         pip install coverage
     - name: Run tests with coverage
       run: |
-        coverage run -m unittest discover -v -s agents/king/tests -p "test_*.py"
+        coverage run -m pytest -vv
         coverage report -m
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Some features rely on large libraries such as `numpy`, `torch` and `faiss`. Thes
 pip install numpy torch faiss-cpu  # or faiss-gpu for CUDA systems
 ```
 
-The tokenizer file `rag_system/utils/token_data/cl100k_base.tiktoken` is bundled so that `tiktoken` can initialize without internet access. Ensure you have a `.env` file in the project root containing your API keys. After installing the dependencies you can run the test suite:
+The tokenizer file `rag_system/utils/token_data/cl100k_base.tiktoken` is bundled so that `tiktoken` can initialize without internet access. Ensure you have a `.env` file in the project root containing your API keys. After installing the dependencies you can run the test suite with `pytest`:
 ```bash
-python -m unittest discover tests
+pytest
 ```
 
 ## Testing
@@ -82,7 +82,8 @@ main `requirements.txt` file contains heavy packages such as `torch` and
 pip install -r requirements.txt
 ```
 
-Install the additional test-only packages from `requirements-dev.txt`:
+Install the additional test-only packages from `requirements-dev.txt`.
+Both files include `PyYAML`, which is required by the test configuration:
 
 ```bash
 pip install -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest
 pytest-asyncio
 requests
 numpy
+PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pytest
 pytest-asyncio
 click
 pyyaml
+PyYAML
 ollama
 aiohttp>=3.10.5
 flake8>=7.1.1


### PR DESCRIPTION
## Summary
- add PyYAML to dependency lists
- install all requirements when running CI
- run pytest for automated checks
- mention PyYAML in README

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for llama.cpp)*
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68542f16d674832cbccd2ac26f053437