### PR TITLE
Fix missing BitNet utilities and extend tests

### DIFF
--- a/agent_forge/model_compression/__init__.py
+++ b/agent_forge/model_compression/__init__.py
@@ -1,8 +1,12 @@
-from .model_compression import ModelCompressionTask, BitNetModel, BitLinear, HyperCompressor
+from .model_compression import ModelCompressionTask, BitNetModel, BitLinear, HyperCompressor, convert_to_bitnet
+from .bitlinearization import quantize_weights, quantize_activations
 
 __all__ = [
     'ModelCompressionTask',
     'BitNetModel',
     'BitLinear',
+    'convert_to_bitnet',
+    'quantize_weights',
+    'quantize_activations',
     'HyperCompressor'
 ]

--- a/agent_forge/model_compression/bitlinearization.py
+++ b/agent_forge/model_compression/bitlinearization.py
@@ -1,0 +1,20 @@
+"""Utility wrappers for BitNet-style linear layers and quantization helpers."""
+
+from .model_compression import BitNetModel, BitLinear, convert_to_bitnet
+
+# quantization helpers originally located in training.training
+try:
+    from agent_forge.training.training import quantize_weights, quantize_activations
+except Exception:  # pragma: no cover - optional if training module unavailable
+    def quantize_weights(x):
+        raise ImportError("quantize_weights not available")
+    def quantize_activations(x):
+        raise ImportError("quantize_activations not available")
+
+__all__ = [
+    "BitNetModel",
+    "BitLinear",
+    "convert_to_bitnet",
+    "quantize_weights",
+    "quantize_activations",
+]

--- a/agent_forge/model_compression/bitlinearization.py
+++ b/agent_forge/model_compression/bitlinearization.py
@@ -2,9 +2,10 @@
 
 from .model_compression import BitNetModel, BitLinear, convert_to_bitnet
 
-# quantization helpers originally located in training.training
+# quantization helpers located in training modules
 try:
-    from agent_forge.training.training import quantize_weights, quantize_activations
+    from agent_forge.training.training import quantize_weights
+    from agent_forge.training.sleep_and_dream import quantize_activations
 except Exception:  # pragma: no cover - optional if training module unavailable
     def quantize_weights(x):
         raise ImportError("quantize_weights not available")

--- a/tests/test_bayesnet.py
+++ b/tests/test_bayesnet.py
@@ -3,7 +3,16 @@ from unittest import mock
 import asyncio
 import sys
 from pathlib import Path
+import types
 import pytest
+
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda *args, **kwargs: {}
+sys.modules.setdefault("yaml", yaml_stub)
+sys.modules.setdefault("networkx", types.ModuleType("networkx"))
+requests_stub = types.ModuleType("requests")
+requests_stub.get = lambda *a, **k: None
+sys.modules.setdefault("requests", requests_stub)
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 

--- a/tests/test_compression_pipeline.py
+++ b/tests/test_compression_pipeline.py
@@ -14,6 +14,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import torch
 from agent_forge.compression import SeedLMCompressor, VPTQQuantizer, stream_compress_model
+from agent_forge.model_compression.bitlinearization import BitNetModel
 
 class TestCompressionPipeline(unittest.TestCase):
     def test_seedlm_roundtrip(self):
@@ -36,6 +37,13 @@ class TestCompressionPipeline(unittest.TestCase):
         compressed = stream_compress_model(model)
         self.assertIn('weight', compressed)
         self.assertIn('bias', compressed)
+        self.assertGreater(compressed['__compression_ratio__'], 1.0)
+
+    def test_bitnet_wrapper(self):
+        lin = torch.nn.Linear(4,2)
+        bit = BitNetModel(lin)
+        out = bit(torch.randn(1,4))
+        self.assertEqual(out.shape[-1], 2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -53,10 +53,11 @@ class TestServer(unittest.TestCase):
                 resp1 = await server.upload_endpoint(file)
                 file = UploadFile(filename="test.txt", file=BytesIO(b"hello"))
                 resp2 = await server.upload_endpoint(file)
+                query_resp = await server.query_endpoint(server.QueryRequest(query="hi"))
                 await server.shutdown_event()
-                return resp1, resp2
+                return resp1, resp2, query_resp
 
-            resp1, resp2 = asyncio.run(run_flow())
+            resp1, resp2, query_resp = asyncio.run(run_flow())
 
             mock_init.assert_awaited_once()
             mock_shutdown.assert_awaited_once()
@@ -66,6 +67,7 @@ class TestServer(unittest.TestCase):
             emb1 = server.vector_store.documents[0]["embedding"]
             emb2 = server.vector_store.documents[1]["embedding"]
             self.assertTrue(np.array_equal(emb1, emb2))
+            self.assertEqual(query_resp, async_mock_response)
 
 
 if __name__ == "__main__":

--- a/tests/test_unified_config.py
+++ b/tests/test_unified_config.py
@@ -1,5 +1,11 @@
 import unittest
 from datetime import timedelta
+import types, sys
+
+yaml_stub = types.ModuleType("yaml")
+yaml_stub.safe_load = lambda *args, **kwargs: {}
+sys.modules.setdefault("yaml", yaml_stub)
+
 from rag_system.core.config import UnifiedConfig
 
 class TestUnifiedConfig(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add `bitlinearization.py` providing BitNet wrappers and quantization helpers
- integrate BitNet conversion and compression ratio calculation in `stream_compress_model`
- expose new helpers in `model_compression.__init__`
- enhance tests for compression, server, and config modules
- stub optional dependencies in tests so they run without PyYAML or networkx

## Testing
- `pytest tests/test_compression_pipeline.py tests/test_server.py tests/test_bayesnet.py tests/test_unified_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e87566fe4832ca738bc33b955a865