### PR TITLE
Document placeholders and fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ architecture for continuous improvement and adaptation.
 > 
 > All other phases &mdash; including Quiet-STaR thought generation, expert
 > vectors and ADAS optimization &mdash; remain future work and are outlined for
-> reference only in the documentation.
+> reference only in the documentation.  The `SelfEvolvingSystem` class present
+> in the code is a lightweight stub used for demos and tests.
 
 ## System Components
 
@@ -73,6 +74,9 @@ and place it in `rag_system/utils/token_data/`.
 5. Review the default Retrieval-Augmented Generation configuration:
    - The file `configs/rag_config.yaml` contains the default settings used by
      the RAG pipeline. Edit this file if you need to customize the behaviour.
+   - Parameters such as `vector_store_type` and `graph_store_type` are
+     currently informational only&mdash;`VectorStore` always uses FAISS and
+     `GraphStore` always uses NetworkX.
 6. Tune decision-making hyperparameters:
    - `configs/decision_making.yaml` defines settings for the MCTS and DPO modules.
 
@@ -82,6 +86,11 @@ Some features rely on large libraries such as `numpy`, `torch` and `faiss`. Thes
 ```bash
 pip install numpy torch faiss-cpu  # or faiss-gpu for CUDA systems
 ```
+
+The geometry-aware training helpers attempt to use the optional
+`torch-twonn` package for intrinsic dimension estimation but will fall
+back to the lightweight implementation in `agent_forge/geometry/id_twonn.py`
+if it is not installed.
 
 Ensure the file `rag_system/utils/token_data/cl100k_base.tiktoken` exists before running the code. If absent, download it from the [tiktoken repository](https://github.com/openai/tiktoken). After installing the dependencies and placing the file, you can run the test suite with `pytest`:
 ```bash
@@ -118,6 +127,10 @@ After installing these dependencies you can execute the full test suite:
 ```bash
 pytest
 ```
+
+Some unit tests automatically skip themselves if optional packages such
+as PyTorch are missing. Installing the full requirements is recommended
+for complete coverage.
 
 
 

--- a/agent_forge/geometry/snapshot.py
+++ b/agent_forge/geometry/snapshot.py
@@ -7,7 +7,10 @@ Fast utilities for sensing representational geometry every mini-batch.
 from __future__ import annotations
 import torch, math
 from torch import Tensor
-from twonn import twonn                           # Two-NN impl
+try:
+    from twonn import twonn  # external Two-NN implementation
+except Exception:  # pragma: no cover - fallback for minimal installs
+    from .id_twonn import twonn  # lightweight local estimator
 from torch.linalg import svdvals                  # native batched SVD (PyTorch ≥2.1)
 
 __all__ = ["snapshot", "GeomState"]

--- a/agents/unified_base_agent.py
+++ b/agents/unified_base_agent.py
@@ -499,6 +499,16 @@ class _QualityAssuranceStub:
         return [_SafetyCheck(random.uniform(0.5, 1.0)) for _ in range(5)]
 
 class SelfEvolvingSystem:
+    """Simplified placeholder managing agent evolution.
+
+    This class is a stub.  It exposes just enough behaviour for the
+    tutorials and unit tests to run without implementing the full
+    self‑evolving pipeline outlined in the documentation.  Additional
+    modules such as Quiet‑STaR, expert vectors and ADAS optimisation are
+    not integrated yet and will require substantial work before this
+    system becomes feature complete.
+    """
+
     def __init__(self, agents: List[UnifiedBaseAgent]):
         self.agents = agents
         # Initialize basic stub components so the system functions even

--- a/docs/geometry_aware_training.md
+++ b/docs/geometry_aware_training.md
@@ -6,7 +6,9 @@ This document summarises the additional components used to implement the self-ad
 
 - **Transformer² (SakanaAI/self-adaptive-llms)** — provides the `ExpertVector` class for Σ-scale expert vectors and prompt baking utilities.
 - **SVF (syp2ysy/SVF)** — lightweight singular value fine-tuning kernel used by `apply_svf` in `training/svf_ops.py`.
-- **torch-twonn** — Two-NN intrinsic dimension estimator, wrapped by `geometry/id_twonn.py`.
+- **torch-twonn** — Two-NN intrinsic dimension estimator.  `geometry/snapshot.py`
+  will automatically fall back to the local implementation in
+  `geometry/id_twonn.py` if this package is unavailable.
 - **grokfast** — custom optimizer giving slow gradients extra weight, referenced in the training loop.
 - **Intelligence_at_the_edge_of_chaos** — computes Langton λ and entropy for the PID loop in `training/pid_edgechaos.py`.
 - **unexpected-benefits-of-self-modeling** — hidden-state predictor that regularises weights in the self-modeling task.


### PR DESCRIPTION
## Summary
- clarify that SelfEvolvingSystem is a stub
- describe fixed vector/graph store backends in README
- note optional torch‐twonn dependency and fallback
- update geometry docs with same information
- fallback to local Two‑NN estimator in `snapshot.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607731c980832ca17f43ed05c6f51b