### PR TITLE
Add tests for new training modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,8 +490,8 @@ The RAG system consists of the following main components:
 
 To run the unit tests and integration tests:
 
-```
-python -m unittest discover tests
+```bash
+pytest -vv
 ```
 
 ## Configuration

--- a/tests/test_quiet_star.py
+++ b/tests/test_quiet_star.py
@@ -1,0 +1,35 @@
+import importlib
+import unittest
+
+if importlib.util.find_spec("torch") is None:
+    raise unittest.SkipTest("PyTorch not installed")
+
+import torch
+from agent_forge.training.quiet_star import QuietSTaRModel
+
+class DummyModel:
+    def __init__(self, hidden_size=4, vocab_size=6):
+        self.config = type("cfg", (), {"hidden_size": hidden_size})
+        self.vocab_size = vocab_size
+    def __call__(self, input_ids, attention_mask=None):
+        b, l = input_ids.shape
+        logits = torch.randn(b, l, self.vocab_size)
+        return type("Out", (), {"logits": logits})
+
+class TestQuietStar(unittest.TestCase):
+    def test_forward_with_thoughts(self):
+        model = QuietSTaRModel(DummyModel())
+        inp = torch.ones(2, 3, dtype=torch.long)
+        logits, thoughts = model(inp)
+        self.assertEqual(logits.shape, (2, 3, model.base_model.vocab_size))
+        self.assertEqual(thoughts.shape, (2, 3, model.base_model.vocab_size))
+
+    def test_forward_without_thoughts(self):
+        model = QuietSTaRModel(DummyModel())
+        inp = torch.ones(1, 2, dtype=torch.long)
+        logits, thoughts = model(inp, generate_thoughts=False)
+        self.assertEqual(logits.shape, (1, 2, model.base_model.vocab_size))
+        self.assertIsNone(thoughts)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -5,6 +5,7 @@ if importlib.util.find_spec("torch") is None:
     raise unittest.SkipTest("PyTorch not installed")
 
 import torch
+import builtins
 from agent_forge.geometry.snapshot import snapshot
 
 class TestSnapshot(unittest.TestCase):
@@ -14,6 +15,18 @@ class TestSnapshot(unittest.TestCase):
         self.assertIn("ID_nl", g)
         self.assertIn("ID_lin", g)
         self.assertGreaterEqual(g["ID_lin"], 1)
+
+    def test_twonn_fallback(self):
+        import importlib as il
+        import agent_forge.geometry.snapshot as snap
+        orig_import = builtins.__import__
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == 'twonn':
+                raise ImportError
+            return orig_import(name, globals, locals, fromlist, level)
+        with unittest.mock.patch('builtins.__import__', side_effect=fake_import):
+            snap = il.reload(snap)
+            self.assertIn('id_twonn', snap.twonn.__module__)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_train_level.py
+++ b/tests/test_train_level.py
@@ -1,0 +1,25 @@
+import sys
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+try:
+    import torch.nn  # noqa: F401
+except Exception:
+    pytest.skip("PyTorch not installed", allow_module_level=True)
+
+repo_root = Path(__file__).resolve().parents[1]
+path = repo_root / 'agent_forge' / 'training' / 'train_level.py'
+spec = importlib.util.spec_from_file_location('agent_forge.training.train_level', path)
+train_level = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = train_level
+spec.loader.exec_module(train_level)
+
+class TestTrainLevel:
+    def test_invokes_components(self):
+        with patch.object(train_level, 'run_level') as run, \
+             patch.object(train_level, 'self_model_cycle') as cycle:
+            train_level.train_level('ds', ['t'], 'm', {'s': 1})
+            run.assert_called_once_with('ds')
+            cycle.assert_called_once_with('m', ['t'], {'s': 1})


### PR DESCRIPTION
## Summary
- add unit tests for Quiet-STaR model and training-level orchestration
- ensure snapshot uses fallback TwoNN implementation when `twonn` is absent
- document running tests with `pytest -vv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607c3e00dc832cb05bfa1475886c94