### PR TITLE
Implement basic UPO checker and improve decision training

### DIFF
--- a/agents/self_evolve/quality_assurance.py
+++ b/agents/self_evolve/quality_assurance.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+import random
+import numpy as np
+
+try:
+    from agents.utils.task import Task as LangroidTask
+except Exception:  # pragma: no cover - optional dependency for simple tests
+    LangroidTask = object  # type: ignore
+
+
+@dataclass
+class SafetyCheck:
+    """Represents the safety score of a single task evaluation."""
+
+    safety_score: float
+
+
+class BasicUPOChecker:
+    """Minimal Uncertainty-based safety checker.
+
+    The checker keeps a history of scores calculated as ``1 - uncertainty``.  The
+    ``upo_threshold`` determines the minimum acceptable score.
+    """
+
+    def __init__(self, upo_threshold: float = 0.7) -> None:
+        self.upo_threshold = upo_threshold
+        self._history: List[float] = []
+
+    def estimate_uncertainty(self, task: LangroidTask) -> float:
+        """Estimate task uncertainty.
+
+        Current implementation is a stub that returns a random value.
+        """
+        return random.random()
+
+    async def check_task_safety(self, task: LangroidTask) -> bool:
+        """Return ``True`` if the task is considered safe."""
+        uncertainty = self.estimate_uncertainty(task)
+        score = 1.0 - uncertainty
+        self._history.append(score)
+        if len(self._history) > 1000:
+            self._history.pop(0)
+        return score >= self.upo_threshold
+
+    async def get_recent_safety_checks(self) -> List[SafetyCheck]:
+        """Return the most recent safety scores."""
+        return [SafetyCheck(s) for s in self._history[-5:]]
+
+    async def evolve(self) -> None:
+        """Adjust the threshold based on recent history."""
+        if not self._history:
+            return
+        recent = self._history[-10:]
+        mean = float(np.mean(recent))
+        std = float(np.std(recent))
+        new_threshold = mean - 1.5 * std
+        self.upo_threshold = max(0.5, min(0.9, new_threshold))

--- a/tests/test_self_evolving_system.py
+++ b/tests/test_self_evolving_system.py
@@ -59,5 +59,15 @@ class TestSelfEvolvingSystem(unittest.IsolatedAsyncioTestCase):
         self.assertGreater(ses.mcts.exploration_weight, old_weight)
         self.assertGreater(ses.mcts.simulation_depth, old_depth)
 
+    async def test_system_evolve(self):
+        class EvoAgent(DummyAgent):
+            async def evolve(self):
+                self.add_capability("new")
+
+        agent = EvoAgent()
+        ses = SelfEvolvingSystem([agent])
+        await ses.evolve()
+        self.assertIn("new", agent.capabilities)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a simple BasicUPOChecker implementation
- wire BasicUPOChecker into SelfEvolvingSystem
- extend _DPOModule with in-memory dataset and train during evolution
- record decisions in the DPO dataset
- test system level evolve to ensure capability updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607c2e27fc832ca386cb1c47c67f6c