### PR TITLE
Add query history to SelfReferentialQueryProcessor

### DIFF
--- a/tests/test_self_referential_query_processor.py
+++ b/tests/test_self_referential_query_processor.py
@@ -1,0 +1,39 @@
+import unittest
+import asyncio
+from types import SimpleNamespace
+
+from rag_system.processing.self_referential_query_processor import SelfReferentialQueryProcessor
+
+class DummyCountStore:
+    async def get_count(self):
+        return 0
+
+class DummyRAGPipeline:
+    def __init__(self):
+        self.hybrid_retriever = SimpleNamespace(
+            vector_store=DummyCountStore(),
+            graph_store=DummyCountStore(),
+        )
+
+    async def process(self, query: str):
+        return f"processed {query}"
+
+class TestSelfReferentialQueryProcessor(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.pipeline = DummyRAGPipeline()
+        self.processor = SelfReferentialQueryProcessor(self.pipeline, history_limit=10)
+
+    async def test_history_accumulation(self):
+        await self.processor.process_self_query("What is AI?")
+        await self.processor.process_self_query("SELF:STATUS")
+        self.assertEqual(self.processor.query_history, ["What is AI?", "SELF:STATUS"])
+
+    async def test_get_query_history(self):
+        await self.processor.process_self_query("Q1")
+        await self.processor.process_self_query("Q2")
+        await self.processor.process_self_query("Q3")
+        history = await self.processor._get_query_history(2)
+        self.assertEqual(history, "Recent queries: [Q2], [Q3]")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep recent queries in `SelfReferentialQueryProcessor`
- parse HISTORY command and limit
- implement `_get_query_history`
- unit tests for accumulation and retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607c289404832c9abad0670560549e