### PR TITLE
Add keyword intent mapping to Sage

### DIFF
--- a/agents/sage/user_intent_interpreter.py
+++ b/agents/sage/user_intent_interpreter.py
@@ -19,15 +19,44 @@ class UserIntentInterpreter:
         Returns:
             Dict[str, Any]: A dictionary containing the interpreted intent and any additional information.
         """
-        # Implement intent interpretation logic here
-        # This could involve NLP techniques, machine learning models, or rule-based systems
-        
-        # Placeholder implementation
-        intent = {
-            "type": "information_request",
-            "topic": query,
-            "confidence": 0.8
+        # Simple keyword-based intent detection.
+        # In a production system this could be replaced with NLP models or more
+        # advanced rule engines.  The mapping below is intentionally lightweight
+        # to keep this component dependency free.
+
+        patterns = {
+            "search for": "search",
+            "look up": "search",
+            "find": "search",
+            "summarize": "summarize",
+            "summary of": "summarize",
+            "explain": "explanation",
+            "analyze": "analysis",
+            "compare": "comparison",
+            "generate": "generation",
+            "write": "generation",
+            "create": "generation",
         }
-        
+
+        lower_query = query.lower()
+        for phrase, intent_type in patterns.items():
+            if phrase in lower_query:
+                # Extract the topic following the matched phrase if possible.
+                topic = lower_query.split(phrase, 1)[1].strip() or query
+                intent = {
+                    "type": intent_type,
+                    "topic": topic,
+                    "confidence": 0.9,
+                }
+                logger.info(f"Interpreted intent: {intent}")
+                return intent
+
+        # Fallback for unrecognised queries
+        intent = {
+            "type": "unknown",
+            "topic": query,
+            "confidence": 0.4,
+        }
+
         logger.info(f"Interpreted intent: {intent}")
         return intent

--- a/docs/system_overview.md
+++ b/docs/system_overview.md
@@ -24,3 +24,18 @@ artifacts.
 The project follows a monolithic layout with modular packages rather than multiple
 microservices. Agents share a common `UnifiedBaseAgent` class and interact with the
 RAG pipeline through well defined interfaces.
+
+## User Intent Interpretation
+
+The `UserIntentInterpreter` in `agents/sage` detects simple intent types using
+keyword patterns. The following phrases are recognised:
+
+- `search for`, `look up`, `find` → **search**
+- `summarize`, `summary of` → **summarize**
+- `explain` → **explanation**
+- `analyze` → **analysis**
+- `compare` → **comparison**
+- `generate`, `write`, `create` → **generation**
+
+Queries that do not match any pattern are marked as `unknown` with a lower
+confidence score.

--- a/tests/test_user_intent_interpreter.py
+++ b/tests/test_user_intent_interpreter.py
@@ -1,0 +1,37 @@
+import unittest
+import asyncio
+import sys
+import importlib.util
+from pathlib import Path
+
+# Load the interpreter directly to avoid importing heavy dependencies from the
+# parent `agents` package during test collection.
+module_path = Path(__file__).resolve().parents[1] / "agents" / "sage" / "user_intent_interpreter.py"
+spec = importlib.util.spec_from_file_location("user_intent_interpreter", module_path)
+ui = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ui)  # type: ignore
+UserIntentInterpreter = ui.UserIntentInterpreter
+
+
+class TestUserIntentInterpreter(unittest.IsolatedAsyncioTestCase):
+    async def test_search_intent(self):
+        interpreter = UserIntentInterpreter()
+        result = await interpreter.interpret_intent("search for python tutorials")
+        self.assertEqual(result["type"], "search")
+        self.assertGreaterEqual(result["confidence"], 0.9)
+
+    async def test_summarize_intent(self):
+        interpreter = UserIntentInterpreter()
+        result = await interpreter.interpret_intent("summarize the rust book")
+        self.assertEqual(result["type"], "summarize")
+        self.assertIn("rust book", result["topic"])
+
+    async def test_unknown_intent(self):
+        interpreter = UserIntentInterpreter()
+        result = await interpreter.interpret_intent("Tell me something interesting")
+        self.assertEqual(result["type"], "unknown")
+        self.assertLess(result["confidence"], 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement simple keyword-based intent detection
- document intent patterns
- add tests for interpreter

## Testing
- `pytest tests/test_user_intent_interpreter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686082cca60c832c893e9b2b391f6c2b