### PR TITLE
Enhance rule baking

### DIFF
--- a/agent_forge/training/identity.py
+++ b/agent_forge/training/identity.py
@@ -106,11 +106,11 @@ class MoralFrameworkBaker:
         )
 
     def deep_bake_rules(self) -> List[Rule]:
-        """Blend the Eudaimonic framework into each rule text.
+        """Return a contextualized version of the core moral rules.
 
-        The basic rules establish a moral skeleton. This method
-        interlaces the details from the *Eudaimonic Morality System for AI*
-        so the final guidance is richer and self contained.
+        The method enriches the skeleton provided by ``self.core_rules`` with
+        additional constraints and references to the :class:`TriPartCompass`.
+        The resulting list replaces ``self.core_rules`` and is returned.
         """
 
         baked_rules: List[Rule] = []
@@ -124,6 +124,12 @@ class MoralFrameworkBaker:
                     "65% or greater, continue. Otherwise engage the Three-Part "
                     "Moral Compass for deliberation. Respect everyone's agency "
                     "while seeking the best collective outcome."
+                )
+                additional.append(
+                    "When uncertain consult the compass questions:"
+                    f" {self.tri_part_compass.jesus_archetype.question_template},"
+                    f" {self.tri_part_compass.lao_tzu_archetype.question_template}"
+                    f" and {self.tri_part_compass.diogenes_archetype.question_template}."
                 )
             elif rule.number == 2:
                 additional.append(
@@ -152,4 +158,5 @@ class MoralFrameworkBaker:
                 Rule(number=rule.number, text=enriched_text, priority=rule.priority)
             )
 
+        self.core_rules = baked_rules
         return baked_rules

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -25,13 +25,15 @@ class TestIdentitySystem(unittest.TestCase):
 
     def test_deep_bake_rules(self):
         baker = MoralFrameworkBaker()
+        original_texts = [r.text for r in baker.core_rules]
         baked_rules = baker.deep_bake_rules()
-        self.assertEqual(len(baked_rules), len(baker.core_rules))
-        differences = [
-            baked.text != core.text
-            for baked, core in zip(baked_rules, baker.core_rules)
-        ]
-        self.assertTrue(any(differences))
+
+        # the returned rules should match what is stored on the baker
+        self.assertEqual(baked_rules, baker.core_rules)
+
+        # every rule text should be enriched compared to the original
+        for baked, original in zip(baked_rules, original_texts):
+            self.assertNotEqual(baked.text, original)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enrich MoralFrameworkBaker.deep_bake_rules to rewrite core rules
- return the refined rules back on the baker
- expand unit test to verify enrichment and in-place mutation

## Testing
- `pytest tests/test_identity.py::TestIdentitySystem::test_deep_bake_rules -vv`
- `pytest -k deep_bake_rules -vv`

------
https://chatgpt.com/codex/tasks/task_e_6860a62d9e88832c8ef0b31504d418c7