### PR TITLE
Update Python version requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ['3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ planned milestones.
 
 ## Setup
 
+This project requires **Python 3.10 or higher**. Ensure your virtual
+environment uses a compatible interpreter.
+
 1. Clone the repository:
    ```
    git clone https://github.com/yourusername/ai-village.git
@@ -252,6 +255,10 @@ To provide your AI Village with a starting base of information, you can manually
    - Consider updating the `configs/rag_config.yaml` file to optimize the RAG system for academic paper processing.
 
 By following these steps, you can manually feed several dozen academic papers into your RAG system, providing a rich starting base of information for your AI Village. This will enhance the system's ability to answer queries and perform tasks related to the content of these papers.
+
+### Prerequisites
+
+Make sure you have **Python 3.10+** installed before continuing with the installation steps below.
 
 ## Installation
 

--- a/docs/system_overview.md
+++ b/docs/system_overview.md
@@ -20,7 +20,7 @@ artifacts.
 
 ## Technologies
 
-- **Language**: Python 3 (≈21k lines across 240+ files).
+- **Language**: Python 3.10+ (≈21k lines across 240+ files).
 - **Web Framework**: FastAPI powers the server (`server.py`).
 - **ML Libraries**: PyTorch, Transformers, FAISS, Langroid.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- document Python 3.10+ requirement in the README and docs
- add a minimal `pyproject.toml` with `requires-python` metadata
- test CI only on Python 3.10 and 3.11

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement llama.cpp)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6860ac1dc82c832c88afde44b3f5ccea