### PR TITLE
Integrate secure communication modules

### DIFF
--- a/communications/__init__.py
+++ b/communications/__init__.py
@@ -1,5 +1,10 @@
 from .protocol import StandardCommunicationProtocol
 from .message import Message, MessageType, Priority
 from .queue import MessageQueue
-
-__all__ = ['StandardCommunicationProtocol', 'Message', 'MessageType', 'Priority', 'MessageQueue']
+__all__ = [
+    'StandardCommunicationProtocol',
+    'Message',
+    'MessageType',
+    'Priority',
+    'MessageQueue',
+]

--- a/communications/a2a_protocol.py
+++ b/communications/a2a_protocol.py
@@ -1,0 +1,53 @@
+import json
+import requests
+from jwcrypto import jwk, jws, jwe
+from cryptography import x509
+
+
+def _load_priv(pem_path: str) -> jwk.JWK:
+    return jwk.JWK.from_pem(open(pem_path, "rb").read())
+
+
+def _load_pub(cert_path: str) -> jwk.JWK:
+    cert = x509.load_pem_x509_certificate(open(cert_path, "rb").read())
+    return jwk.JWK.from_pyca(cert.public_key())
+
+
+def sign(payload: dict, key: jwk.JWK) -> str:
+    token = jws.JWS(json.dumps(payload).encode())
+    token.add_signature(key, None, json.dumps({"alg": "RS256"}))
+    return token.serialize()
+
+
+def encrypt(signed: str, key: jwk.JWK) -> str:
+    enc = jwe.JWE(signed.encode(), json.dumps({"alg": "RSA-OAEP", "enc": "A256GCM"}))
+    enc.add_recipient(key)
+    return enc.serialize()
+
+
+def decrypt(raw: str, priv: jwk.JWK) -> str:
+    token = jwe.JWE()
+    token.deserialize(raw, key=priv)
+    return token.payload.decode()
+
+
+def verify(signed: str, pub: jwk.JWK) -> dict:
+    token = jws.JWS()
+    token.deserialize(signed)
+    token.verify(pub)
+    return json.loads(token.payload)
+
+
+def send_a2a(url: str, message: dict, sender_priv: str, receiver_pub: str, encrypt_msg: bool = True) -> requests.Response:
+    priv = _load_priv(sender_priv)
+    pub = _load_pub(receiver_pub)
+    signed = sign(message, priv)
+    body = encrypt(signed, pub) if encrypt_msg else signed
+    hdr = {"Content-Type": "application/jwe" if encrypt_msg else "application/jws"}
+    return requests.post(url, data=body, headers=hdr)
+
+
+def receive_a2a(raw: str, receiver_priv: str, sender_pub: str, encrypted: bool = True) -> dict:
+    priv = _load_priv(receiver_priv)
+    data = decrypt(raw, priv) if encrypted else raw
+    return verify(data, _load_pub(sender_pub))

--- a/communications/mcp_client.py
+++ b/communications/mcp_client.py
@@ -1,0 +1,30 @@
+import os
+import uuid
+import requests
+from jose import jwt
+
+JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret")
+
+class MCPClient:
+    """JSON-RPC 2.0 over HTTPS with mTLS & JWT."""
+
+    def __init__(self, endpoint: str, cert: str, key: str, ca: str):
+        self.endpoint = endpoint
+        self.session = requests.Session()
+        self.session.verify = ca
+        self.session.cert = (cert, key)
+
+    def _make_token(self) -> str:
+        return jwt.encode({"aud": "mcp"}, JWT_SECRET, algorithm="HS256")
+
+    def call(self, method: str, params: dict) -> dict:
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": str(uuid.uuid4()),
+        }
+        headers = {"Authorization": f"Bearer {self._make_token()}"}
+        resp = self.session.post(self.endpoint, json=payload, headers=headers)
+        resp.raise_for_status()
+        return resp.json()

--- a/communications/message.py
+++ b/communications/message.py
@@ -14,6 +14,13 @@ class MessageType(Enum):
     KNOWLEDGE_SHARE = "knowledge_share"
     TASK_RESULT = "task_result"
     JOINT_REASONING_RESULT = "joint_reasoning_result"
+    UPDATE = "update"
+    COMMAND = "command"
+    BULK_UPDATE = "bulk_update"
+    PROJECT_UPDATE = "project_update"
+    SYSTEM_STATUS_UPDATE = "system_status_update"
+    CONFIG_UPDATE = "config_update"
+    TOOL_CALL = "tool_call"
 
 class Priority(Enum):
     LOW = 0
@@ -27,6 +34,7 @@ class Message:
     sender: str
     receiver: str
     content: Dict[str, Any]
+    metadata: Optional[Dict[str, Any]] = None
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     parent_id: Optional[str] = None
     timestamp: datetime = field(default_factory=datetime.now)
@@ -41,7 +49,8 @@ class Message:
             "content": self.content,
             "parent_id": self.parent_id,
             "timestamp": self.timestamp.isoformat(),
-            "priority": self.priority.value
+            "priority": self.priority.value,
+            "metadata": self.metadata,
         }
 
     @classmethod
@@ -54,5 +63,34 @@ class Message:
             content=data["content"],
             parent_id=data.get("parent_id"),
             timestamp=datetime.fromisoformat(data["timestamp"]),
-            priority=Priority(data["priority"])
+            priority=Priority(data["priority"]),
+            metadata=data.get("metadata"),
+        )
+
+    def with_updated_content(self, new_content: Dict[str, Any]) -> "Message":
+        """Return a new Message with updated content."""
+        return Message(
+            type=self.type,
+            sender=self.sender,
+            receiver=self.receiver,
+            content=new_content,
+            id=self.id,
+            parent_id=self.parent_id,
+            timestamp=self.timestamp,
+            priority=self.priority,
+            metadata=self.metadata,
+        )
+
+    def with_updated_priority(self, new_priority: Priority) -> "Message":
+        """Return a new Message with a different priority."""
+        return Message(
+            type=self.type,
+            sender=self.sender,
+            receiver=self.receiver,
+            content=self.content,
+            id=self.id,
+            parent_id=self.parent_id,
+            timestamp=self.timestamp,
+            priority=new_priority,
+            metadata=self.metadata,
         )

--- a/communications/prompt_baking.py
+++ b/communications/prompt_baking.py
@@ -1,0 +1,24 @@
+import json
+import torch
+import torch.nn as nn
+from transformers import AutoTokenizer
+
+class PromptBank(nn.Module):
+    """Frozen embeddings for baked-in system prompts and manifests."""
+
+    def __init__(self, manifest: dict, tokenizer_name: str, embed_dim: int):
+        super().__init__()
+        prompt_text = json.dumps(manifest, sort_keys=True, indent=None)
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+        token_ids = self.tokenizer(prompt_text)["input_ids"]
+        self.register_buffer("prompt_ids", torch.tensor(token_ids))
+        self.embed = nn.Embedding(len(token_ids), embed_dim)
+        nn.init.normal_(self.embed.weight, std=0.02)
+        for p in self.parameters():
+            p.requires_grad_(False)
+
+    def prepend(self, input_ids: torch.LongTensor) -> torch.LongTensor:
+        """Prepend baked prompt tokens to a batch of input ids."""
+        batch_size = input_ids.size(0)
+        prompt_batch = self.prompt_ids.unsqueeze(0).repeat(batch_size, 1)
+        return torch.cat([prompt_batch, input_ids], dim=1)

--- a/docs/communication_explainer.txt
+++ b/docs/communication_explainer.txt
@@ -12,7 +12,7 @@ Purpose: Defines the Message class and related enums for message types and prior
 
 MessageType Enum: Specifies the type of message.
 
-Values: TASK, QUERY, RESPONSE, UPDATE, COMMAND, BULK_UPDATE, PROJECT_UPDATE, SYSTEM_STATUS_UPDATE, CONFIG_UPDATE.
+Values: TASK, QUERY, RESPONSE, UPDATE, COMMAND, BULK_UPDATE, PROJECT_UPDATE, SYSTEM_STATUS_UPDATE, CONFIG_UPDATE, TOOL_CALL.
 Priority Enum: Specifies the priority level of messages.
 
 Values: LOW, MEDIUM, HIGH, CRITICAL.

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,24 @@
+import unittest
+from communications.message import Message, MessageType, Priority
+
+class TestMessageHelpers(unittest.TestCase):
+    def test_helper_methods_and_metadata(self):
+        msg = Message(
+            type=MessageType.TASK,
+            sender="a",
+            receiver="b",
+            content={"x": 1},
+            metadata={"m": 1},
+        )
+        updated = msg.with_updated_content({"x": 2})
+        self.assertEqual(updated.content, {"x": 2})
+        self.assertEqual(updated.priority, msg.priority)
+        self.assertEqual(updated.metadata, msg.metadata)
+        pri_msg = msg.with_updated_priority(Priority.HIGH)
+        self.assertEqual(pri_msg.priority, Priority.HIGH)
+        d = msg.to_dict()
+        restored = Message.from_dict(d)
+        self.assertEqual(restored.metadata, msg.metadata)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -51,5 +51,22 @@ class TestProtocol(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         self.assertEqual(received, ["a"])
 
+    async def test_history_and_process(self):
+        protocol = StandardCommunicationProtocol()
+        processed = []
+
+        async def handler(msg: Message):
+            processed.append(msg)
+
+        task = asyncio.create_task(protocol.process_messages(handler))
+        await protocol.send_message(Message(type=MessageType.NOTIFICATION, sender="s", receiver="r", content={}))
+        await asyncio.sleep(0.05)
+        protocol._running = False
+        await asyncio.sleep(0.01)
+        self.assertTrue(processed)
+        hist = protocol.get_message_history("r")
+        self.assertEqual(len(hist), 1)
+        task.cancel()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add prompt baking utility for frozen prompt embeddings
- add secure MCP client and A2A messaging helpers
- expand `Message` with new types, metadata and helper methods
- enhance `StandardCommunicationProtocol` with history tracking and async processing
- document new message types in communication explainer
- cover new functionality with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68613b218b8c832c82e973767a5e7f31