### PR TITLE
Improve message metadata typing and tests

### DIFF
--- a/communications/message.py
+++ b/communications/message.py
@@ -34,7 +34,7 @@ class Message:
     sender: str
     receiver: str
     content: Dict[str, Any]
-    metadata: Optional[Dict[str, Any]] = None
+    metadata: Dict[str, Any] | None = None
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     parent_id: Optional[str] = None
     timestamp: datetime = field(default_factory=datetime.now)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -20,5 +20,13 @@ class TestMessageHelpers(unittest.TestCase):
         restored = Message.from_dict(d)
         self.assertEqual(restored.metadata, msg.metadata)
 
+    def test_message_types_exist(self):
+        self.assertTrue(hasattr(MessageType, "UPDATE"))
+        self.assertTrue(hasattr(MessageType, "COMMAND"))
+        self.assertTrue(hasattr(MessageType, "BULK_UPDATE"))
+        self.assertTrue(hasattr(MessageType, "PROJECT_UPDATE"))
+        self.assertTrue(hasattr(MessageType, "SYSTEM_STATUS_UPDATE"))
+        self.assertTrue(hasattr(MessageType, "CONFIG_UPDATE"))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- update `Message` metadata field to use union typing
- add a test ensuring new message types exist

## Testing
- `pytest tests/test_message.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68613f67af3c832cbff5959daf67ac4d