### PR TITLE
Expand message history tracking

### DIFF
--- a/communications/protocol.py
+++ b/communications/protocol.py
@@ -75,7 +75,10 @@ class StandardCommunicationProtocol(CommunicationProtocol):
 
     async def send_message(self, message: Message) -> None:
         self.enqueue(message)
+        # Track history for both the sender and receiver so each agent can
+        # retrieve the full conversation context.
         self.message_history.setdefault(message.receiver, []).append(message)
+        self.message_history.setdefault(message.sender, []).append(message)
         await self._notify_subscribers(message)
 
         if self.mcp and message.type == MessageType.TOOL_CALL:
@@ -107,7 +110,6 @@ class StandardCommunicationProtocol(CommunicationProtocol):
         message = self.dequeue(agent_id)
         if message is None:
             raise AIVillageException(f"No messages for agent {agent_id}")
-        self.message_history.setdefault(agent_id, []).append(message)
         return message
 
     async def query(


### PR DESCRIPTION
## Summary
- track both sender and receiver history in `send_message`
- avoid duplicates by removing logging in `receive_message`
- verify history filtering and sender tracking in tests
- add test to ensure receive doesn't double record

## Testing
- `pytest -q tests/test_protocol.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68613f66bfd0832c8ddb4d46aff8b927