### PR TITLE
Fix callback async docs

### DIFF
--- a/docs/communication_explainer.txt
+++ b/docs/communication_explainer.txt
@@ -97,10 +97,11 @@ message = Message(
 await protocol.send_message(message)
 
 # Agent B subscribes to receive messages
-def agent_b_callback(message):
+async def agent_b_callback(message):
     # Process the message
     pass
 
+# subscribe() expects an async callback
 protocol.subscribe('agent_b', agent_b_callback)
 Group Communication
 Group Identification:


### PR DESCRIPTION
## Summary
- clarify async callback usage in docs

## Testing
- `pytest -k communications -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68614abf7f98832c89888a5938f40f12