### PR TITLE
Clarify get_message_history usage

### DIFF
--- a/docs/communication_explainer.txt
+++ b/docs/communication_explainer.txt
@@ -65,7 +65,7 @@ Agents register to receive messages addressed to them.
 unsubscribe(agent_id, callback):
 Agents can remove their subscription.
 get_message_history(agent_id, message_type=None):
-Retrieves messages sent to or from an agent. Omitting message_type returns all messages.
+Returns the message history for the given agent. If message_type is omitted, all messages are returned.
 process_messages(handler):
 Asynchronous; continuously processes messages using a handler coroutine.
 Example usage: await protocol.process_messages(handler)


### PR DESCRIPTION
## Summary
- document optional `message_type` argument in `get_message_history`

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError for torch and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68614cd5b114832c8f1507784980ccdb