### PR TITLE
Clarify optional metadata description

### DIFF
--- a/docs/communication_explainer.txt
+++ b/docs/communication_explainer.txt
@@ -26,7 +26,7 @@ content: Dictionary containing message content.
 priority: Priority level (Priority).
 timestamp: Time when the message was created.
 parent_id: (Optional) ID of the parent message, used for threading.
-metadata: Optional dictionary with additional data.
+metadata: Optional dictionary with additional data about the message.
 Methods:
 
 with_updated_content(new_content): Returns a new Message with updated content.


### PR DESCRIPTION
## Summary
- clarify that the `metadata` field in `communication_explainer.txt` is optional

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614e2608cc832c9e97eea61635103f