### PR TITLE
Clarify future work references

### DIFF
--- a/docs/Explanation of Agent Forge Process Charts.txt
+++ b/docs/Explanation of Agent Forge Process Charts.txt
@@ -1,5 +1,7 @@
 # Explanation of Agent Forge Process Charts
 
+These diagrams describe the long‑term vision for Agent Forge. Features such as Quiet‑STaR and the ADAS process are conceptual only and are **not implemented** in the current repository.
+
 ## 1. Corrected Training Loop
 
 This chart illustrates the training process for an individual model within the Agent Forge system.
@@ -49,7 +51,7 @@ Prompt baking is a crucial step in the Agent Forge process, allowing the model t
 
 ## 4. ADAS Process
 
-The Automatic Discovery of Agentic Space (ADAS) process is shown in this chart. It's a method for optimizing the model's architecture and capabilities.
+The Automatic Discovery of Agentic Space (ADAS) process is shown in this chart. This step is conceptual and not implemented in the current codebase. It's a method proposed for optimizing the model's architecture and capabilities.
 
 Key steps:
 1. Start with an integrated model
@@ -68,13 +70,13 @@ This chart provides an overview of the entire Agent Forge process, showing how a
 Key stages:
 1. Select specialized models
 2. Apply the Evolution and Merge Pipeline
-3. Apply Quiet-STaR
+3. Apply Quiet-STaR *(planned feature, not implemented)*
 4. Perform 1.58-bit Quantization
 5. Conduct Training
 6. Engage in Prompt Engineering and Baking
 7. Apply Hyper-compression
 8. Integrate Tools and Memory
-9. Undergo the ADAS Process
+9. Undergo the ADAS Process *(future work)*
 10. Deploy the Final Agent
 
 This chart illustrates the full journey from initial specialized models to a fully optimized, deployment-ready AI agent. It shows how each step builds upon the previous ones, creating a sophisticated agent through a series of refinement and optimization processes.

--- a/docs/agent_forge_pipeline_overview.md
+++ b/docs/agent_forge_pipeline_overview.md
@@ -6,7 +6,7 @@ This document summarizes the full Agent Forge pipeline used to create self-impro
 
 ## Phase 1 – Model Foundation & Merging
 1. **Evolution and Merge Pipeline** – Start with three specialized base models. Use multiple merge techniques (linear, SLERP, TIES, DARE, Frankenmerge, DFS) to create an initial population of merged models. Evaluate, select top performers, mutate and recombine over many generations until the best foundation model is obtained.
-2. **Quiet‑STaR Integration** – Modify the architecture to generate parallel "thought" tokens. Introduce learnable `<|startofthought|>` and `<|endofthought|>` tokens for internal monologue generation.
+2. **Quiet‑STaR Integration** – Modify the architecture to generate parallel "thought" tokens. Introduce learnable `<|startofthought|>` and `<|endofthought|>` tokens for internal monologue generation. *(future work, not implemented)*
 3. **Initial Compression** – Apply 1.58‑bit quantization and convert the model to the BitNet format to reduce size before heavy training.
     - SeedLM pseudo-random block encoding and VPTQ quantization provide additional reduction before deployment.
 
@@ -16,15 +16,15 @@ This document summarizes the full Agent Forge pipeline used to create self-impro
 3. **Self‑Modeling** – Every few cycles, the model trains on its own generated texts across a range of temperatures to refine reasoning patterns and creativity.
 
 ## Phase 3 – Self‑Modeling & Expert Vectors
-1. **Quiet‑STaR Self‑Reflection** – Periodically run deeper self‑modeling where the model analyses its thoughts, identifies errors and generates improved reasoning.
-2. **Expert Vector Creation** – Successful reasoning patterns are converted into specialized expert vectors using Singular Value Fine‑tuning (SVF). A dispatch system selects appropriate vectors depending on task type and confidence.
+1. **Quiet‑STaR Self‑Reflection** – Periodically run deeper self‑modeling where the model analyses its thoughts, identifies errors and generates improved reasoning. *(future work)*
+2. **Expert Vector Creation** – Successful reasoning patterns are converted into specialized expert vectors using Singular Value Fine‑tuning (SVF). A dispatch system selects appropriate vectors depending on task type and confidence. *(future work)*
 
 ## Phase 4 – Advanced Integration
 1. **Prompt Baking** – Incorporate new knowledge and reasoning strategies directly into model weights via an iterative prompt testing and baking process.
 2. **Tool & Memory Integration** – Connect the model to external tools and the shared RAG system, enabling persistent knowledge storage and retrieval.
-3. **ADAS Optimization** – A meta‑model repeatedly tests, grades and adjusts the agent’s architecture until further improvements plateau.
-4. After training completes the code automatically runs `ADASystem.optimize_agent_architecture` to produce the final optimized model saved in `adas_optimized_model`.
-5. To try ADAS yourself, instantiate `ADASystem` with the path to a trained model and call `optimize_agent_architecture(output_dir)`. The method performs a few lightweight hyperparameter perturbations and writes the best configuration to `adas_config.json` inside the output folder.
+3. **ADAS Optimization** – A meta‑model repeatedly tests, grades and adjusts the agent’s architecture until further improvements plateau. *(future work)*
+4. After training completes the code would run `ADASystem.optimize_agent_architecture` to produce the final optimized model saved in `adas_optimized_model`. This behaviour is currently unimplemented.
+5. To try ADAS yourself, instantiate `ADASystem` with the path to a trained model and call `optimize_agent_architecture(output_dir)`. The method description is conceptual only and not executed in the repository.
 
 ## Phase 5 – Deployment
 1. **Compression & Packaging** – Apply final compression passes for efficient deployment.

--- a/docs/comprehensive-agent-forge-process.mermaid
+++ b/docs/comprehensive-agent-forge-process.mermaid
@@ -1,3 +1,4 @@
+%% NOTE: Quiet-STaR and ADAS steps in this diagram are conceptual only and not implemented.
 graph TD
     A[Start: Select Specialized Models] --> B[Evolution and Merge Pipeline]
     B --> C[Apply Quiet-STaR]

--- a/docs/geometry_aware_training.md
+++ b/docs/geometry_aware_training.md
@@ -1,6 +1,6 @@
 # Geometry-Aware Training Modules
 
-This document summarises the additional components used to implement the self-adaptive "geometry-aware" training pipeline. They correspond to the roadmap provided in `external_modules_roadmap.md` and are referenced by various modules in `agent_forge/training/` and `agent_forge/geometry/`.
+This document summarises the additional components proposed for the self-adaptive "geometry-aware" training pipeline. Most of these modules are experimental stubs only. Features such as expert vectors and advanced sleep/dream cycles are **not implemented** in the current repository.
 
 ## Key External Projects
 
@@ -17,7 +17,7 @@ This document summarises the additional components used to implement the self-ad
 
 ## Integration Points
 
-1. **Expert Vectors**: `training/expert_vectors.py` trains and applies SVF-based expert vectors. Use `ExpertVectorSystem.train_expert_vector_from_texts` to build vectors from raw text or curriculum tasks. `PromptBakingManager` automatically applies any loaded vectors when baking prompts or loading a model.
+1. **Expert Vectors**: `training/expert_vectors.py` is a placeholder for SVF-based expert vectors. Use `ExpertVectorSystem.train_expert_vector_from_texts` to build vectors from raw text or curriculum tasks once this feature is implemented. `PromptBakingManager` currently does not load real vectors.
 2. **Intrinsic Dimension Monitoring**: `geometry/snapshot.py` wraps the Two‑NN estimator and token entropy probes for a complete geometry snapshot each mini‑batch.
 3. **Grokfast Optimizer**: `training/grokfast_opt.py` exposes an AugmentedAdam wrapper with a `slow_power()` probe used whenever `pre_grok` is `True`.
 4. **Edge-of-Chaos PID**: `training/pid_edgechaos.py` adjusts the learning rate based on complexity metrics to keep the network near λ ≈ 0.5.

--- a/docs/groks_in_the_shadows.md
+++ b/docs/groks_in_the_shadows.md
@@ -4,6 +4,7 @@
 emergence of grok-like behaviour in language models. It combines the
 **Quiet‑STaR** thought layer and the **Grokfast** optimizer to monitor hidden
 states and gradient dynamics long before the validation loss visibly improves.
+These components are experimental only, and Quiet‑STaR is not yet integrated into the main training loop.
 
 The technique operates in two phases:
 


### PR DESCRIPTION
## Summary
- annotate Quiet-STaR, expert vector and ADAS references in pipeline overview
- note that geometry-aware modules and Quiet-STaR are experimental
- mark diagrams and process charts as conceptual only

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686195c15dd8832ca8f442572cbb7322