### PR TITLE
Fix CI caching and add dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
           python-version: '3.11'
       - name: Install Poetry
         run: pip install poetry
+      - name: Cache Poetry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-
       - name: Install dependencies
         run: |
           poetry install --no-interaction --no-root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,11 @@ description = "Self-improving multi-agent system"
 requires-python = ">=3.10"
 readme = "README.md"
 license = {file = "LICENSE"}
+
+[tool.poetry.dependencies]
+requests = "^2.32"
+hypothesis = { version = "^6.101", optional = true }
+scikit-learn = { version = "^1.5", markers = "platform_machine != 'arm64'" }
+
+[tool.poetry.extras]
+dev = ["hypothesis", "scikit-learn"]


### PR DESCRIPTION
## Summary
- pin `requests` and add extras in `pyproject.toml`
- cache Poetry in CI workflow

## Testing
- `poetry lock --no-update` *(fails: option does not exist)*
- `poetry export -f requirements.txt --without-hashes -o requirements.txt` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686328e97e38832ca3f6afaa94f73ee5