### PR TITLE
Add ChatEngine in Twin endpoint

### DIFF
--- a/calibration/conformal.py
+++ b/calibration/conformal.py
@@ -1,0 +1,24 @@
+"""Simple conformal calibrator placeholder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def _clip(p: float) -> float:
+    return max(0.0, min(1.0, p))
+
+
+@dataclass
+class ConformalCalibrator:
+    scale: float = 0.8
+    bias: float = 0.1
+
+    def calibrate(self, prob: float) -> float:
+        """Apply affine calibration with clipping."""
+        return _clip(self.scale * prob + self.bias)
+
+    @classmethod
+    def load_default(cls) -> "ConformalCalibrator":
+        """Load default model (placeholder)."""
+        return cls()

--- a/core/chat_engine.py
+++ b/core/chat_engine.py
@@ -1,0 +1,86 @@
+# PURPOSE: Central chat engine that wraps Twin inference and applies optional
+#          conformal calibration to the model's raw confidence score.
+#
+# IMPLEMENTATION NOTES
+# • Feature-flag via env var CALIBRATION_ENABLED=1
+# • Falls back gracefully if calibrator fails >3× in a row
+# • Twin client discovered via TWIN_URL (HTTP JSON API)
+# • Exposes ChatEngine.process_chat(message, conversation_id)
+#   ↳ returns dict {"response": str,
+#                   "conversation_id": str,
+#                   "raw_prob": float,
+#                   "calibrated_prob": float|None,
+#                   "timestamp": datetime}
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+TWIN_URL = os.getenv("TWIN_URL", "http://twin:8001/v1/chat")
+CALIB_ENABLED = os.getenv("CALIBRATION_ENABLED", "0") == "1"
+
+if CALIB_ENABLED:
+    try:
+        from calibration.conformal import ConformalCalibrator
+
+        _calibrator = ConformalCalibrator.load_default()
+        logger.info("Calibration enabled (loaded default model)")
+    except Exception:  # pragma: no cover - fallback is tested separately
+        logger.exception("Failed to init calibrator – continuing without")
+        CALIB_ENABLED = False
+        _calibrator = None
+else:  # pragma: no cover - branch for disabled feature
+    _calibrator = None
+
+
+class ChatEngine:
+    """Thin wrapper around the Twin micro-service plus optional calibration."""
+
+    def __init__(self) -> None:
+        self._calib_enabled = CALIB_ENABLED
+        self._consecutive_calib_errors = 0
+
+    # ------------------------------------------------------------------
+    def process_chat(self, message: str, conversation_id: str) -> Dict[str, Any]:
+        started = time.time()
+        twin_payload = {"prompt": message, "conversation_id": conversation_id}
+        try:
+            twin_resp = requests.post(TWIN_URL, json=twin_payload, timeout=15)
+            twin_resp.raise_for_status()
+        except Exception as exc:  # pragma: no cover - network failure
+            logger.exception("Twin request failed")
+            raise exc
+
+        data = twin_resp.json()
+        resp_text: str = data.get("response", "")
+        raw_prob: float = float(data.get("raw_prob", 0.5))
+        calibrated: Optional[float] = data.get("calibrated_prob")
+
+        if calibrated is None and self._calib_enabled:
+            try:
+                calibrated = _calibrator.calibrate(raw_prob)  # type: ignore[attr-defined]
+                self._consecutive_calib_errors = 0
+            except Exception as exc:  # pragma: no cover - rarely triggered
+                logger.warning("Calibration error: %s", exc)
+                self._consecutive_calib_errors += 1
+                if self._consecutive_calib_errors >= 3:
+                    logger.error("Disabling calibration after 3 failures")
+                    self._calib_enabled = False
+
+        return {
+            "response": resp_text,
+            "conversation_id": conversation_id,
+            "raw_prob": raw_prob,
+            "calibrated_prob": calibrated,
+            "timestamp": datetime.utcnow().isoformat(),
+            "processing_time_ms": int((time.time() - started) * 1000),
+        }

--- a/services/twin/schemas.py
+++ b/services/twin/schemas.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class ChatRequest(BaseModel):
+    message: str = Field(..., min_length=1, max_length=10_000)
+    user_id: str = Field(..., description="Unique user identifier")
+    conversation_id: Optional[str] = None
+    context: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ChatResponse(BaseModel):
+    response: str
+    conversation_id: str
+    timestamp: datetime
+    processing_time_ms: float
+    calibrated_prob: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Conformally calibrated confidence (0-1) when CALIBRATION_ENABLED=1",
+    )
+
+    model_config = ConfigDict(ser_json_exclude_none=True)
+
+
+class HealthResponse(BaseModel):
+    status: str
+    version: str
+    model_loaded: bool
+    timestamp: datetime

--- a/tests/core/test_chat_engine.py
+++ b/tests/core/test_chat_engine.py
@@ -1,0 +1,43 @@
+from core.chat_engine import ChatEngine
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_process_chat(monkeypatch):
+    ce = ChatEngine()
+
+    called = {}
+
+    def fake_post(url, json, timeout):
+        called["payload"] = json
+        return DummyResp({"response": "ok", "raw_prob": 0.6})
+
+    monkeypatch.setattr("requests.post", fake_post)
+    out = ce.process_chat("hi", "cid")
+    assert out["response"] == "ok"
+    assert out["conversation_id"] == "cid"
+    assert out["raw_prob"] == 0.6
+    assert "timestamp" in out
+    assert called["payload"]["prompt"] == "hi"
+
+
+def test_process_chat_prefers_server_calib(monkeypatch):
+    monkeypatch.setenv("CALIBRATION_ENABLED", "1")
+    ce = ChatEngine()
+
+    def fake_post(url, json, timeout):
+        return DummyResp({"response": "hi", "raw_prob": 0.4, "calibrated_prob": 0.8})
+
+    monkeypatch.setattr("requests.post", fake_post)
+    out = ce.process_chat("hello", "x")
+    assert out["calibrated_prob"] == 0.8

--- a/tests/test_twin_calibration.py
+++ b/tests/test_twin_calibration.py
@@ -1,0 +1,17 @@
+import importlib
+import asyncio
+
+
+from services.twin.schemas import ChatRequest
+
+
+def test_calibrated_prob_feature(monkeypatch):
+    monkeypatch.setenv("CALIBRATION_ENABLED", "1")
+    if "services.twin.app" in importlib.sys.modules:
+        del importlib.sys.modules["services.twin.app"]
+    mod = importlib.import_module("services.twin.app")
+    agent = mod.TwinAgent(mod.settings.model_path)
+    req = ChatRequest(message="hello", user_id="u1")
+    out = asyncio.run(agent.chat(req))
+    assert out.calibrated_prob is not None
+    assert 0.0 <= out.calibrated_prob <= 1.0


### PR DESCRIPTION
## Summary
- update ChatEngine to call `/v1/chat`
- use ChatEngine inside Twin service chat endpoint

## Testing
- `ruff check services/twin/app.py services/twin/schemas.py core/chat_engine.py tests/core/test_chat_engine.py tests/test_twin_calibration.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_calibration_module.py tests/core/test_chat_engine.py tests/test_twin_calibration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68712b664d90832c8697cfbbd6d8a9d1