### PR TITLE
Harden ADAS technique execution

### DIFF
--- a/docs/agent_forge_security.md
+++ b/docs/agent_forge_security.md
@@ -1,0 +1,23 @@
+# Agent Forge Security Model
+
+This document outlines the basic security precautions used when executing
+user supplied code in the ADAS subsystem.
+
+## ADAS technique execution
+
+`AgentTechnique.handle` runs small code snippets provided by the user. To
+reduce the impact of malicious code the following measures are taken:
+
+- Only a minimal set of builtin functions are exposed: `__import__`, `open`,
+  `len`, `range`, `min`, `max`, `str` and `float`.
+- The code is parsed with the Python `ast` module and any import statement is
+  checked against a small allow list (currently only `os`). Calls to dangerous
+  functions such as `exec`, `eval` or `compile` are rejected.
+- The code is compiled before execution so that syntax errors are caught
+  safely.
+- Each run happens inside a fresh temporary directory to avoid unwanted
+  file system interactions.
+
+These checks are intentionally simple and should not be considered a
+complete sandbox. They merely reduce the attack surface for running
+untrusted techniques.


### PR DESCRIPTION
## Summary
- restrict builtins available when executing ADAS techniques
- validate technique code with AST parser before execution
- document the security model for ADAS

## Testing
- `poetry run pytest -q`
- `poetry run pytest tests/test_adas_technique.py::TestAgentTechniqueHandle::test_handle_executes_code -q`


------
https://chatgpt.com/codex/tasks/task_e_68715314d784832c9d30640d8c21f59b