### PR TITLE
Switch VectorStore persistence to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ The agent system has recently undergone significant updates to improve modularit
 4. Removal of the `langroid` folder, with its functionality now integrated into the main agent structure.
 5. Updates to the `orchestration.py` file to use the new agent classes and self-evolving system.
 6. Addition of a mesh-sharding subsystem in `communications/` providing peer-to-peer networking, federated learning, credit management, and sharding utilities.
+7. `VectorStore` persistence now uses JSON instead of pickle. Convert existing `.pkl` stores or regenerate them.
+
+For details see [docs/migration_notes.md](docs/migration_notes.md).
 
 These changes have made the code more modular and easier to maintain. The self-evolving system remains a stub used for demos and tests, so additional work is required before it can manage real agent evolution.
 
@@ -467,6 +470,9 @@ The agent system has recently undergone significant updates to improve modularit
 
 6. Enhancement of the IncentiveModel with improved functionality for calculating incentives, updating based on task results, and adapting to changing agent performance.
 7. Improved integration of incentive-based management in the UnifiedTaskManager for more effective task allocation and agent motivation.
+8. `VectorStore` persistence now uses JSON instead of pickle. Convert existing `.pkl` stores or regenerate them.
+
+For details see [docs/migration_notes.md](docs/migration_notes.md).
 
 These changes have further improved the system's ability to adapt and optimize its performance over time.
 

--- a/docs/migration_notes.md
+++ b/docs/migration_notes.md
@@ -1,0 +1,7 @@
+# Migration Notes
+
+## Vector Store Format Change
+
+The persisted `VectorStore` now uses a JSON file (`vector_store.json`) instead of the previous pickle format (`vector_store.pkl`).
+
+Existing pickled stores must be converted or regenerated before use with the updated code.

--- a/rag_system/faiss_backend.py
+++ b/rag_system/faiss_backend.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Iterable, List, Tuple
 from rag_system.retrieval.vector_store import VectorStore as PickledStore
 from rag_system.core.config import UnifiedConfig
 
-DEFAULT_STORE_PATH = os.getenv("VECTOR_STORE_PATH", "vector_store.pkl")
+DEFAULT_STORE_PATH = os.getenv("VECTOR_STORE_PATH", "vector_store.json")
 DEFAULT_DIM = 768
 
 

--- a/scripts/migrate_to_qdrant.py
+++ b/scripts/migrate_to_qdrant.py
@@ -1,8 +1,8 @@
 """Migrate existing FAISS vectors into a Qdrant collection.
 
 Run ``python scripts/migrate_to_qdrant.py`` with optional ``--dry-run``
-and ``--delete-existing`` flags.  The script expects a pickled
-``VectorStore`` (``vector_store.pkl`` by default) and will upsert the
+and ``--delete-existing`` flags.  The script expects a serialized
+``VectorStore`` (``vector_store.json`` by default) and will upsert the
 stored embeddings into the Qdrant collection defined by the environment
 variables ``QDRANT_URL`` and ``COLLECTION_NAME``.
 

--- a/tests/test_vector_store_persistence.py
+++ b/tests/test_vector_store_persistence.py
@@ -1,0 +1,67 @@
+import importlib.util
+import unittest
+import json
+import tempfile
+import sys
+from pathlib import Path
+from datetime import datetime
+import types
+
+if importlib.util.find_spec("numpy") is None:
+    raise unittest.SkipTest("Required dependency not installed")
+
+import numpy as np
+
+# Provide a lightweight faiss stub with serialization support
+fake_faiss = types.ModuleType("faiss")
+
+class DummyIndex:
+    def __init__(self):
+        self.vectors = []
+
+    def add(self, vecs):
+        self.vectors.extend(vecs.tolist())
+
+    def search(self, x, k):
+        return np.zeros((1, k), dtype="float32"), np.zeros((1, k), dtype=int)
+
+    def remove_ids(self, x):
+        pass
+
+fake_faiss.IndexFlatL2 = lambda dim: DummyIndex()
+fake_faiss.serialize_index = lambda idx: json.dumps(idx.vectors).encode()
+
+def _deserialize(data: bytes):
+    idx = DummyIndex()
+    idx.vectors = json.loads(data.decode())
+    return idx
+
+fake_faiss.deserialize_index = _deserialize
+sys.modules["faiss"] = fake_faiss
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from rag_system.retrieval.vector_store import VectorStore
+
+
+class TestVectorStorePersistence(unittest.TestCase):
+    def test_save_and_load(self):
+        store = VectorStore(dimension=2)
+        doc = {
+            "id": "1",
+            "content": "a",
+            "embedding": np.zeros(2, dtype="float32"),
+            "timestamp": datetime.now(),
+        }
+        store.add_documents([doc])
+
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "store.json"
+            store.save(str(path))
+            loaded = VectorStore.load(str(path), store.config)
+            self.assertEqual(loaded.get_size(), 1)
+            self.assertEqual(loaded.dimension, store.dimension)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- store and load vector store data using JSON instead of pickle
- update faiss adapter path and migration script docs
- add migration notes
- mention JSON format in README
- test new persistence logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687153190f40832cb22530734fbfcdd7