### PR TITLE
Document HTTP use and gRPC plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Refer to [docs/feature_matrix.md](docs/feature_matrix.md) for a status overview 
 | ADAS Optimisation | ✅ |
 | ConfidenceEstimator | ✅ |
 <!--feature-matrix-end-->
-The [messaging protocol decision](docs/adr/0002-messaging-protocol.md) is documented in **ADR-0002**.
+The [messaging protocol decision](docs/adr/0002-messaging-protocol.md) is documented in **ADR-0002**.  gRPC/WebSocket support described there is **not yet implemented**; the Gateway and Twin currently communicate over plain HTTP.
 
 ## System Components
 

--- a/docs/adr/0002-messaging-protocol.md
+++ b/docs/adr/0002-messaging-protocol.md
@@ -1,13 +1,14 @@
 # ADR-0002  Messaging Protocol Choice
 
-**Status**: Proposed  
+**Status**: Proposed
+_Implementation Pending_
 **Date**: 2025-07-01
 
 ## Context
 Edge devices may sit behind strict firewalls.  Pure gRPC (HTTP/2) offers type-safety & bi-directional streams but fails on some corporate proxies; WebSocket (HTTP/1.1 upgrade) is widely allowed but lacks strong proto contracts.
 
 ## Decision (draft)
-Adopt **gRPC primary** with automatic **WebSocket fallback** using JSON-encoded protobuf messages.  Connection manager negotiates highest-capability transport then hands channel to agents.
+Adopt **gRPC primary** with automatic **WebSocket fallback** using JSON-encoded protobuf messages.  Connection manager negotiates highest-capability transport then hands channel to agents. **As of July 2025 the microservices still communicate over plain HTTP; gRPC/WebSocket support remains planned.**
 
 ## Consequences
 * Slightly heavier client lib (~100 KB for fallback shim).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,7 @@
 
 The repository started as a monolithic Python project. It now includes two
 microservices – a Gateway and the Twin runtime – which communicate over HTTP.
+gRPC/WebSocket support proposed in ADR-0002 is not yet implemented.
 Most other modules remain in-process libraries. Quiet-STaR and expert vectors
 remain stubs, while a basic ADAS prototype is available.
 

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -7,9 +7,9 @@
 | Self-Evolving System | Placeholder | `SelfEvolvingSystem` stub; not integrated across agents |
 | Twin Runtime | ✅ v0.2.0 | Extracted microservice in `services/twin` |
 | Twin Extraction | Prototype | Endpoints at `/v1/chat` & `/v1/user/{id}`; LRU eviction documented in ADR-0001 |
-| Gateway service | ✅ v0.2.0 | Prometheus metrics and rate limiting |
+| Gateway service | ✅ v0.2.0 | Prometheus metrics and rate limiting; HTTP only |
 | Mesh Networking / Federated Learning | Placeholder | skeleton modules in `communications/`, not fully functional |
 | Expert Vectors training | Planned | documented in `docs/geometry_aware_training.md` but unimplemented |
 | ADAS optimization | Prototype | basic optimizer in `agent_forge/adas` |
 | Quiet-STaR module | Planned | not implemented; tests marked xfail |
-| ADR-0002: Messaging Protocol | Proposed | gRPC with WebSocket fallback |
+| ADR-0002: Messaging Protocol | Proposed | gRPC with WebSocket fallback (not yet implemented) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,5 +13,6 @@ This short roadmap clarifies the current state of the project and highlights pla
 - Self-evolving agent system with expert vectors
 - Full evolutionary training pipeline (see `complete_agent_forge_pipeline.md`)
 - ADAS optimisation and advanced compression
+- gRPC/WebSocket support for inter-service communication
 
 The roadmap will be updated as milestones are completed.

--- a/docs/system_overview.md
+++ b/docs/system_overview.md
@@ -24,7 +24,7 @@ artifacts.
 - **Web Framework**: FastAPI powers the server (`server.py`).
 - **ML Libraries**: PyTorch, Transformers, FAISS, Langroid.
 
-The repository now includes two microservices &ndash; a Gateway and the Twin runtime &ndash; which communicate over HTTP. All other modules remain in-process libraries. Agents share a common `UnifiedBaseAgent` class and interact with the RAG pipeline through well defined interfaces.
+The repository now includes two microservices &ndash; a Gateway and the Twin runtime &ndash; which communicate over HTTP. All other modules remain in-process libraries. gRPC/WebSocket support is planned but has not been implemented. Agents share a common `UnifiedBaseAgent` class and interact with the RAG pipeline through well defined interfaces.
 
 Many advanced features referenced in the repository (such as the SAGE framework and expert vectors) are still conceptual. The running code now includes a working ADAS optimizer in addition to the base RAG pipeline and prompt-baking utilities.
 

--- a/docs/twin/README.md
+++ b/docs/twin/README.md
@@ -1,3 +1,3 @@
 # Twin Runtime
 
-Utilities for loading and fine-tuning small models for mobile demos. Advanced compression is a work in progress.
+Utilities for loading and fine-tuning small models for mobile demos. Advanced compression is a work in progress. The Twin currently talks to the Gateway over plain HTTP; gRPC/WebSocket transport is planned.


### PR DESCRIPTION
## Summary
- document that gRPC transport is not yet implemented
- clarify HTTP communication for Gateway/Twin docs
- note future gRPC/WebSocket support in roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871531afd38832cb193859f881d6252