### PR TITLE
Reduce test stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,11 @@ own model when constructing `VectorStore`.
 
 ## Testing
 
-Before running the tests ensure that **all** dependencies are installed. The
-main `requirements.txt` file includes heavy packages such as `torch`,
-`faiss-cpu` and `numpy` that are required by the tests. Run the setup
-script to install everything you need:
+The test suite uses lightweight stubs so that `pytest` can discover the tests
+even when heavy optional dependencies like PyTorch are missing.  To actually
+execute the ML focused tests install the full requirements first.  The helper
+script below installs both runtime and development dependencies including
+`torch`, `faiss-cpu` and `scikit-learn`:
 
 ```bash
 bash scripts/setup_env.sh
@@ -140,6 +141,12 @@ bash scripts/setup_env.sh
 
 The script installs both runtime and development requirements,
 including `PyYAML` which is required by the test configuration.
+If you prefer to manage the heavy ML libraries yourself, simply install the
+test extras with:
+
+```bash
+pip install -r tests/requirements.txt
+```
 
 After installing these dependencies you can execute the full test suite:
 
@@ -148,8 +155,8 @@ pytest
 ```
 
 Some unit tests automatically skip themselves if optional packages such
-as PyTorch are missing. Installing the full requirements is recommended
-for complete coverage.
+as PyTorch are missing. When these packages are available they will be used
+instead of the lightweight stubs, providing complete coverage.
 
 
 
@@ -522,10 +529,14 @@ The RAG system consists of the following main components:
 
 ## Running Tests
 
-To run the unit tests and integration tests:
+To run the unit tests and integration tests (with real ML libraries installed):
 
 ```bash
 pytest -vv
+```
+Install the additional testing dependencies with:
+```bash
+pip install -r tests/requirements.txt
 ```
 
 ## Configuration

--- a/conftest.py
+++ b/conftest.py
@@ -6,9 +6,6 @@ import pytest
 
 _STUBBED_MODULES = set()
 
-# Provide lightweight stubs for heavy optional dependencies so test collection
-# succeeds even if they are not installed in the environment.
-
 
 def _ensure_module(name: str, attrs: dict | None = None):
     spec = importlib.util.find_spec(name)
@@ -26,69 +23,14 @@ def _ensure_module(name: str, attrs: dict | None = None):
     return sys.modules.get(name)
 
 
-class _DummyArray(list):
-    def mean(self, *args, **kwargs):
-        return self
+# Minimal stubs for heavy optional dependencies
+_ensure_module("faiss", {"IndexFlatL2": lambda *a, **k: object()})
 
-    def detach(self, *args, **kwargs):
-        return self
-
-    def cpu(self, *args, **kwargs):
-        return self
-
-    def numpy(self, *args, **kwargs):
-        return self
-
-    def astype(self, *_a, **_k):
-        return self
-
-
-# Stub faiss if missing
-_ensure_module("faiss", {"IndexFlatL2": lambda *args, **kwargs: object()})
-_ensure_module(
-    "numpy",
-    {
-        "zeros": lambda *args, **kwargs: [0] * (args[0] if args else 0),
-        "ndarray": list,
-        "array": lambda *a, **k: _DummyArray(),
-        "asarray": lambda arr, dtype=None: _DummyArray(arr),
-        "array_equal": lambda a, b: list(a) == list(b),
-        "random": types.SimpleNamespace(
-            default_rng=lambda *a, **k: types.SimpleNamespace(
-                random=lambda size=None: _DummyArray([0.0] * (size if size else 1))
-            )
-        ),
-    },
-)
-_ensure_module("httpx")
-_ensure_module(
-    "requests",
-    {
-        "get": lambda *a, **k: types.SimpleNamespace(status_code=200, ok=True),
-        "post": lambda *a, **k: types.SimpleNamespace(ok=True, json=lambda: {}),
-        "delete": lambda *a, **k: types.SimpleNamespace(
-            ok=True, json=lambda: {"deleted_conversations": 1}
-        ),
-        "RequestException": Exception,
-    },
-)
-_ensure_module("yaml", {"safe_load": lambda *a, **k: {}})
-_ensure_module(
-    "hypothesis",
-    {"given": lambda *a, **k: (lambda f: f)},
-)
-hyp_strategies = types.ModuleType("hypothesis.strategies")
-hyp_strategies.text = lambda *a, **k: ""
-sys.modules.setdefault("hypothesis.strategies", hyp_strategies)
-tmod = sys.modules.get("hypothesis")
-if tmod:
-    tmod.strategies = hyp_strategies
 torch_mod = _ensure_module(
     "torch",
     {
         "Tensor": object,
         "randn": lambda *a, **k: 0,
-        "__getattr__": lambda name: object,
     },
 )
 if torch_mod is not None:
@@ -96,135 +38,14 @@ if torch_mod is not None:
     torch_mod.__path__ = []
     nn_mod = types.ModuleType("torch.nn")
     nn_mod.Module = object
-    nn_mod.functional = types.ModuleType("torch.nn.functional")
-    optim_mod = types.ModuleType("torch.optim")
     torch_mod.nn = nn_mod
-    torch_mod.optim = optim_mod
-    torch_mod.nn.functional = nn_mod.functional
     sys.modules.setdefault("torch.nn", nn_mod)
-    sys.modules.setdefault("torch.nn.functional", nn_mod.functional)
-    sys.modules.setdefault("torch.optim", optim_mod)
-_ensure_module(
-    "transformers",
-    {
-        "BertTokenizer": object,
-        "BertModel": object,
-        "BertForSequenceClassification": object,
-        "BertForQuestionAnswering": object,
-    },
-)
-_ensure_module("bs4", {"BeautifulSoup": object})
-_ensure_module("python_multipart", {"__version__": "99.0.0"})
-_ensure_module("multipart")
+
 _ensure_module("sklearn")
 _ensure_module("sklearn.feature_extraction")
-
-
-class _DummyTfidfVectorizer:
-    def fit(self, docs):
-        self.vocab = sorted({w.lower() for d in docs for w in str(d).split()})
-        return self
-
-    def transform(self, docs):
-        vecs = []
-        for d in docs:
-            tokens = d.lower().split()
-            vecs.append([tokens.count(v) for v in self.vocab])
-        return vecs
-
-
-_ensure_module(
-    "sklearn.feature_extraction.text", {"TfidfVectorizer": _DummyTfidfVectorizer}
-)
+_ensure_module("sklearn.feature_extraction.text", {"TfidfVectorizer": object})
 _ensure_module("sklearn.metrics")
-_ensure_module("sklearn.linear_model", {"LogisticRegression": object})
-
-
-class _DummyCosineResult(list):
-    def __getitem__(self, item):
-        if isinstance(item, tuple):
-            return super().__getitem__(item[0])[item[1]]
-        return super().__getitem__(item)
-
-    class _Diag(list):
-        def mean(self):
-            return sum(self) / len(self) if self else 0.0
-
-    def diagonal(self):
-        return self._Diag([self[i][i] for i in range(min(len(self), len(self[0])))])
-
-
-def _dummy_cosine_similarity(a, b):
-    import math
-
-    def dot(u, v):
-        return sum(x * y for x, y in zip(u, v))
-
-    def norm(u):
-        return math.sqrt(sum(x * x for x in u))
-
-    res = []
-    for row in a:
-        row_res = []
-        for col in b:
-            denom = norm(row) * norm(col)
-            row_res.append(dot(row, col) / denom if denom else 0.0)
-        res.append(row_res)
-    return _DummyCosineResult(res)
-
-
-_ensure_module(
-    "sklearn.metrics.pairwise", {"cosine_similarity": _dummy_cosine_similarity}
-)
-_ensure_module("psutil")
-_ensure_module("networkx", {"Graph": object})
-parent = _ensure_module(
-    "langroid",
-    {
-        "ChatAgent": object,
-        "ChatAgentConfig": object,
-        "Task": object,
-    },
-)
-if parent is not None:
-    parent.__spec__.submodule_search_locations = []
-    parent.__path__ = []
-_ensure_module("langroid.agent")
-mod_agent = _ensure_module("langroid.agent")
-if mod_agent is not None:
-    mod_agent.__spec__.submodule_search_locations = []
-    mod_agent.__path__ = []
-_ensure_module("langroid.agent.tool_message", {"ToolMessage": object})
-_ensure_module("langroid.language_models")
-mod_lm = _ensure_module("langroid.language_models")
-if mod_lm is not None:
-    mod_lm.__spec__.submodule_search_locations = []
-    mod_lm.__path__ = []
-_ensure_module("langroid.language_models.openai_gpt", {"OpenAIGPTConfig": object})
-tok = _ensure_module("tiktoken")
-if tok is not None:
-    tok.__spec__.submodule_search_locations = []
-    tok.__path__ = []
-    tok.Encoding = object
-_ensure_module("tiktoken.load", {"load_tiktoken_bpe": lambda p: {}})
-
-# Provide simple stubs for optional dependencies used in tests.  These
-# allow the test suite to be imported even when the real packages are not
-# installed.  The actual tests that rely on them will be skipped if the
-# dependencies are missing.
-_ensure_module(
-    "numpy",
-    {
-        "__version__": "0.0",
-        "array": lambda *a, **k: [],
-        "zeros": lambda *a, **k: [],
-        "ndarray": list,
-    },
-)
-_ensure_module("httpx")
-
-# Ensure `importlib.util.find_spec` reports these stubs as missing so tests
-# can detect optional dependencies correctly.
+_ensure_module("sklearn.metrics.pairwise", {"cosine_similarity": lambda a, b: []})
 
 _real_find_spec = importlib.util.find_spec
 
@@ -235,23 +56,25 @@ def _patched_find_spec(name, *args, **kwargs):
         return None
     if name in _STUBBED_MODULES:
         return None
-    if name.startswith("torch") or name.startswith("sklearn"):
-        return None
     return _real_find_spec(name, *args, **kwargs)
 
 
 importlib.util.find_spec = _patched_find_spec
 
 
-def pytest_collection_modifyitems(config, items):
-    """Skip tests requiring heavy ML dependencies if they aren't available."""
+def _deps_missing(*deps):
     missing = []
-    for dep in ("torch", "sklearn", "psutil", "numpy", "httpx"):
+    for dep in deps:
         try:
             if importlib.util.find_spec(dep) is None:
                 missing.append(dep)
         except ValueError:
             missing.append(dep)
+    return missing
+
+
+def pytest_collection_modifyitems(config, items):
+    missing = _deps_missing("torch", "sklearn", "faiss")
     if not missing:
         return
     skip_marker = pytest.mark.skip(reason=f"Missing dependencies: {', '.join(missing)}")
@@ -280,28 +103,12 @@ def pytest_ignore_collect(path, config):
     }
     pstr = str(path)
     if any(h in pstr for h in heavy_dirs):
-        missing = []
-        for dep in ("torch", "sklearn", "psutil", "numpy", "httpx"):
-            try:
-                if importlib.util.find_spec(dep) is None:
-                    missing.append(dep)
-            except ValueError:
-                missing.append(dep)
-        if missing:
-            print(f"Skipping {pstr} due to missing dependencies: {', '.join(missing)}")
+        if _deps_missing("torch", "sklearn", "faiss"):
+            print(f"Skipping {pstr} due to missing dependencies")
             return True
     for tpath, deps in special_tests.items():
         if pstr.endswith(tpath):
-            missing = []
-            for dep in deps:
-                try:
-                    if importlib.util.find_spec(dep) is None:
-                        missing.append(dep)
-                except ValueError:
-                    missing.append(dep)
-            if missing:
-                print(
-                    f"Skipping {pstr} due to missing dependencies: {', '.join(missing)}"
-                )
+            if _deps_missing(*deps):
+                print(f"Skipping {pstr} due to missing dependencies")
                 return True
     return False


### PR DESCRIPTION
## Summary
- simplify conftest module stubs
- keep only torch/sklearn/faiss for test discovery
- document optional dependency setup in README

## Testing
- `pip install -r tests/requirements.txt`
- `pytest tests/test_stubs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871567eb35c832cb2338df45dbf9552