### PR TITLE
Fix docs links and add roadmap

### DIFF
--- a/cleanup_documentation.py
+++ b/cleanup_documentation.py
@@ -54,8 +54,8 @@ class DocumentationCleanup:
                 'SMOKE_TEST_INTEGRATION.md'
             ],
             'docs/reference/': [
-                'TODO.md', 'roadmap.md', 'feature_matrix.md', 'benchmark_results.md',
-                'DIRECTORY_STRUCTURE.md', 'ENTRY_POINTS.md', 'ENTRY_POINT_MAPPING.md'
+                'TODO_1.md', 'roadmap.md', 'feature_matrix_1.md', 'benchmark_results.md',
+                'DIRECTORY_STRUCTURE_1.md', 'ENTRY_POINTS.md', 'ENTRY_POINT_MAPPING_1.md'
             ],
             'deprecated/old_reports/': [
                 # All report files will go here
@@ -321,10 +321,10 @@ Development workflows, testing, and contribution guidelines.
 
 ### 📋 Reference
 Reference materials, roadmaps, and administrative documentation.
-- [Project Roadmap](reference/roadmap.md)
-- [Feature Matrix](reference/feature_matrix.md)
-- [Directory Structure](reference/DIRECTORY_STRUCTURE.md)
-- [TODO List](reference/TODO.md)
+    - [Project Roadmap](reference/roadmap.md)
+    - [Feature Matrix](reference/feature_matrix_1.md)
+    - [Directory Structure](reference/DIRECTORY_STRUCTURE_1.md)
+    - [TODO List](reference/TODO_1.md)
 
 ## Quick Links
 

--- a/deprecated/old_reports/DOCUMENTATION_REMEDIATION_PLAN_1.md
+++ b/deprecated/old_reports/DOCUMENTATION_REMEDIATION_PLAN_1.md
@@ -14,7 +14,7 @@
   - Justification: Multiple core features are stubs or incomplete
 
 ### 1.3 Update Feature Matrix with Accurate Status
-- [ ] **Fix**: Update docs/feature_matrix.md with real implementation status
+- [ ] **Fix**: Update docs/reference/feature_matrix_1.md with real implementation status
   ```markdown
   | Feature | Status | Notes |
   | ------- | ------ | ----- |

--- a/deprecated/old_reports/DOCUMENTATION_TRANSFORMATION_SUMMARY_1.md
+++ b/deprecated/old_reports/DOCUMENTATION_TRANSFORMATION_SUMMARY_1.md
@@ -56,7 +56,7 @@ AIVillage/
 │   └── reference/                 # Reference materials
 │       ├── README.md
 │       ├── roadmap.md
-│       └── feature_matrix.md
+│       └── feature_matrix_1.md
 └── deprecated/
     └── old_reports/              # Archived historical docs
         └── (All reports and summaries)

--- a/deprecated/old_reports/ROOT_CLEANUP_SUMMARY_1.md
+++ b/deprecated/old_reports/ROOT_CLEANUP_SUMMARY_1.md
@@ -15,16 +15,16 @@ Cleaned up and organized loose files from the root directory to improve codebase
 
 ### Documentation → `docs/`
 - `BRANCHING_STRATEGY.md`
-- `DIRECTORY_STRUCTURE.md`
+- `DIRECTORY_STRUCTURE_1.md`
 - `ENTRY_POINTS.md`
-- `ENTRY_POINT_MAPPING.md`
+- `ENTRY_POINT_MAPPING_1.md`
 - `FIXES_APPLIED.md`
 - `MIGRATION_CHECKLIST.md`
 - `MIGRATION_PLAN.md`
 - `REPOSITORY_ANALYSIS_REPORT.md`
 - `SCOUT_REPORT.md`
 - `STAGE1_COMPRESSION_SUMMARY.md`
-- `TODO.md`
+- `TODO_1.md`
 - `WORKSPACE_HEALTH_REPORT.md`
 - `test_analysis_report.md`
 - `test_health_dashboard.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,9 +37,9 @@ Development workflows, testing, and contribution guidelines.
 ### 📋 Reference
 Reference materials, roadmaps, and administrative documentation.
 - [Project Roadmap](reference/roadmap.md)
-- [Feature Matrix](reference/feature_matrix.md)
-- [Directory Structure](reference/DIRECTORY_STRUCTURE.md)
-- [TODO List](reference/TODO.md)
+- [Feature Matrix](reference/feature_matrix_1.md)
+- [Directory Structure](reference/DIRECTORY_STRUCTURE_1.md)
+- [TODO List](reference/TODO_1.md)
 
 ## Quick Links
 

--- a/docs/architecture/DEPRECATED_DOCS_README_1.md
+++ b/docs/architecture/DEPRECATED_DOCS_README_1.md
@@ -21,8 +21,8 @@ This directory contains documentation files that made premature or misleading su
 For accurate project status, refer to:
 - `README.md` - Current implementation status and realistic percentages
 - `docs/architecture.md` - Actual architecture and component readiness
-- `docs/roadmap.md` - Realistic development roadmap
-- `docs/feature_matrix.md` - Feature completion matrix
+- `docs/reference/roadmap.md` - Realistic development roadmap
+- `docs/reference/feature_matrix_1.md` - Feature completion matrix
 
 ## Archive Date
 Archived: 2025-07-31

--- a/docs/architecture/compression_1.md
+++ b/docs/architecture/compression_1.md
@@ -121,7 +121,7 @@
 ## Documentation Updates
 
 - [ ] Updated `docs/compression_guide.md`
-- [ ] Updated `docs/feature_matrix.md`
+- [ ] Updated `docs/reference/feature_matrix_1.md`
 - [ ] Updated `README.md` if necessary
 - [ ] Added/updated API documentation
 - [ ] Updated benchmark results documentation

--- a/docs/reference/TODO_1.md
+++ b/docs/reference/TODO_1.md
@@ -1,6 +1,6 @@
 # TODO
 
-This repository is under active development. For full details see [docs/roadmap.md](docs/roadmap.md) or the GitHub issue tracker.
+This repository is under active development. For full details see [roadmap](roadmap.md) or the GitHub issue tracker.
 
 ## Prioritized Tasks
 

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -1,0 +1,18 @@
+# Agent Forge Roadmap
+
+This short roadmap clarifies the current state of the project and highlights planned features. The geometry-aware modules described in `geometry_aware_training.md` are now included as experimental components.
+
+## Implemented
+- Retrieval-Augmented Generation (basic pipeline)
+- FastAPI server with simple query endpoint
+- Initial EvoMerge utilities for model merging
+- Geometry-aware training helpers (Two-NN ID estimator, Grokfast optimizer, Edge-of-Chaos PID, SleepNet/DreamNet stubs, BitNet quantization)
+
+## In Progress / Planned
+- Quiet-STaR thought generation
+- Self-evolving agent system with expert vectors
+- Full evolutionary training pipeline (see `complete_agent_forge_pipeline.md`)
+- ADAS optimisation and advanced compression
+- gRPC/WebSocket support for inter-service communication
+
+The roadmap will be updated as milestones are completed.

--- a/scripts/archive/align_documentation.py
+++ b/scripts/archive/align_documentation.py
@@ -98,9 +98,9 @@ class DocumentationAligner:
 
     def update_feature_matrix(self):
         """Update feature matrix with accurate status."""
-        matrix_path = Path("docs/feature_matrix.md")
+        matrix_path = Path("docs/reference/feature_matrix_1.md")
         if not matrix_path.exists():
-            matrix_path = Path("docs/FEATURE_MATRIX.md")
+            matrix_path = Path("docs/reference/FEATURE_MATRIX_1.md")
 
         if not matrix_path.exists():
             # Create the docs directory if it doesn't exist

--- a/tools/scripts/demonstrate_cleanup.py
+++ b/tools/scripts/demonstrate_cleanup.py
@@ -65,7 +65,7 @@ def demonstrate_cleanup():
             "testing*.md", "BRANCHING_STRATEGY.md"
         ],
         "Reference (docs/reference/)": [
-            "roadmap.md", "TODO.md", "feature_matrix.md"
+            "roadmap.md", "TODO_1.md", "feature_matrix_1.md"
         ]
     }
 


### PR DESCRIPTION
## Summary
- update Feature Matrix, Directory Structure, and TODO references to the _1 versions
- add a missing Project Roadmap document under `docs/reference`
- update cleanup scripts and historical docs for new filenames

## Testing
- `bash run_core_tests.sh` *(fails: ModuleNotFoundError)*
- `bash run_all_tests.sh` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688d283636d0832cb5f20fa592ae7197