### PR TITLE
Add evolution scheduler for production agents

### DIFF
--- a/src/production/agent_forge/evolution/__init__.py
+++ b/src/production/agent_forge/evolution/__init__.py
@@ -7,7 +7,7 @@ including nightly incremental improvements and breakthrough discoveries.
 # Core classes - import order matters to avoid circular imports
 from .base import EvolvableAgent
 from .evolution_metrics import EvolutionMetrics
-# from .evolution_scheduler import EvolutionScheduler  # TODO: Implement
+from .evolution_scheduler import EvolutionScheduler
 
 # Evolution engines
 from .dual_evolution_system import DualEvolutionSystem
@@ -17,8 +17,8 @@ from .magi_architectural_evolution import MagiArchitecturalEvolution
 __all__ = [
     'EvolvableAgent',
     'EvolutionMetrics',
-    # 'EvolutionScheduler',  # TODO: Implement
-    'DualEvolutionSystem', 
+    'EvolutionScheduler',
+    'DualEvolutionSystem',
     'NightlyEvolutionOrchestrator',
     'MagiArchitecturalEvolution'
 ]

--- a/src/production/agent_forge/evolution/evolution_scheduler.py
+++ b/src/production/agent_forge/evolution/evolution_scheduler.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import EvolvableAgent
+
+
+@dataclass
+class SchedulerConfig:
+    """Configuration for :class:`EvolutionScheduler`."""
+
+    retirement_threshold: float = 0.4
+    evolution_threshold: float = 0.6
+
+
+class EvolutionScheduler:
+    """Decides when an agent should evolve or retire based on KPIs."""
+
+    def __init__(self, config: Optional[SchedulerConfig] = None) -> None:
+        self.config = config or SchedulerConfig()
+
+    def get_action(self, agent: EvolvableAgent) -> str:
+        """Return the recommended action for the agent.
+
+        Possible values are ``"retire"``, ``"evolve"``, or ``"none"``.
+        """
+        kpis = agent.evaluate_kpi()
+        performance = kpis.get("performance", 0.5)
+
+        if performance < self.config.retirement_threshold or agent.should_retire():
+            return "retire"
+
+        if performance < self.config.evolution_threshold or agent.needs_evolution():
+            return "evolve"
+
+        return "none"
+

--- a/tests/production/test_evolution_scheduler.py
+++ b/tests/production/test_evolution_scheduler.py
@@ -1,0 +1,59 @@
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from src.production.agent_forge.evolution import (
+    EvolutionScheduler,
+    DualEvolutionSystem,
+    EvolvableAgent,
+)
+
+
+class DummyAgent(EvolvableAgent):
+    def __init__(self, performance: float):
+        super().__init__({'agent_id': str(uuid4())})
+        self._performance = performance
+
+    def evaluate_kpi(self):
+        return {'performance': self._performance, 'reliability': 0.5}
+
+    def should_retire(self) -> bool:
+        return self._performance < self.retirement_threshold
+
+    def needs_evolution(self) -> bool:
+        return self.retirement_threshold <= self._performance < self.evolution_threshold
+
+
+def test_scheduler_basic_actions():
+    scheduler = EvolutionScheduler()
+    agent_retire = DummyAgent(0.3)
+    agent_evolve = DummyAgent(0.5)
+    agent_none = DummyAgent(0.8)
+
+    assert scheduler.get_action(agent_retire) == 'retire'
+    assert scheduler.get_action(agent_evolve) == 'evolve'
+    assert scheduler.get_action(agent_none) == 'none'
+
+
+@pytest.mark.asyncio
+async def test_dual_evolution_system_triggers_scheduler_actions():
+    system = DualEvolutionSystem()
+    agent_retire = DummyAgent(0.2)
+    agent_evolve = DummyAgent(0.5)
+    system.register_agent(agent_retire, {})
+    system.register_agent(agent_evolve, {})
+
+    evolved = {}
+
+    async def fake_evolve(agent):
+        evolved['id'] = agent.agent_id
+        return True
+
+    system._evolve_agent_nightly = fake_evolve
+
+    await system._monitor_agent_performance()
+
+    assert agent_retire.agent_id not in system.registered_agents
+    assert evolved['id'] == agent_evolve.agent_id
+


### PR DESCRIPTION
## Summary
- implement KPI-based `EvolutionScheduler`
- expose scheduler in evolution module exports
- integrate scheduler with `DualEvolutionSystem`
- add unit tests for new scheduler behaviour

## Testing
- `pytest tests/production/test_evolution_scheduler.py -q`
- `pytest tests/production -q`

------
https://chatgpt.com/codex/tasks/task_e_688d3b3aedd0832cae785f7c3254b03c