### PR TITLE
docs: note digital_twin module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Added `digital_twin` module, increasing core module count to 17.
+
 ## [1.0.0] - 2025-07-27
 ### Added
 - **Sprint 2 Complete**: Production/experimental separation with quality gates

--- a/SPRINT_1-5_FINAL_ASSESSMENT.md
+++ b/SPRINT_1-5_FINAL_ASSESSMENT.md
@@ -9,7 +9,7 @@ The comprehensive repository cleanup and functionality verification reveals **AI
 ## Repository Cleanup Status
 ✅ **COMPLETE - Professional structure achieved**
 - 189 cleanup actions executed successfully
-- Clean src/ structure with 16 modules organized
+- Clean src/ structure with 17 modules organized (including `digital_twin`)
 - Organized tests/, tools/, experimental/ directories
 - Archived mobile projects and old reports
 - **Result**: Transformed from 40+ chaotic directories to professional structure

--- a/docs/development/onboarding_1.md
+++ b/docs/development/onboarding_1.md
@@ -16,6 +16,9 @@
    ```
 4. **Mobile quick-start** – See [`mobile-app/README.md`](../mobile-app/README.md)
 
+5. **Explore source modules**
+   - The `src/` directory now contains **17 modules**, including the new `digital_twin` module for personalized twins.
+
 ## Troubleshooting FAQ
 | Symptom | Fix |
 |---------|-----|

--- a/docs/reference/DIRECTORY_STRUCTURE_1.md
+++ b/docs/reference/DIRECTORY_STRUCTURE_1.md
@@ -1,5 +1,7 @@
 # AIVillage Directory Structure
 
+The `src/` directory contains **17 top-level modules**, including the newly added `digital_twin` module.
+
 ## Root Directory
 ```
 AIVillage/
@@ -149,6 +151,12 @@ AIVillage/
 │   ├── communication.py
 │   ├── error_handling.py
 │   └── logging_config.py
+├── digital_twin/               # Digital twin personalization engine
+│   ├── core/
+│   ├── deployment/
+│   ├── engine/
+│   ├── monitoring/
+│   └── security/
 ├── data/                       # Data storage
 │   ├── agent_data.db
 │   └── backups/
@@ -251,6 +259,12 @@ Handles inter-agent communication with:
 - Credit management system
 - Mesh networking
 - MCP (Model Context Protocol) integration
+
+### digital_twin/
+Personalization and twin management features with:
+- User preference modeling
+- Deployment and monitoring utilities
+- Security and privacy tooling
 
 ### tests/
 Comprehensive test suite covering:


### PR DESCRIPTION
## Summary
- note that src now has 17 modules including the new digital_twin component
- document digital_twin in directory structure and onboarding guide
- record module addition in changelog

## Testing
- `bash run_core_tests.sh` *(fails: ModuleNotFoundError: No module named 'core.logging_config')*


------
https://chatgpt.com/codex/tasks/task_e_688d7d276d24832c8680ae09dbdec400