### PR TITLE
Add p2p tests and metrics CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,6 +256,8 @@ Changelog = "https://github.com/aivillage/aivillage/blob/main/CHANGELOG.md"
 aivillage = "core.cli:main"
 forge = "agent_forge.cli:main"
 village-dashboard = "core.dashboard:main"
+reliability-metrics = "core.cli:reliability_metrics"
+latency-metrics = "core.cli:latency_metrics"
 
 [build-system]
 requires = ["setuptools>=75.0.0", "wheel>=0.44.0"]

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -1,0 +1,81 @@
+import argparse
+import json
+from typing import List
+
+
+def _compute_reliability(sent: int, received: int, dropped: int = 0) -> float:
+    """Calculate simple reliability metric."""
+    total = sent + dropped
+    if total == 0:
+        return 0.0
+    return received / total
+
+
+def reliability_metrics() -> float:
+    """CLI entry point for reliability metrics."""
+    parser = argparse.ArgumentParser(description="Generate reliability metrics")
+    parser.add_argument("--sent", type=int, required=True, help="Messages sent")
+    parser.add_argument("--received", type=int, required=True, help="Messages received")
+    parser.add_argument("--dropped", type=int, default=0, help="Messages dropped")
+    args = parser.parse_args()
+    reliability = _compute_reliability(args.sent, args.received, args.dropped)
+    result = {
+        "sent": args.sent,
+        "received": args.received,
+        "dropped": args.dropped,
+        "reliability": reliability,
+    }
+    print(json.dumps(result))
+    return reliability
+
+
+def latency_metrics() -> dict:
+    """CLI entry point for latency metrics."""
+    parser = argparse.ArgumentParser(description="Generate latency metrics")
+    parser.add_argument("latencies", nargs="+", type=float, help="Latency samples in ms")
+    args = parser.parse_args()
+    latencies: List[float] = args.latencies
+    avg = sum(latencies) / len(latencies)
+    metrics = {
+        "average_latency": avg,
+        "min_latency": min(latencies),
+        "max_latency": max(latencies),
+    }
+    print(json.dumps(metrics))
+    return metrics
+
+
+def main() -> None:
+    """Core CLI with reliability and latency subcommands."""
+    parser = argparse.ArgumentParser(description="AIVillage core CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    rel = subparsers.add_parser("reliability", help="Generate reliability metrics")
+    rel.add_argument("--sent", type=int, required=True)
+    rel.add_argument("--received", type=int, required=True)
+    rel.add_argument("--dropped", type=int, default=0)
+
+    lat = subparsers.add_parser("latency", help="Generate latency metrics")
+    lat.add_argument("latencies", nargs="+", type=float)
+
+    args = parser.parse_args()
+    if args.command == "reliability":
+        reliability = _compute_reliability(args.sent, args.received, args.dropped)
+        result = {
+            "sent": args.sent,
+            "received": args.received,
+            "dropped": args.dropped,
+            "reliability": reliability,
+        }
+        print(json.dumps(result))
+    elif args.command == "latency":
+        latencies = args.latencies
+        avg = sum(latencies) / len(latencies)
+        metrics = {
+            "average_latency": avg,
+            "min_latency": min(latencies),
+            "max_latency": max(latencies),
+        }
+        print(json.dumps(metrics))
+    else:
+        parser.print_help()

--- a/src/core/p2p/test_encryption_layer.py
+++ b/src/core/p2p/test_encryption_layer.py
@@ -1,0 +1,26 @@
+import pytest
+
+from .encryption_layer import EncryptionLayer
+
+
+@pytest.mark.asyncio
+async def test_encrypt_decrypt_roundtrip() -> None:
+    layer = EncryptionLayer("node1")
+    await layer.initialize()
+    encrypted = await layer.encrypt_message("hello", recipient_id="peer1")
+    decrypted = await layer.decrypt_message(encrypted, sender_id="peer1")
+    assert decrypted == "hello"
+    assert layer.stats["messages_encrypted"] == 1
+    assert layer.stats["messages_decrypted"] == 1
+    await layer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_replay_protection() -> None:
+    layer = EncryptionLayer("node1")
+    await layer.initialize()
+    encrypted = await layer.encrypt_message("hi", recipient_id="peer1")
+    await layer.decrypt_message(encrypted, sender_id="peer1")
+    with pytest.raises(ValueError):
+        await layer.decrypt_message(encrypted, sender_id="peer1")
+    await layer.shutdown()

--- a/src/core/p2p/test_message_protocol.py
+++ b/src/core/p2p/test_message_protocol.py
@@ -1,0 +1,58 @@
+import asyncio
+import json
+import pytest
+
+from .message_protocol import MessageProtocol, EvolutionMessage, MessageType
+
+
+class DummyNode:
+    def __init__(self) -> None:
+        self.node_id = "node"
+        self.peer_registry = {}
+        self.connections = {}
+
+
+class DummyWriter:
+    def __init__(self) -> None:
+        self.buffer = b""
+
+    def write(self, data: bytes) -> None:
+        self.buffer += data
+
+    async def drain(self) -> None:  # pragma: no cover - no IO
+        pass
+
+
+class DummyReader:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+    async def readexactly(self, n: int) -> bytes:
+        if len(self.data) < n:
+            raise asyncio.IncompleteReadError(partial=self.data, expected=n)
+        result = self.data[:n]
+        self.data = self.data[n:]
+        return result
+
+
+@pytest.mark.asyncio
+async def test_send_message_tracks_retries() -> None:
+    node = DummyNode()
+    protocol = MessageProtocol(node)
+    writer = DummyWriter()
+    msg = EvolutionMessage(message_id="1", message_type=MessageType.PING, sender_id="node", requires_ack=True)
+    await protocol.send_message(msg, writer)
+    queued = await protocol.retry_queue.get()
+    assert queued.message_id == "1"
+    assert protocol.stats["messages_sent"] == 1
+
+
+@pytest.mark.asyncio
+async def test_read_message_rejects_large() -> None:
+    node = DummyNode()
+    protocol = MessageProtocol(node)
+    length = 1024 * 1024 + 1
+    header = length.to_bytes(4, "big")
+    data = b"x" * length
+    reader = DummyReader(header + data)
+    assert await protocol.read_message(reader) is None

--- a/src/core/p2p/test_peer_discovery.py
+++ b/src/core/p2p/test_peer_discovery.py
@@ -1,0 +1,45 @@
+import time
+import pytest
+
+from .peer_discovery import PeerDiscovery
+
+
+class DummyNode:
+    def __init__(self) -> None:
+        self.node_id = "node"
+        self.listen_port = 9000
+        self.peer_registry = {}
+        self.connections = {}
+        self.local_capabilities = None
+        self.use_tls = False
+        self.ssl_context = None
+
+    async def send_to_peer(self, peer_id, message):  # pragma: no cover - placeholder
+        pass
+
+
+def test_add_and_remove_peer() -> None:
+    node = DummyNode()
+    discovery = PeerDiscovery(node)
+    discovery.add_known_peer("1.1.1.1", 9000)
+    assert ("1.1.1.1", 9000) in discovery.discovered_peers
+    discovery.remove_peer("1.1.1.1", 9000)
+    assert ("1.1.1.1", 9000) not in discovery.discovered_peers
+
+
+def test_discovery_stats_counts() -> None:
+    node = DummyNode()
+    discovery = PeerDiscovery(node)
+    discovery.add_known_peer("2.2.2.2", 9000)
+    stats = discovery.get_discovery_stats()
+    assert stats["discovered_peers_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_targets() -> None:
+    node = DummyNode()
+    discovery = PeerDiscovery(node)
+    discovery.failed_peers[("3.3.3.3", 9000)] = time.time() - 601
+    targets = discovery._get_retry_targets()
+    assert ("3.3.3.3", 9000) in targets
+    assert ("3.3.3.3", 9000) not in discovery.failed_peers

--- a/tests/agents/test_agent_specialization.py
+++ b/tests/agents/test_agent_specialization.py
@@ -1,0 +1,8 @@
+from scripts.agent_kpi_system import AgentKPITracker, KPIMetric
+
+
+def test_specialization_weights_differ() -> None:
+    king = AgentKPITracker("a1", "king")
+    magi = AgentKPITracker("a2", "magi")
+    assert king.kpi_weights[KPIMetric.INTER_AGENT_COOPERATION] != magi.kpi_weights[KPIMetric.INTER_AGENT_COOPERATION]
+    assert magi.kpi_weights[KPIMetric.OUTPUT_QUALITY_SCORE] > king.kpi_weights[KPIMetric.OUTPUT_QUALITY_SCORE]

--- a/tests/agents/test_kpi_tracker.py
+++ b/tests/agents/test_kpi_tracker.py
@@ -1,0 +1,13 @@
+from datetime import timedelta
+
+from scripts.agent_kpi_system import AgentKPITracker, KPIMetric
+
+
+def test_kpi_tracking_records_and_scores() -> None:
+    tracker = AgentKPITracker("agent1", "king")
+    tracker.record_performance("task1", {KPIMetric.TASK_COMPLETION_RATE: 0.8})
+    tracker.record_performance("task2", {KPIMetric.TASK_COMPLETION_RATE: 0.9})
+    score = tracker.calculate_overall_kpi()
+    assert 0 < score <= 1
+    recent = tracker.calculate_overall_kpi(time_window=timedelta(days=1))
+    assert recent > 0


### PR DESCRIPTION
## Summary
- add CLI utilities for reliability and latency metrics
- add peer discovery, message protocol, and encryption layer tests
- cover KPI tracking and specialization differentiation for agents

## Testing
- `pytest src/core/p2p/test_peer_discovery.py src/core/p2p/test_message_protocol.py src/core/p2p/test_encryption_layer.py tests/agents/test_kpi_tracker.py tests/agents/test_agent_specialization.py -q`
- `PYTHONPATH=src python -c "import sys; from core.cli import reliability_metrics; sys.argv=['reliability-metrics','--sent','10','--received','8','--dropped','1']; reliability_metrics()"`
- `PYTHONPATH=src python -c "import sys; from core.cli import latency_metrics; sys.argv=['latency-metrics','10','20','30']; latency_metrics()"`


------
https://chatgpt.com/codex/tasks/task_e_688d7d385ee4832caa6cdcca70002088