### PR TITLE
Add integration test for distributed AI workflow

### DIFF
--- a/tests/integration/test_full_integration.py
+++ b/tests/integration/test_full_integration.py
@@ -1,0 +1,180 @@
+"""Full integration test for distributed AI workflow.
+
+This test simulates deploying agents, establishing a peer-to-peer network,
+profiling devices with model sharding, executing distributed inference and
+federated learning. Each stage records metrics and reports overall success
+or failure.
+"""
+
+import asyncio
+import logging
+import random
+import time
+from typing import Dict, Tuple
+
+import pytest
+
+# Configure logging for visibility during test runs
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class MetricsRecorder:
+    """Utility to record success/failure metrics for test stages."""
+
+    def __init__(self) -> None:
+        self.results: Dict[str, Dict[str, object]] = {}
+        self.start_time = time.time()
+
+    def record(self, name: str, success: bool, **details: object) -> None:
+        self.results[name] = {
+            "success": success,
+            "details": details,
+            "timestamp": time.time(),
+        }
+        status = "PASS" if success else "FAIL"
+        logger.info(f"[{status}] {name}: {details}")
+
+    def summary(self) -> Dict[str, object]:
+        total = len(self.results)
+        passed = sum(1 for r in self.results.values() if r["success"])
+        failed = total - passed
+        return {
+            "total": total,
+            "passed": passed,
+            "failed": failed,
+            "overall_status": "PASS" if failed == 0 else "FAIL",
+            "duration": time.time() - self.start_time,
+            "results": self.results,
+        }
+
+
+class DistributedAIWorkflow:
+    """Simulates a multi-stage distributed AI workflow."""
+
+    def __init__(self, runner: MetricsRecorder) -> None:
+        self.runner = runner
+        self.agents = ["ingest", "inference", "training", "monitor"]
+        self.devices = [
+            {"name": "edge_1", "ram": 4},
+            {"name": "edge_2", "ram": 8},
+            {"name": "edge_3", "ram": 16},
+        ]
+
+    async def deploy_agents(self) -> bool:
+        start = time.time()
+        deployed = []
+        for agent in self.agents:
+            await asyncio.sleep(0.01)
+            deployed.append(agent)
+        success = len(deployed) == len(self.agents)
+        self.runner.record(
+            "agent_deployment",
+            success,
+            duration=time.time() - start,
+            deployed=len(deployed),
+            expected=len(self.agents),
+        )
+        return success
+
+    async def establish_p2p_network(self) -> bool:
+        start = time.time()
+        connections = {a: [b for b in self.agents if b != a] for a in self.agents}
+        total_links = sum(len(v) for v in connections.values())
+        expected_links = len(self.agents) * (len(self.agents) - 1)
+        success = total_links == expected_links
+        self.runner.record(
+            "p2p_network",
+            success,
+            duration=time.time() - start,
+            nodes=len(self.agents),
+            connections=total_links // 2,
+        )
+        return success
+
+    async def profile_and_shard(self) -> Tuple[bool, Dict[str, int]]:
+        start = time.time()
+        model_size = 24  # abstract units
+        total_ram = sum(d["ram"] for d in self.devices)
+        shards: Dict[str, int] = {}
+        assigned = 0
+        for device in self.devices:
+            share = int(model_size * device["ram"] / total_ram)
+            shards[device["name"]] = share
+            assigned += share
+        if assigned < model_size:
+            shards[self.devices[-1]["name"]] += model_size - assigned
+        success = sum(shards.values()) == model_size
+        self.runner.record(
+            "device_profiling",
+            success,
+            duration=time.time() - start,
+            shards=shards,
+            model_size=model_size,
+        )
+        return success, shards
+
+    async def distributed_inference(self, shards: Dict[str, int]) -> bool:
+        start = time.time()
+        inputs = [random.random() for _ in range(5)]
+        partials = []
+        latencies = []
+        for device, count in shards.items():
+            t0 = time.time()
+            await asyncio.sleep(0.01)
+            result = sum(inputs[: min(count, len(inputs))])
+            latencies.append(time.time() - t0)
+            partials.append(result)
+        aggregated = sum(partials)
+        success = len(partials) == len(shards)
+        self.runner.record(
+            "distributed_inference",
+            success,
+            duration=time.time() - start,
+            latency_avg=sum(latencies) / len(latencies),
+            result=aggregated,
+        )
+        return success
+
+    async def federated_learning(self, shards: Dict[str, int]) -> bool:
+        start = time.time()
+        global_metric = 0.5
+        updates = []
+        for _ in shards:
+            await asyncio.sleep(0.01)
+            updates.append(global_metric + random.random() * 0.1)
+        new_metric = sum(updates) / len(updates)
+        success = new_metric > global_metric
+        self.runner.record(
+            "federated_learning",
+            success,
+            duration=time.time() - start,
+            old_accuracy=global_metric,
+            new_accuracy=new_metric,
+        )
+        return success
+
+    async def run_workflow(self) -> bool:
+        if not await self.deploy_agents():
+            return False
+        if not await self.establish_p2p_network():
+            return False
+        profiled, shards = await self.profile_and_shard()
+        if not profiled:
+            return False
+        if not await self.distributed_inference(shards):
+            return False
+        if not await self.federated_learning(shards):
+            return False
+        return True
+
+
+@pytest.mark.asyncio
+async def test_full_integration() -> None:
+    """Run the simulated full integration workflow."""
+    runner = MetricsRecorder()
+    workflow = DistributedAIWorkflow(runner)
+    success = await workflow.run_workflow()
+    runner.record("full_integration", success)
+    report = runner.summary()
+    assert report["overall_status"] == "PASS", report


### PR DESCRIPTION
## Summary
- add full integration test that deploys agents, builds a P2P network, shards a model across profiled devices, runs distributed inference and federated learning
- record success/failure metrics for each stage using a metrics recorder

## Testing
- `pytest tests/integration/test_full_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7d3e3d60832c84e7d823985a35d0