### PR TITLE
Add cleanup verification script with metrics logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,6 +207,7 @@ coverage.xml
 !package.json
 !package-lock.json
 !tsconfig.json
+!cleanup_metrics.json
 
 # Specific generated JSON files
 *_results.json

--- a/cleanup_metrics.json
+++ b/cleanup_metrics.json
@@ -1,0 +1,3 @@
+{
+  "cleanup_actions": 2
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Development workflows, testing, and contribution guidelines.
 - [Branching Strategy](development/BRANCHING_STRATEGY.md)
 - [Testing Best Practices](development/testing-best-practices.md)
 - [Integration Testing](development/SMOKE_TEST_INTEGRATION.md)
+- [Cleanup Verification](development/cleanup_verification.md)
 
 ### 📋 Reference
 Reference materials, roadmaps, and administrative documentation.

--- a/docs/development/cleanup_verification.md
+++ b/docs/development/cleanup_verification.md
@@ -1,0 +1,14 @@
+# Cleanup Verification
+
+The project includes a script to verify cleanup actions and record metrics for future audits.
+
+## Usage
+
+1. Generate a log file where each line describes a cleanup action.
+2. Run the verification script:
+   ```bash
+   python tools/verify_cleanup.py path/to/cleanup.log
+   ```
+3. The script logs each action, counts them, and writes the total to `cleanup_metrics.json`.
+
+The `cleanup_metrics.json` file is kept in the repository to make cleanup claims reproducible.

--- a/tools/verify_cleanup.py
+++ b/tools/verify_cleanup.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Utility for verifying and counting cleanup actions.
+
+This script reads a log file containing cleanup actions (one per line),
+logs each action, counts the total number of actions, and records the
+count in a machine-readable JSON metrics file.
+
+Usage:
+    python tools/verify_cleanup.py [path_to_log] [--metrics output_json]
+
+The default log file is ``cleanup.log`` and the default metrics file is
+``cleanup_metrics.json``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Iterable
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Verify cleanup actions and record metrics.")
+    parser.add_argument(
+        "logfile",
+        nargs="?",
+        default="cleanup.log",
+        help="Path to a file listing cleanup actions (one per line).",
+    )
+    parser.add_argument(
+        "--metrics",
+        default="cleanup_metrics.json",
+        help="Destination JSON file for writing cleanup metrics.",
+    )
+    return parser.parse_args()
+
+
+def iter_actions(log_path: Path) -> Iterable[str]:
+    """Yield cleanup actions from ``log_path``.
+
+    Empty lines are ignored. The function is separated for easier testing.
+    """
+    if not log_path.exists():
+        raise FileNotFoundError(f"Log file not found: {log_path}")
+
+    with log_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            action = line.strip()
+            if action:
+                yield action
+
+
+def main() -> int:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    log_path = Path(args.logfile)
+    actions = list(iter_actions(log_path))
+
+    for action in actions:
+        logging.info("cleanup action: %s", action)
+
+    metrics = {"cleanup_actions": len(actions)}
+    metrics_path = Path(args.metrics)
+    metrics_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+    logging.info("Recorded %s cleanup actions to %s", len(actions), metrics_path)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `verify_cleanup.py` to log and count cleanup actions
- record cleanup counts in `cleanup_metrics.json`
- document cleanup verification process and link from docs index

## Testing
- `python tools/verify_cleanup.py cleanup.log --metrics cleanup_metrics.json`
- `pytest` *(fails: ModuleNotFoundError: No module named 'agents.king')*

------
https://chatgpt.com/codex/tasks/task_e_688d7d57f7ec832c8ab50523a7305a5d