### PR TITLE
Add P2P and resource management tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [tool:pytest]
-testpaths = tests
+testpaths =
+    tests
+    src/core/p2p
+    src/core/resources
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*

--- a/src/core/p2p/test_encryption_layer.py
+++ b/src/core/p2p/test_encryption_layer.py
@@ -1,0 +1,20 @@
+import argparse
+import pytest
+from .encryption_layer import EncryptionLayer
+
+parser = argparse.ArgumentParser(description="Encryption layer test options")
+parser.add_argument("--simulate", action="store_true", help="enable simulated mode")
+ARGS, _ = parser.parse_known_args()
+
+
+@pytest.mark.asyncio
+async def test_encrypt_decrypt_roundtrip():
+    layer = EncryptionLayer("node-a")
+    await layer.initialize()
+    message = "secret"
+    encrypted = await layer.encrypt_message(message, recipient_id="peer1")
+    assert isinstance(encrypted, bytes)
+    assert encrypted != message.encode()
+    decrypted = await layer.decrypt_message(encrypted, sender_id="peer1")
+    assert decrypted == message
+    await layer.shutdown()

--- a/src/core/p2p/test_message_protocol.py
+++ b/src/core/p2p/test_message_protocol.py
@@ -1,0 +1,46 @@
+import argparse
+import asyncio
+import pytest
+from .message_protocol import EvolutionMessage, MessageProtocol, MessageType
+
+# CLI flag for simulation (unused but available)
+parser = argparse.ArgumentParser(description="Message protocol test options")
+parser.add_argument("--simulate", action="store_true", help="run protocol tests in simulation mode")
+ARGS, _ = parser.parse_known_args()
+
+
+class DummyWriter:
+    """Minimal async writer capturing written data."""
+
+    def __init__(self):
+        self.data = b""
+
+    def write(self, b: bytes):
+        self.data += b
+
+    async def drain(self):
+        pass
+
+
+def test_message_serialization_roundtrip():
+    msg = EvolutionMessage(message_id="1", message_type=MessageType.PING, sender_id="a")
+    restored = EvolutionMessage.from_dict(msg.to_dict())
+    assert restored.message_id == msg.message_id
+    assert restored.message_type == msg.message_type
+
+
+def test_retry_logic():
+    msg = EvolutionMessage(message_id="2", message_type=MessageType.PING, sender_id="a", max_retries=1)
+    assert msg.should_retry()
+    msg.retry_count = 1
+    assert not msg.should_retry()
+
+
+@pytest.mark.asyncio
+async def test_send_tracks_message():
+    protocol = MessageProtocol(None)
+    writer = DummyWriter()
+    msg = EvolutionMessage(message_id="3", message_type=MessageType.PING, sender_id="a")
+    result = await protocol.send_message(msg, writer)
+    assert result is True
+    assert msg.message_id in protocol.sent_messages

--- a/src/core/p2p/test_peer_discovery.py
+++ b/src/core/p2p/test_peer_discovery.py
@@ -1,0 +1,22 @@
+import argparse
+from .peer_discovery import PeerDiscovery
+
+# CLI option for tests
+parser = argparse.ArgumentParser(description="Peer discovery test options")
+parser.add_argument("--min-peers", type=int, default=1, help="minimum peers to discover")
+# parse_known_args to ignore pytest's own flags
+ARGS, _ = parser.parse_known_args()
+
+
+def test_min_peers_cli_parsing():
+    """Ensure the custom CLI flag is parsed correctly."""
+    assert isinstance(ARGS.min_peers, int)
+
+
+def test_peer_discovery_initial_state():
+    """PeerDiscovery should start with no discovered peers."""
+    class DummyNode:
+        pass
+
+    discovery = PeerDiscovery(DummyNode())
+    assert discovery.discovered_peers == set()

--- a/src/core/resources/test_constraint_manager.py
+++ b/src/core/resources/test_constraint_manager.py
@@ -1,0 +1,62 @@
+import argparse
+import asyncio
+from .device_profiler import DeviceProfiler, ResourceSnapshot, PowerState, ThermalState
+from .constraint_manager import ConstraintManager, ResourceConstraints, ConstraintType
+
+parser = argparse.ArgumentParser(description="Constraint manager test options")
+parser.add_argument("--simulate", action="store_true", help="use simulated data")
+ARGS, _ = parser.parse_known_args()
+
+
+def _sample_snapshot() -> ResourceSnapshot:
+    return ResourceSnapshot(
+        timestamp=0,
+        memory_total=200 * 1024 * 1024,
+        memory_available=50 * 1024 * 1024,
+        memory_used=150 * 1024 * 1024,
+        memory_percent=75.0,
+        cpu_percent=60.0,
+        cpu_cores=4,
+        cpu_freq_current=None,
+        cpu_freq_max=None,
+        cpu_temp=80.0,
+        storage_total=10 * 1024 * 1024 * 1024,
+        storage_used=9 * 1024 * 1024 * 1024,
+        storage_free=0.5 * 1024 * 1024 * 1024,
+        storage_percent=90.0,
+        battery_percent=10.0,
+        power_plugged=False,
+        power_state=PowerState.BATTERY_LOW,
+        thermal_state=ThermalState.HOT,
+        network_sent=0,
+        network_received=0,
+        network_connections=0,
+        process_count=1,
+        gpu_memory_used=None,
+        gpu_memory_total=None,
+        gpu_utilization=None,
+    )
+
+
+def test_detects_violations():
+    profiler = DeviceProfiler(monitoring_interval=0.1, enable_background_monitoring=False)
+    cm = ConstraintManager(profiler)
+    constraints = ResourceConstraints(
+        max_memory_mb=100,
+        memory_warning_mb=80,
+        memory_critical_mb=90,
+        max_cpu_percent=50.0,
+        cpu_warning_percent=40.0,
+        cpu_critical_percent=45.0,
+        min_battery_percent=20.0,
+        battery_warning_percent=30.0,
+        max_temperature_celsius=70.0,
+        temperature_warning_celsius=60.0,
+        min_free_storage_gb=1.0,
+        storage_warning_gb=2.0,
+    )
+    snapshot = _sample_snapshot()
+    violations = asyncio.run(cm._check_task_constraints("task", constraints, snapshot))
+    types = {v.constraint_type for v in violations}
+    assert ConstraintType.MEMORY in types
+    assert ConstraintType.CPU in types

--- a/src/core/resources/test_device_profiler.py
+++ b/src/core/resources/test_device_profiler.py
@@ -1,0 +1,67 @@
+import argparse
+import psutil
+import pytest
+from .device_profiler import DeviceProfiler, ResourceSnapshot, PowerState, ThermalState
+
+parser = argparse.ArgumentParser(description="Device profiler test options")
+parser.add_argument("--simulate", action="store_true", help="use simulated metrics")
+ARGS, _ = parser.parse_known_args()
+
+
+def _apply_simulation(monkeypatch):
+    class Mem:
+        total = 1024 ** 3
+        available = total // 2
+        used = total // 2
+        percent = 50.0
+
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: Mem)
+    monkeypatch.setattr(psutil, "cpu_percent", lambda interval=None: 10.0)
+    monkeypatch.setattr(psutil, "cpu_count", lambda logical=True: 4)
+    monkeypatch.setattr(psutil, "cpu_freq", lambda: type("cf", (), {"current": 1000})())
+    monkeypatch.setattr(psutil, "disk_usage", lambda path: type("du", (), {"total": 1000, "used": 500, "free": 500})())
+    monkeypatch.setattr(psutil, "net_io_counters", lambda: type("nio", (), {"bytes_sent": 0, "bytes_recv": 0})())
+    monkeypatch.setattr(psutil, "net_connections", lambda: [])
+    monkeypatch.setattr(psutil, "pids", lambda: [1])
+    monkeypatch.setattr(psutil, "sensors_battery", lambda: type("bat", (), {"percent": 100, "power_plugged": True})())
+    monkeypatch.setattr(psutil, "sensors_temperatures", lambda: {"coretemp": [type("t", (), {"current": 50})()]})
+
+
+def test_take_snapshot(monkeypatch):
+    if ARGS.simulate:
+        _apply_simulation(monkeypatch)
+    profiler = DeviceProfiler(monitoring_interval=0.1, enable_background_monitoring=False)
+    snapshot = profiler.take_snapshot()
+    assert snapshot.memory_total > 0
+    assert snapshot.cpu_percent >= 0
+
+
+def test_resource_snapshot_flags():
+    snapshot = ResourceSnapshot(
+        timestamp=0,
+        memory_total=1000,
+        memory_available=100,
+        memory_used=900,
+        memory_percent=90.0,
+        cpu_percent=95.0,
+        cpu_cores=4,
+        cpu_freq_current=None,
+        cpu_freq_max=None,
+        cpu_temp=90.0,
+        storage_total=1000,
+        storage_used=900,
+        storage_free=100,
+        storage_percent=90.0,
+        battery_percent=4.0,
+        power_plugged=False,
+        power_state=PowerState.BATTERY_CRITICAL,
+        thermal_state=ThermalState.CRITICAL,
+        network_sent=0,
+        network_received=0,
+        network_connections=0,
+        process_count=0,
+        gpu_memory_used=None,
+        gpu_memory_total=None,
+        gpu_utilization=None,
+    )
+    assert snapshot.is_resource_constrained

--- a/src/core/resources/test_resource_monitor.py
+++ b/src/core/resources/test_resource_monitor.py
@@ -1,0 +1,57 @@
+import argparse
+import asyncio
+from .device_profiler import DeviceProfiler, ResourceSnapshot, PowerState, ThermalState
+from .resource_monitor import ResourceMonitor, MonitoringMode
+
+parser = argparse.ArgumentParser(description="Resource monitor test options")
+parser.add_argument("--simulate", action="store_true", help="use simulated snapshots")
+ARGS, _ = parser.parse_known_args()
+
+
+def _make_snapshot(mem_percent: float) -> ResourceSnapshot:
+    mem_total = 1000
+    mem_used = mem_total * mem_percent / 100
+    return ResourceSnapshot(
+        timestamp=0,
+        memory_total=mem_total,
+        memory_available=mem_total - mem_used,
+        memory_used=mem_used,
+        memory_percent=mem_percent,
+        cpu_percent=10.0,
+        cpu_cores=4,
+        cpu_freq_current=None,
+        cpu_freq_max=None,
+        cpu_temp=None,
+        storage_total=0,
+        storage_used=0,
+        storage_free=0,
+        storage_percent=0,
+        battery_percent=None,
+        power_plugged=None,
+        power_state=PowerState.UNKNOWN,
+        thermal_state=ThermalState.UNKNOWN,
+        network_sent=0,
+        network_received=0,
+        network_connections=0,
+        process_count=0,
+        gpu_memory_used=None,
+        gpu_memory_total=None,
+        gpu_utilization=None,
+    )
+
+
+def test_mode_interval_adjustment():
+    profiler = DeviceProfiler(monitoring_interval=1.0, enable_background_monitoring=False)
+    monitor = ResourceMonitor(profiler)
+    monitor.set_monitoring_mode(MonitoringMode.EVOLUTION)
+    expected = monitor.base_interval * monitor.interval_adjustments[MonitoringMode.EVOLUTION]
+    assert monitor.current_interval == expected
+
+
+def test_trend_simulation():
+    profiler = DeviceProfiler(monitoring_interval=1.0, enable_background_monitoring=False)
+    snapshots = [_make_snapshot(10), _make_snapshot(11), _make_snapshot(12)]
+    profiler.snapshots = snapshots
+    monitor = ResourceMonitor(profiler)
+    asyncio.run(monitor._update_trends(snapshots[-1]))
+    assert "memory_percent" in monitor.trends


### PR DESCRIPTION
## Summary
- cover peer discovery CLI via `--min-peers`
- add reliability checks for message protocol and encryption layer
- simulate device profiling, resource monitoring, and constraint management

## Testing
- `pytest src/core/p2p/test_peer_discovery.py src/core/p2p/test_message_protocol.py src/core/p2p/test_encryption_layer.py src/core/resources/test_device_profiler.py src/core/resources/test_resource_monitor.py src/core/resources/test_constraint_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d7d6e4ba4832cb63a044685b6c72f