### PR TITLE
Add benchmark aggregation and stress test utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ fix_*.py
 apply_*.py
 run_*.py
 quick_*.py
+!benchmarks/run_all.py
 
 # Mesh network and integration test files
 mesh_network_*.py

--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ pytest tests/performance/
 pytest --cov=src
 ```
 
+## Performance Benchmarking & Stress Testing
+
+Run all sprint benchmarks and aggregate their metrics:
+
+```bash
+python benchmarks/run_all.py --output performance_comparison.json
+```
+
+Simulate production load to evaluate system stability:
+
+```bash
+python stress_tests/production_simulation.py --devices 100 --duration 60 --failure-rate 0.01
+```
+
+Both utilities emit JSON reports for reproducible performance analysis.
+
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:

--- a/benchmarks/run_all.py
+++ b/benchmarks/run_all.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Aggregate all sprint benchmarks and output performance comparison.
+
+This script runs the creativity, personalization, and repair test benchmarks
+and saves their aggregated metrics to ``performance_comparison.json``.
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+
+async def run_all(output_file: Path) -> dict:
+    """Run all benchmarks and write aggregated metrics to *output_file*.
+
+    Parameters
+    ----------
+    output_file:
+        Path to the JSON file where aggregated metrics will be stored.
+    """
+
+    from benchmarks.hyperag_creativity import CreativityBenchmark
+    from benchmarks.hyperag_personalization import PersonalizationBenchmark
+    from benchmarks.hyperag_repair_test_suite import RepairTestSuite
+
+    results: dict[str, object] = {}
+
+    # Creativity benchmark
+    creativity = CreativityBenchmark()
+    creativity_metrics = await creativity.run_full_benchmark()
+    results["creativity"] = asdict(creativity_metrics)
+
+    # Personalization benchmark
+    personalization = PersonalizationBenchmark()
+    personalization_results = await personalization.run_full_benchmark()
+    results["personalization"] = {
+        name: asdict(metrics) for name, metrics in personalization_results.items()
+    }
+
+    # Repair test suite
+    repair_suite = RepairTestSuite()
+    repair_metrics = await repair_suite.run_comprehensive_repair_tests()
+    results["repair"] = asdict(repair_metrics)
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+
+    return results
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run all sprint benchmarks and aggregate results"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("performance_comparison.json"),
+        help="File to write aggregated benchmark metrics",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+    results = await run_all(args.output)
+    print(json.dumps(results, indent=2))
+    print(f"\nPerformance comparison written to {args.output}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/stress_tests/production_simulation.py
+++ b/stress_tests/production_simulation.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Simple production load simulation for stability testing.
+
+The simulation models a fleet of devices that may fail during a test window.
+Users can configure the number of devices, duration of the simulation and the
+probability of failure per device per second.  Aggregated stability metrics are
+written to a JSON file for reproducibility.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class StabilityMetrics:
+    """Results produced by :func:`run_simulation`."""
+
+    devices: int
+    duration: int
+    failure_rate: float
+    total_failures: int
+    total_events: int
+    observed_failure_rate: float
+    uptime_percentage: float
+    mean_time_between_failures: float
+
+
+def run_simulation(devices: int, duration: int, failure_rate: float) -> StabilityMetrics:
+    """Run a probabilistic failure simulation."""
+    failures = 0
+    events = devices * duration
+
+    for _ in range(duration):
+        for _ in range(devices):
+            if random.random() < failure_rate:
+                failures += 1
+
+    observed_rate = failures / events if events else 0.0
+    uptime = 1 - observed_rate
+    mtbf = (events / failures) if failures else float("inf")
+
+    return StabilityMetrics(
+        devices=devices,
+        duration=duration,
+        failure_rate=failure_rate,
+        total_failures=failures,
+        total_events=events,
+        observed_failure_rate=observed_rate,
+        uptime_percentage=uptime,
+        mean_time_between_failures=mtbf,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Production load simulation")
+    parser.add_argument("--devices", type=int, default=100, help="Number of devices")
+    parser.add_argument(
+        "--duration", type=int, default=60, help="Duration of the simulation in seconds"
+    )
+    parser.add_argument(
+        "--failure-rate",
+        type=float,
+        default=0.01,
+        help="Failure probability per device per second",
+    )
+    parser.add_argument(
+        "--output", type=Path, default=Path("stress_test_results.json"), help="Output file"
+    )
+    parser.add_argument(
+        "--seed", type=int, default=None, help="Random seed for reproducibility"
+    )
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+
+    metrics = run_simulation(args.devices, args.duration, args.failure_rate)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(asdict(metrics), f, indent=2)
+
+    print(json.dumps(asdict(metrics), indent=2))
+    print(f"\nSimulation results written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `benchmarks/run_all.py` to execute all sprint benchmarks and collate metrics into `performance_comparison.json`
- add `stress_tests/production_simulation.py` to simulate device failures for stability metrics
- document benchmark aggregation and stress test usage for reproducible performance testing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agents.king')*

------
https://chatgpt.com/codex/tasks/task_e_688d7d5ea7f8832cbc0ea87a0a43dec3