### PR TITLE
Align orchestrator agent types with available templates

### DIFF
--- a/src/production/distributed_agents/distributed_agent_orchestrator.py
+++ b/src/production/distributed_agents/distributed_agent_orchestrator.py
@@ -33,7 +33,7 @@ class AgentType(Enum):
     GARDENER = "gardener"                  # System maintenance
     LEGAL = "legal"                        # Compliance and legal
     MAKER = "maker"                        # Content creation
-    MASTER = "master"                      # Training coordination
+    SHAMAN = "shaman"                      # Intuitive reasoning
     MEDIC = "medic"                        # System health
     NAVIGATOR = "navigator"                # Path finding and routing
     ORACLE = "oracle"                      # Prediction and forecasting
@@ -228,13 +228,12 @@ class DistributedAgentOrchestrator:
                 dependencies=[AgentType.SAGE, AgentType.CURATOR]
             ),
 
-            AgentType.MASTER: AgentSpec(
-                agent_type=AgentType.MASTER,
+            AgentType.SHAMAN: AgentSpec(
+                agent_type=AgentType.SHAMAN,
                 priority=AgentPriority.MEDIUM,
-                memory_requirement_mb=1024.0,
-                compute_requirement=3.5,
-                specialization="training_coordination",
-                dependencies=[AgentType.KING]
+                memory_requirement_mb=512.0,
+                compute_requirement=2.0,
+                specialization="intuitive_reasoning"
             ),
 
             AgentType.MEDIC: AgentSpec(


### PR DESCRIPTION
## Summary
- replace obsolete `MASTER` agent with `SHAMAN` in the distributed agent orchestrator
- define shaman deployment specification to keep total agent count at 18

## Testing
- `PYTHONPATH=.:src:agent_forge pytest tests/core/test_communication.py -q`
- `PYTHONPATH=.:src:agent_forge pytest tests/core/test_evidencepack.py -q`
- `PYTHONPATH=.:src:agent_forge pytest tests/test_message.py -q`
- `PYTHONPATH=.:src:agent_forge pytest tests/test_integration.py -q --maxfail=5` *(fails: file or directory not found)*


------
https://chatgpt.com/codex/tasks/task_e_688d8519c5fc832cb8713e3963b48cd9