### PR TITLE
Add distributed agent orchestrator tests

### DIFF
--- a/src/production/distributed_agents/agent_registry.py
+++ b/src/production/distributed_agents/agent_registry.py
@@ -1,0 +1,18 @@
+"""Lightweight agent registry stubs for testing."""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class AgentLocation:
+    """Represents where agents are running."""
+    agent_type: Any
+    device_id: str
+    instance_ids: List[str] = field(default_factory=list)
+
+
+class DistributedAgentRegistry:
+    """Minimal registry tracking agent locations."""
+
+    def __init__(self):
+        self.registry: Dict[Any, AgentLocation] = {}

--- a/tests/distributed_agents/conftest.py
+++ b/tests/distributed_agents/conftest.py
@@ -1,0 +1,96 @@
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from src.production.distributed_agents.distributed_agent_orchestrator import (
+    AgentInstance,
+    DistributedAgentOrchestrator,
+)
+
+
+@dataclass
+class DeviceProfile:
+    """Minimal device profile for orchestrator tests."""
+    device_id: str
+    capabilities: Any = None
+    available_memory_mb: float = 0.0
+    compute_score: float = 0.0
+    network_latency_ms: float = 0.0
+    battery_level: float | None = None
+    reliability_score: float = 1.0
+
+
+class DummyShardingEngine:
+    """Stub sharding engine returning predefined device profiles."""
+
+    def __init__(self, devices: list[DeviceProfile]):
+        self.devices = devices
+
+    async def _get_device_profiles(self, target_devices=None):  # noqa: D401 - matches orchestrator expectations
+        return self.devices
+
+
+class DummyP2PNode:
+    """Stub P2P node capturing network calls."""
+
+    def __init__(self, node_id: str = "dev1"):
+        self.node_id = node_id
+        self.broadcasts = []
+        self.sent_messages = []
+
+    async def send_to_peer(self, device_id, message):  # noqa: D401 - simple passthrough
+        self.sent_messages.append((device_id, message))
+        return True
+
+    async def broadcast_to_peers(self, event, message):  # noqa: D401 - simple passthrough
+        self.broadcasts.append((event, message))
+        return True
+
+
+class DummyResourceMonitor:
+    """Placeholder resource monitor."""
+    pass
+
+
+async def _fast_deploy(self, instance):
+    """Instant local deployment used to speed up tests."""
+    instance.status = "running"
+    instance.last_heartbeat = time.time()
+    instance.resource_usage = {
+        "memory_mb": instance.agent_spec.memory_requirement_mb,
+        "compute": instance.agent_spec.compute_requirement,
+    }
+    return True
+
+
+@pytest.fixture
+def orchestrator_setup(monkeypatch):
+    """Provide a configured orchestrator and its P2P stub."""
+    devices = [
+        DeviceProfile(
+            device_id="dev1",
+            available_memory_mb=8000,
+            compute_score=40,
+            network_latency_ms=10,
+            battery_level=100,
+        ),
+        DeviceProfile(
+            device_id="dev2",
+            available_memory_mb=8000,
+            compute_score=40,
+            network_latency_ms=20,
+            battery_level=100,
+        ),
+    ]
+    sharding = DummyShardingEngine(devices)
+    p2p = DummyP2PNode("dev1")
+    monitor = DummyResourceMonitor()
+    orch = DistributedAgentOrchestrator(p2p, monitor, sharding)
+
+    # Speed up local deployments
+    monkeypatch.setattr(DistributedAgentOrchestrator, "_deploy_agent_locally", _fast_deploy)
+    monkeypatch.setattr(AgentInstance, "__hash__", lambda self: hash(self.instance_id))
+
+    return orch, p2p

--- a/tests/distributed_agents/test_agent_collaboration.py
+++ b/tests/distributed_agents/test_agent_collaboration.py
@@ -1,0 +1,24 @@
+import pytest
+from src.production.distributed_agents.distributed_agent_orchestrator import DistributedAgentOrchestrator
+
+
+@pytest.mark.asyncio
+async def test_agent_collaboration_protocol(orchestrator_setup, monkeypatch):
+    orchestrator, p2p = orchestrator_setup
+    await orchestrator.deploy_agent_constellation()
+
+    # Avoid long running monitor task
+    async def _instant_monitor(self):
+        return
+
+    monkeypatch.setattr(DistributedAgentOrchestrator, "_monitor_agent_collaboration", _instant_monitor)
+
+    await orchestrator.enable_cross_device_collaboration()
+
+    # Verify broadcast of collaboration configuration
+    assert p2p.broadcasts, "No collaboration broadcast was sent"
+    event, payload = p2p.broadcasts[-1]
+    assert event == "ENABLE_AGENT_COLLABORATION"
+    assert payload["type"] == "ENABLE_AGENT_COLLABORATION"
+    assert payload["agent_registry"]
+    assert payload["device_assignments"]

--- a/tests/distributed_agents/test_agent_deployment.py
+++ b/tests/distributed_agents/test_agent_deployment.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cross_device_deployment(orchestrator_setup):
+    orchestrator, _ = orchestrator_setup
+    plan = await orchestrator.deploy_agent_constellation()
+    assert plan is not None
+
+    # Ensure agents were distributed across multiple devices
+    used_devices = [d for d, ids in plan.device_assignments.items() if ids]
+    assert len(used_devices) >= 2
+
+    status = orchestrator.get_deployment_status()
+    assert status["deployed"] is True
+    assert status["devices_used"] >= 2

--- a/tests/distributed_agents/test_agent_migration.py
+++ b/tests/distributed_agents/test_agent_migration.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.production.distributed_agents.agent_migration_manager import (
+    AgentMigrationManager,
+    MigrationReason,
+)
+
+
+@pytest.mark.asyncio
+async def test_agent_migration_stress(orchestrator_setup):
+    orchestrator, p2p = orchestrator_setup
+    await orchestrator.deploy_agent_constellation()
+
+    # Collect a subset of agents that are migratable
+    migratable = [
+        agent_id
+        for agent_id, inst in orchestrator.active_agents.items()
+        if inst.agent_spec.can_migrate
+    ][:5]
+    assert migratable, "No migratable agents available for testing"
+
+    with patch.object(AgentMigrationManager, "_start_background_tasks", lambda self: None):
+        manager = AgentMigrationManager(p2p, orchestrator)
+
+    for agent_id in migratable:
+        await manager.request_migration(agent_id, MigrationReason.LOAD_BALANCING)
+
+    assert manager.stats["migrations_requested"] == len(migratable)
+    assert len(manager.pending_migrations) == len(migratable)


### PR DESCRIPTION
## Summary
- add lightweight agent registry stub to satisfy orchestrator imports
- test cross-device deployment via DistributedAgentOrchestrator
- test collaboration broadcast and migration stress scenarios

## Testing
- `pytest tests/distributed_agents/test_agent_deployment.py tests/distributed_agents/test_agent_collaboration.py tests/distributed_agents/test_agent_migration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d851c6ec8832cb9c63f1e8fc1d529