### PR TITLE
Add security verification script and Bandit config

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,3 @@
+[bandit]
+exclude = tests,experimental,deprecated
+skips = B101,B601

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ pytest tests/performance/
 pytest --cov=src
 ```
 
+## Security Scanning
+
+Run static analysis with [Bandit](https://bandit.readthedocs.io/):
+
+```bash
+bandit --ini .bandit -r src
+```
+
 ## Performance Benchmarking & Stress Testing
 
 Run all sprint benchmarks and aggregate their metrics:

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,0 +1,1 @@
+"""Security utilities and verification tools."""

--- a/src/security/verify_fixes.py
+++ b/src/security/verify_fixes.py
@@ -1,0 +1,69 @@
+"""Verify serialization hardening and TLS configuration.
+
+This module provides runtime checks to ensure that known security
+fixes remain in place. It focuses on two areas:
+
+1. Serialization hardening: uses ``yaml.safe_load`` to protect
+   against execution of arbitrary objects.
+2. TLS configuration: verifies that the default SSL context enforces
+   certificate validation and uses modern TLS versions.
+"""
+
+from __future__ import annotations
+
+import ssl
+from typing import Tuple
+
+import yaml
+
+
+def check_serialization_hardening() -> bool:
+    """Ensure unsafe YAML payloads cannot be deserialized.
+
+    The check attempts to load a payload that would execute a shell
+    command if processed with ``yaml.load``. Using ``yaml.safe_load``
+    should raise a :class:`yaml.constructor.ConstructorError` and
+    prevent the command from running.
+    """
+
+    malicious_payload = "!!python/object/apply:os.system ['echo vulnerable']"
+    try:
+        yaml.safe_load(malicious_payload)
+    except yaml.constructor.ConstructorError:
+        return True
+    except Exception:
+        return False
+    return False
+
+
+def check_tls_configuration() -> bool:
+    """Verify that the default SSL context is hardened.
+
+    The context should enforce certificate validation and restrict the
+    protocol to TLS v1.2 or newer.
+    """
+
+    context = ssl.create_default_context()
+    cert_required = context.verify_mode == ssl.CERT_REQUIRED
+
+    minimum_version = getattr(ssl, "TLSVersion", None)
+    if minimum_version is not None:
+        tls_version_ok = context.minimum_version >= ssl.TLSVersion.TLSv1_2
+    else:
+        tls_version_ok = True  # Python < 3.7 defaults to secure versions
+
+    return cert_required and tls_version_ok
+
+
+def verify_security_fixes() -> Tuple[bool, bool]:
+    """Run all security checks and return their results."""
+
+    return check_serialization_hardening(), check_tls_configuration()
+
+
+if __name__ == "__main__":
+    serialization_ok, tls_ok = verify_security_fixes()
+    print(f"Serialization hardening: {'PASS' if serialization_ok else 'FAIL'}")
+    print(f"TLS configuration: {'PASS' if tls_ok else 'FAIL'}")
+    if not (serialization_ok and tls_ok):
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- implement security verification module for serialization and TLS checks
- add Bandit configuration and document static analysis usage

## Testing
- `ruff format src/security/verify_fixes.py src/security/__init__.py`
- `ruff check src/security/verify_fixes.py src/security/__init__.py`
- `bandit --ini .bandit -r src/security/verify_fixes.py`
- `python src/security/verify_fixes.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agents.king')*
- `pre-commit run --files README.md src/security/__init__.py src/security/verify_fixes.py .bandit` *(fails: InvalidConfigError in .pre-commit-config.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_688d8532dbc4832ca6d592ad8ff7b1f4