### PR TITLE
Add SQLite storage backend for HyperAG MCP server

### DIFF
--- a/src/mcp_servers/hyperag/protocol.py
+++ b/src/mcp_servers/hyperag/protocol.py
@@ -352,8 +352,13 @@ class MCPProtocolHandler:
     ) -> dict[str, Any]:
         """Handle add knowledge request."""
         node_id = str(uuid.uuid4())
+        if not self.storage_backend:
+            raise InternalError("Storage backend not configured")
 
-        # TODO: Implement actual storage
+        await self.storage_backend.add_knowledge(
+            node_id, content, content_type, metadata
+        )
+
         return {
             "node_id": node_id,
             "status": "success",
@@ -371,18 +376,18 @@ class MCPProtocolHandler:
         **kwargs,
     ) -> dict[str, Any]:
         """Handle search knowledge request."""
-        # Mock search results
-        results = [
-            {
-                "id": f"node_{i}",
-                "content": f"Search result {i} for: {query}",
-                "relevance": 0.9 - (i * 0.1),
-                "metadata": {"type": "document"},
-            }
-            for i in range(min(limit, 3))
-        ]
+        if not self.storage_backend:
+            raise InternalError("Storage backend not configured")
 
-        return {"results": results, "total_count": len(results), "query": query}
+        results = await self.storage_backend.search_knowledge(
+            query, limit, filters
+        )
+
+        return {
+            "results": results,
+            "total_count": len(results),
+            "query": query,
+        }
 
     @require_permission(HypeRAGPermissions.WRITE)
     @audit_operation("update_knowledge")
@@ -395,7 +400,13 @@ class MCPProtocolHandler:
         **kwargs,
     ) -> dict[str, Any]:
         """Handle update knowledge request."""
-        # TODO: Implement actual update
+        if not self.storage_backend:
+            raise InternalError("Storage backend not configured")
+
+        await self.storage_backend.update_knowledge(
+            node_id, content=content, metadata=metadata
+        )
+
         return {
             "node_id": node_id,
             "status": "success",
@@ -408,7 +419,11 @@ class MCPProtocolHandler:
         self, context: AuthContext, node_id: str, **kwargs
     ) -> dict[str, Any]:
         """Handle delete knowledge request."""
-        # TODO: Implement actual deletion
+        if not self.storage_backend:
+            raise InternalError("Storage backend not configured")
+
+        await self.storage_backend.delete_knowledge(node_id)
+
         return {
             "node_id": node_id,
             "status": "success",

--- a/src/mcp_servers/hyperag/server.py
+++ b/src/mcp_servers/hyperag/server.py
@@ -23,6 +23,7 @@ from .auth import (
 )
 from .models import ModelRegistry
 from .protocol import MCPProtocolHandler, MCPRequest
+from .storage import SQLiteStorage
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ class HypeRAGMCPServer:
         self.config = {}
         self.permission_manager: PermissionManager | None = None
         self.model_registry: ModelRegistry | None = None
+        self.storage_backend: SQLiteStorage | None = None
         self.protocol_handler: MCPProtocolHandler | None = None
         self.server = None
         self.start_time = time.time()
@@ -61,11 +63,14 @@ class HypeRAGMCPServer:
         # Initialize model registry
         self.model_registry = ModelRegistry()
 
+        # Initialize storage backend
+        self.storage_backend = SQLiteStorage()
+
         # Initialize protocol handler
         self.protocol_handler = MCPProtocolHandler(
             permission_manager=self.permission_manager,
             model_registry=self.model_registry,
-            storage_backend=None,  # TODO: Initialize storage backend
+            storage_backend=self.storage_backend,
         )
 
         # Set start time for metrics

--- a/src/mcp_servers/hyperag/storage/__init__.py
+++ b/src/mcp_servers/hyperag/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage backends for HyperAG MCP server."""
+
+from .sqlite_storage import SQLiteStorage
+
+__all__ = ["SQLiteStorage"]

--- a/src/mcp_servers/hyperag/storage/sqlite_storage.py
+++ b/src/mcp_servers/hyperag/storage/sqlite_storage.py
@@ -1,0 +1,128 @@
+"""SQLite-based storage backend for HyperAG MCP server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+class SQLiteStorage:
+    """Simple SQLite storage backend for knowledge items."""
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self.conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS knowledge (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                content_type TEXT NOT NULL,
+                metadata TEXT
+            )
+            """
+        )
+        self.conn.commit()
+
+    async def add_knowledge(
+        self,
+        node_id: str,
+        content: str,
+        content_type: str = "text",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        def _insert() -> None:
+            cur = self.conn.cursor()
+            cur.execute(
+                "INSERT INTO knowledge (id, content, content_type, metadata) VALUES (?, ?, ?, ?)",
+                (node_id, content, content_type, json.dumps(metadata or {})),
+            )
+            self.conn.commit()
+
+        await asyncio.to_thread(_insert)
+
+    async def get_knowledge(self, node_id: str) -> Optional[Dict[str, Any]]:
+        def _get() -> Optional[Dict[str, Any]]:
+            cur = self.conn.cursor()
+            cur.execute(
+                "SELECT id, content, content_type, metadata FROM knowledge WHERE id=?",
+                (node_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            node_id, content, content_type, metadata = row
+            return {
+                "id": node_id,
+                "content": content,
+                "content_type": content_type,
+                "metadata": json.loads(metadata) if metadata else {},
+            }
+
+        return await asyncio.to_thread(_get)
+
+    async def search_knowledge(
+        self,
+        query: str,
+        limit: int = 10,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        like_query = f"%{query}%"
+
+        def _search() -> List[Dict[str, Any]]:
+            cur = self.conn.cursor()
+            cur.execute(
+                "SELECT id, content, content_type, metadata FROM knowledge WHERE content LIKE ? LIMIT ?",
+                (like_query, limit),
+            )
+            rows = cur.fetchall()
+            results = []
+            for row in rows:
+                node_id, content, content_type, metadata = row
+                results.append(
+                    {
+                        "id": node_id,
+                        "content": content,
+                        "content_type": content_type,
+                        "metadata": json.loads(metadata) if metadata else {},
+                        "relevance": 1.0,
+                    }
+                )
+            return results
+
+        return await asyncio.to_thread(_search)
+
+    async def update_knowledge(
+        self,
+        node_id: str,
+        content: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        def _update() -> None:
+            cur = self.conn.cursor()
+            if content is not None:
+                cur.execute("UPDATE knowledge SET content=? WHERE id=?", (content, node_id))
+            if metadata is not None:
+                cur.execute(
+                    "UPDATE knowledge SET metadata=? WHERE id=?",
+                    (json.dumps(metadata), node_id),
+                )
+            self.conn.commit()
+
+        await asyncio.to_thread(_update)
+
+    async def delete_knowledge(self, node_id: str) -> None:
+        def _delete() -> None:
+            cur = self.conn.cursor()
+            cur.execute("DELETE FROM knowledge WHERE id=?", (node_id,))
+            self.conn.commit()
+
+        await asyncio.to_thread(_delete)
+
+    async def close(self) -> None:
+        await asyncio.to_thread(self.conn.close)

--- a/tests/mcp_servers/hyperag/__init__.py
+++ b/tests/mcp_servers/hyperag/__init__.py
@@ -1,0 +1,1 @@
+# Tests for hyperag MCP server storage functionality

--- a/tests/mcp_servers/hyperag/test_storage_protocol.py
+++ b/tests/mcp_servers/hyperag/test_storage_protocol.py
@@ -1,0 +1,97 @@
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+sys.modules.pop("mcp_servers", None)
+sys.modules.pop("mcp_servers.hyperag", None)
+
+from mcp_servers.hyperag.auth import AuthContext, HypeRAGPermissions, PermissionManager
+from mcp_servers.hyperag.models import ModelRegistry
+from mcp_servers.hyperag.protocol import MCPProtocolHandler
+from mcp_servers.hyperag.storage import SQLiteStorage
+
+
+@pytest_asyncio.fixture
+async def protocol_handler():
+    permission_manager = PermissionManager(jwt_secret="test", enable_audit=False)
+    storage = SQLiteStorage()
+    model_registry = ModelRegistry()
+    handler = MCPProtocolHandler(
+        permission_manager=permission_manager,
+        model_registry=model_registry,
+        storage_backend=storage,
+    )
+    yield handler, storage
+    await storage.close()
+
+
+@pytest.fixture
+def auth_context():
+    return AuthContext(
+        user_id="user",
+        agent_id="user",
+        role="admin",
+        permissions={HypeRAGPermissions.READ, HypeRAGPermissions.WRITE},
+        session_id="sess",
+        expires_at=datetime.now() + timedelta(hours=1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_and_search(protocol_handler, auth_context):
+    handler, storage = protocol_handler
+
+    add_result = await handler.handle_add_knowledge(
+        auth_context, content="hello world", content_type="text"
+    )
+    node_id = add_result["node_id"]
+
+    search_result = await handler.handle_search_knowledge(
+        auth_context, query="hello"
+    )
+
+    assert search_result["total_count"] == 1
+    assert search_result["results"][0]["id"] == node_id
+
+
+@pytest.mark.asyncio
+async def test_update(protocol_handler, auth_context):
+    handler, storage = protocol_handler
+
+    add_result = await handler.handle_add_knowledge(
+        auth_context, content="foo", content_type="text"
+    )
+    node_id = add_result["node_id"]
+
+    await handler.handle_update_knowledge(
+        auth_context, node_id=node_id, content="bar"
+    )
+
+    search_result = await handler.handle_search_knowledge(
+        auth_context, query="bar"
+    )
+
+    assert search_result["total_count"] == 1
+    assert search_result["results"][0]["content"] == "bar"
+
+
+@pytest.mark.asyncio
+async def test_delete(protocol_handler, auth_context):
+    handler, storage = protocol_handler
+
+    add_result = await handler.handle_add_knowledge(
+        auth_context, content="to delete", content_type="text"
+    )
+    node_id = add_result["node_id"]
+
+    await handler.handle_delete_knowledge(auth_context, node_id=node_id)
+
+    search_result = await handler.handle_search_knowledge(
+        auth_context, query="to delete"
+    )
+
+    assert search_result["total_count"] == 0


### PR DESCRIPTION
## Summary
- implement async SQLiteStorage backend for knowledge records
- wire storage backend into HypeRAGMCPServer and MCPProtocolHandler CRUD operations
- add tests verifying storage CRUD via protocol handler

## Testing
- `pytest tests/mcp_servers/hyperag/test_storage_protocol.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688df3689128832ca553ba813a356634