### PR TITLE
Track consolidation stats and expose memory usage

### DIFF
--- a/tests/mcp_servers/hyperag/test_hippo_index_stats.py
+++ b/tests/mcp_servers/hyperag/test_hippo_index_stats.py
@@ -1,0 +1,31 @@
+import duckdb
+import pytest
+from datetime import datetime
+
+from src.mcp_servers.hyperag.memory.hippo_index import HippoIndex, HippoNode
+
+
+@pytest.mark.asyncio
+async def test_memory_stats_include_usage_and_consolidation(tmp_path):
+    db_path = tmp_path / "hippo.duckdb"
+    index = HippoIndex(db_path=str(db_path))
+    index.duckdb_conn = duckdb.connect(str(db_path))
+    await index._setup_duckdb_schema()
+
+    node = HippoNode("test content")
+    index.duckdb_conn.execute(
+        "INSERT INTO hippo_nodes (id, content, node_type, memory_type) VALUES (?, ?, ?, ?)",
+        [node.id, node.content, node.node_type, node.memory_type.value],
+    )
+
+    class DummyConsolidator:
+        def __init__(self):
+            self.last_consolidation = datetime.now()
+            self.pending_consolidations = 3
+
+    index.set_consolidator(DummyConsolidator())
+    stats = await index.get_memory_stats()
+    assert stats.total_nodes > 0
+    assert stats.memory_usage_mb > 0
+    assert stats.last_consolidation is not None
+    assert stats.pending_consolidations == 3


### PR DESCRIPTION
## Summary
- compute DuckDB file size for HippoIndex memory stats and surface consolidator info
- track pending consolidation batches in MemoryConsolidator and expose via status
- test HippoIndex stats for non-zero usage and consolidation fields

## Testing
- `pytest tests/mcp_servers/hyperag/test_hippo_index_stats.py -q`
- `pre-commit run --files src/mcp_servers/hyperag/memory/hippo_index.py src/mcp_servers/hyperag/memory/consolidator.py tests/mcp_servers/hyperag/__init__.py tests/mcp_servers/hyperag/test_hippo_index_stats.py` *(fails: InvalidConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_688df369c358832c96f636fcbec29b62