### PR TITLE
Connect query handling to stored knowledge and reasoning models

### DIFF
--- a/tests/mcp_servers/hyperag/test_query_integration.py
+++ b/tests/mcp_servers/hyperag/test_query_integration.py
@@ -1,0 +1,62 @@
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+# Ensure src is on path and modules reloaded
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+sys.modules.pop("mcp_servers", None)
+sys.modules.pop("mcp_servers.hyperag", None)
+
+from mcp_servers.hyperag.auth import AuthContext, HypeRAGPermissions, PermissionManager
+from mcp_servers.hyperag.models import ModelRegistry
+from mcp_servers.hyperag.protocol import MCPProtocolHandler
+from mcp_servers.hyperag.storage import SQLiteStorage
+
+
+@pytest_asyncio.fixture
+async def protocol_handler():
+    permission_manager = PermissionManager(jwt_secret="test", enable_audit=False)
+    storage = SQLiteStorage()
+    model_registry = ModelRegistry()
+    handler = MCPProtocolHandler(
+        permission_manager=permission_manager,
+        model_registry=model_registry,
+        storage_backend=storage,
+    )
+    yield handler, storage
+    await storage.close()
+
+
+@pytest.fixture
+def auth_context():
+    return AuthContext(
+        user_id="user",
+        agent_id="user",
+        role="default",
+        permissions={HypeRAGPermissions.READ, HypeRAGPermissions.WRITE},
+        session_id="sess",
+        expires_at=datetime.now() + timedelta(hours=1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_query_end_to_end(protocol_handler, auth_context):
+    handler, _ = protocol_handler
+
+    await handler.handle_add_knowledge(
+        auth_context,
+        content="Paris is the capital of France",
+        content_type="text",
+    )
+
+    result = await handler.handle_query(
+        auth_context,
+        query="capital of France",
+    )
+
+    assert result["status"] == "success"
+    assert "Paris" in result["result"]["answer"]
+    assert result["result"]["sources"]


### PR DESCRIPTION
## Summary
- Implement real retrieval, graph construction, and reasoning in the MCP HyperAG protocol
- Wire query handling to ModelRegistry and storage backend for live content
- Add integration test validating end-to-end query flow

## Testing
- `pytest tests/mcp_servers/hyperag/test_query_integration.py -q`
- `pytest tests/mcp_servers/hyperag/test_storage_protocol.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688dfa243c64832c8170b7eea322e0e8