### PR TITLE
Add tracking for fallback metrics

### DIFF
--- a/src/mcp_servers/hyperag/guardian/metrics.py
+++ b/src/mcp_servers/hyperag/guardian/metrics.py
@@ -28,12 +28,19 @@ except ImportError:
             self.gauge_value = 0.0
             self.info_data = {}
             self._warn_once = False
+            self.calls = {
+                "inc": 0,
+                "observe": 0,
+                "set": 0,
+                "info": 0,
+            }
             
             # Store in class registry
             MockMetric._instances[name] = self
             
         def inc(self, amount=1, **labels):
             """Increment counter with label tracking."""
+            self.calls["inc"] += 1
             if not self._warn_once:
                 logger.warning(
                     f"Metric '{self.name}' using MockMetric fallback. "
@@ -56,6 +63,7 @@ except ImportError:
 
         def observe(self, amount, **labels):
             """Record observation with statistical tracking."""
+            self.calls["observe"] += 1
             if not self._warn_once:
                 logger.warning(
                     f"Metric '{self.name}' using MockMetric fallback. "
@@ -79,6 +87,7 @@ except ImportError:
 
         def set(self, value, **labels):
             """Set gauge value with change tracking."""
+            self.calls["set"] += 1
             if not self._warn_once:
                 logger.warning(
                     f"Metric '{self.name}' using MockMetric fallback. "
@@ -97,6 +106,7 @@ except ImportError:
 
         def info(self, info_dict):
             """Store info metric data."""
+            self.calls["info"] += 1
             if not self._warn_once:
                 logger.warning(
                     f"Metric '{self.name}' using MockMetric fallback. "

--- a/tests/mcp_servers/test_guardian_mock_metric.py
+++ b/tests/mcp_servers/test_guardian_mock_metric.py
@@ -1,0 +1,44 @@
+import importlib.util
+import sys
+import builtins
+from pathlib import Path
+
+
+# Path to metrics module
+ROOT = Path(__file__).resolve().parents[2]
+METRICS_PATH = ROOT / "src" / "mcp_servers" / "hyperag" / "guardian" / "metrics.py"
+
+
+def test_mock_metric_records_calls(monkeypatch):
+    """Ensure MockMetric tracks metric operations when Prometheus is unavailable."""
+    # Force prometheus_client import to fail
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "prometheus_client":
+            raise ImportError("prometheus_client not installed")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "prometheus_client", raising=False)
+
+    spec = importlib.util.spec_from_file_location("guardian_metrics", METRICS_PATH)
+    metrics = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(metrics)
+    mock_cls = metrics.MockMetric
+
+    metric = mock_cls("test_metric")
+    metric.inc()
+    metric.observe(1.0)
+    metric.set(5)
+    metric.info({"foo": "bar"})
+
+    assert metric.calls["inc"] == 1
+    assert metric.calls["observe"] == 1
+    assert metric.calls["set"] == 1
+    assert metric.calls["info"] == 1
+
+    assert metric.counters[frozenset()] == 1
+    assert metric.values == [1.0]
+    assert metric.gauge_value == 5.0
+    assert metric.info_data["foo"] == "bar"


### PR DESCRIPTION
## Summary
- track MockMetric method invocations using in-memory counters so mock metrics capture increments, observations, gauge updates and info
- add unit test confirming fallback metrics record calls when Prometheus client is unavailable

## Testing
- `pytest tests/mcp_servers/test_guardian_mock_metric.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e18608e64832cb5f75f450c1697f1