### PR TITLE
docs: update rag api info and mark cli experimental

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -35,7 +35,7 @@ This directory contains comprehensive API documentation for all AIVillage compon
 | [P2P Network](core/p2p/README.md) | Distributed communication layer | ✅ Complete |
 | [Compression](production/compression/README.md) | Model compression (4x ratio) | ✅ Complete |
 | [Evolution](production/evolution/README.md) | Agent self-improvement | ✅ Complete |
-| [RAG System](production/rag/README.md) | Knowledge retrieval (<1ms) | ✅ Complete |
+| [RAG System](production/rag/README.md) | Retrieval-augmented generation pipeline | 🟡 Partial |
 | [Federated Learning](production/federated_learning/README.md) | Privacy-preserving training | ✅ Complete |
 | [Resource Management](core/resources/README.md) | Device profiling and constraints | ✅ Complete |
 
@@ -94,6 +94,11 @@ pipeline = CompressionPipeline(config)
 result = await pipeline.compress_model()
 
 print(f"Compression ratio: {result.compression_ratio}x")
+```
+
+### Querying the RAG System
+```bash
+python -m src.production.rag.rag_system.main query --question "What is RAG?"
 ```
 
 ## Development

--- a/src/production/rag/rag_system/main.py
+++ b/src/production/rag/rag_system/main.py
@@ -6,12 +6,20 @@ handling document indexing, querying, and knowledge management.
 """
 
 import argparse
+import asyncio
 import sys
+
+try:  # pragma: no cover - import guard for optional dependencies
+    from rag_system.core.pipeline import EnhancedRAGPipeline
+except Exception:  # pragma: no cover - import guard
+    EnhancedRAGPipeline = None
 
 
 def create_parser():
     """Create argument parser for RAG system"""
-    parser = argparse.ArgumentParser(description="RAG System Service")
+    parser = argparse.ArgumentParser(
+        description="Experimental RAG System Service"
+    )
 
     parser.add_argument(
         "action",
@@ -42,8 +50,26 @@ def query_system(args):
         print("Error: --question is required for query action")
         return 1
 
+    if EnhancedRAGPipeline is None:
+        print("EnhancedRAGPipeline is unavailable; CLI is experimental.")
+        return 1
+
     print(f"Querying: {args.question}")
-    # Implementation would go here
+
+    async def _run_query(question: str):
+        pipeline = EnhancedRAGPipeline()
+        await pipeline.initialize()
+        result = await pipeline.process(question)
+        await pipeline.shutdown()
+        return result
+
+    try:
+        result = asyncio.run(_run_query(args.question))
+    except Exception as exc:  # pragma: no cover - runtime safety
+        print(f"RAG query failed: {exc}")
+        return 1
+
+    print(result)
     return 0
 
 
@@ -53,9 +79,8 @@ def index_document(args):
         print("Error: --document is required for index action")
         return 1
 
-    print(f"Indexing document: {args.document}")
-    # Implementation would go here
-    return 0
+    print("Document indexing is experimental and not yet implemented.")
+    return 1
 
 
 def search_documents(args):
@@ -64,9 +89,8 @@ def search_documents(args):
         print("Error: --question is required for search action")
         return 1
 
-    print(f"Searching for: {args.question}")
-    # Implementation would go here
-    return 0
+    print("Document search is experimental and not yet implemented.")
+    return 1
 
 
 def get_status(args):
@@ -77,9 +101,8 @@ def get_status(args):
 
 def configure_service(args):
     """Configure service"""
-    print("Configuring RAG system...")
-    # Implementation would go here
-    return 0
+    print("Service configuration is experimental and not yet implemented.")
+    return 1
 
 
 def main(args=None):


### PR DESCRIPTION
## Summary
- document RAG pipeline as partial and add CLI usage example
- guard RAG CLI to handle missing EnhancedRAGPipeline and mark other actions experimental

## Testing
- `PYTHONPATH=src/production/rag pytest tests/test_bayesnet.py src/production/rag/test_pipeline.py` *(fails: ModuleNotFoundError: No module named 'core.evidence')*
- `PYTHONPATH=src/production/rag pytest src/production/rag/test_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_688f27a7ef44832ca230608356157d0b