### PR TITLE
doc: update status and links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,33 +6,31 @@ Welcome to the AIVillage documentation. This directory contains comprehensive do
 
 ### 📐 Architecture
 Core system architecture, design decisions, and component relationships.
-- [System Overview](architecture/system_overview.md)
-- [Architecture Documentation](architecture/architecture.md)
-- [Design Documents](architecture/design/)
+- [Architecture Overview](architecture/architecture_1.md)
+- [Updated Architecture](architecture/architecture_updated_1.md)
+- [Index](architecture/index_1.md)
 
 ### 📚 Guides
 Step-by-step guides for setup, configuration, and usage.
-- [Onboarding Guide](guides/onboarding.md)
-- [Advanced Setup](guides/advanced_setup.md)
-- [Usage Examples](guides/usage_examples.md)
-- [Migration Notes](guides/migration_notes.md)
+- [Development Guide](guides/DEVELOPMENT.md)
+- [Advanced Setup](guides/advanced_setup_1.md)
+- [Usage Examples](guides/usage_examples_1.md)
 
 ### 🔌 API Reference
 API documentation, specifications, and interface definitions.
-- [API Documentation](api/API_DOCUMENTATION.md)
-- [Specifications](api/specs/)
+- [API Documentation](api/API_DOCUMENTATION_1.md)
 
 ### 🧩 Components
 Documentation for individual system components and modules.
-- [Mesh Network](components/mesh/)
-- [RAG System](components/rag/)
-- [Agent Forge Pipeline](components/agent_forge_pipeline_overview.md)
+- [Mesh Network](components/mesh-network-engineer_1.md)
+- [RAG System](rag_system_explainer.txt)
+- [Agent Forge Pipeline](components/agent_forge_pipeline_overview_1.md)
 
 ### 🛠️ Development
 Development workflows, testing, and contribution guidelines.
-- [Branching Strategy](development/BRANCHING_STRATEGY.md)
-- [Testing Best Practices](development/testing-best-practices.md)
-- [Integration Testing](development/SMOKE_TEST_INTEGRATION.md)
+- [Branching Strategy](development/BRANCHING_STRATEGY_1.md)
+- [Testing Best Practices](development/testing-best-practices_1.md)
+- [Integration Testing](development/SMOKE_TEST_INTEGRATION_1.md)
 - [Cleanup Verification](development/cleanup_verification.md)
 
 ### 📋 Reference

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -29,15 +29,19 @@ This directory contains comprehensive API documentation for all AIVillage compon
 
 ## Quick Navigation
 
+Statuses reflect the current implementation progress documented in
+[../HONEST_STATUS.md](../HONEST_STATUS.md) and the project
+[README](../../README.md).
+
 | Component | Description | Status |
 |-----------|-------------|--------|
-| [Agent Forge](agent_forge/README.md) | Agent template system and orchestration | ✅ Complete |
-| [P2P Network](core/p2p/README.md) | Distributed communication layer | ✅ Complete |
-| [Compression](production/compression/README.md) | Model compression (4x ratio) | ✅ Complete |
-| [Evolution](production/evolution/README.md) | Agent self-improvement | ✅ Complete |
+| [Agent Forge](agent_forge/README.md) | Agent template system and orchestration | 🟡 Partial |
+| [P2P Network](core/p2p/README.md) | Distributed communication layer | 🟡 Partial |
+| [Compression](production/compression/README.md) | Model compression pipeline | 🟡 Partial |
+| [Evolution](production/evolution/README.md) | Agent self-improvement | 🟡 Partial |
 | [RAG System](production/rag/README.md) | Retrieval-augmented generation pipeline | 🟡 Partial |
-| [Federated Learning](production/federated_learning/README.md) | Privacy-preserving training | ✅ Complete |
-| [Resource Management](core/resources/README.md) | Device profiling and constraints | ✅ Complete |
+| [Federated Learning](production/federated_learning/README.md) | Privacy-preserving training | 🟡 Partial |
+| [Resource Management](core/resources/README.md) | Device profiling and constraints | 🟡 Partial |
 
 ## Usage Examples
 


### PR DESCRIPTION
## Summary
- Mark all API components as partial and remove unverified compression claims
- Refresh documentation index with valid architecture, guide, component, and development links

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agents.king')*

------
https://chatgpt.com/codex/tasks/task_e_688f53ffcc70832cbb162443c99bb8d0