### PR TITLE
chore: overhaul development infrastructure

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203, W503
+exclude = .git,__pycache__,build,dist,venv

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - run: pip install -r requirements-dev.txt
+      - run: pre-commit run --all-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-test.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - run: pip install -r requirements.txt
+      - run: pip install -r requirements-test.txt
+      - run: pytest tests/ -v

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+profile = black
+line_length = 120
+known_first_party = src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -18,17 +18,10 @@ repos:
         exclude: ^(.*\.jsonc|mcp_config\.json)$
 
   - repo: https://github.com/psf/black
-    rev: 24.1.0
+    rev: 24.8.0
     hooks:
       - id: black
         args: [--line-length=120]
-        language_version: python3.10
-
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.11
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix, --line-length=120]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
@@ -36,8 +29,21 @@ repos:
       - id: isort
         args: [--profile=black, --line-length=120]
 
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.0
+    hooks:
+      - id: flake8
+        args: [--max-line-length=120]
+        additional_dependencies: [flake8-bugbear]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.1
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix, --line-length=120]
+
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.11.1
     hooks:
       - id: mypy
         additional_dependencies: [types-all]
@@ -45,7 +51,7 @@ repos:
         exclude: ^(tests/|deprecated/|experimental/)
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.7.7
     hooks:
       - id: bandit
         args: [-r, src/, -f, txt, --skip, B101,B601]
@@ -59,6 +65,9 @@ repos:
         language: system
         files: \.py$
         exclude: ^(tests/|deprecated/|experimental/)
+
+default_language_version:
+  python: python3
 
 ci:
   autofix_commit_msg: |

--- a/INFRASTRUCTURE_FIXES.md
+++ b/INFRASTRUCTURE_FIXES.md
@@ -1,0 +1,21 @@
+# Development Infrastructure Fixes
+
+## Summary
+- Updated `.pre-commit-config.yaml` to use flexible `python3` interpreter, added `default_language_version`, and included standard hooks such as `flake8`.
+- Relaxed Python requirement in `pyproject.toml` to `>=3.8` and aligned tool configurations.
+- Added `.flake8` and `.isort.cfg` for consistent linting.
+- Replaced `Makefile` with a universal template exposing common targets.
+- Created root `requirements-dev.txt` and `requirements-test.txt` for development and testing dependencies.
+- Added helper scripts in `scripts/` and top-level `validate_infrastructure.sh`.
+- Generated `INFRASTRUCTURE_STATUS.md` to document current infrastructure state.
+
+## Usage
+1. Run `scripts/setup.sh` to install dependencies.
+2. Use `make lint` and `make test` for checks.
+3. `scripts/ci_test.sh` mirrors CI pipeline locally.
+4. Execute `validate_infrastructure.sh` to verify tooling.
+
+## Troubleshooting
+- If hooks fail due to formatting, run `make format` to auto-format.
+- Ensure Python 3.8+ is installed and accessible as `python3`.
+- Install missing tools with `pip install -r requirements-dev.txt`.

--- a/INFRASTRUCTURE_STATUS.md
+++ b/INFRASTRUCTURE_STATUS.md
@@ -1,0 +1,32 @@
+# Development Infrastructure Status
+
+This document lists key configuration files and scripts in the repository as of this audit.
+
+## Configuration Files
+
+- `.pre-commit-config.yaml` – **broken**: pinned to `python3.10` and missing default language version.
+- `pyproject.toml` – **outdated**: restricts to Python 3.10+, tool configs inconsistent.
+- `setup.py` – **present**: needs Python version flexibility review.
+- `Makefile` – **outdated**: custom targets, lacks standardized commands.
+- `.github/workflows/` – **varied**: multiple workflows; many use older GitHub action versions.
+- `requirements.txt` – **present**: contains both core and dev dependencies.
+- `requirements/requirements-dev.txt` – **present**: development dependencies.
+- `requirements/requirements-test.txt` – **present**: testing dependencies.
+- Shell scripts in `scripts/` – **mixed**: many lack shebang or safe flags.
+
+## Python Version Requirements
+
+Current configurations often require **Python 3.10+**, which causes issues on environments with only `python3` available. Goal is to support **Python 3.8+**.
+
+## Dependencies
+
+Development tools expected:
+- `pre-commit`
+- `black`
+- `isort`
+- `flake8`
+- `mypy`
+- `pytest`
+
+These should be installed via `requirements-dev.txt` and `requirements-test.txt`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 maintainers = [
     {name = "AIVillage Team", email = "team@aivillage.dev"}
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 readme = "README.md"
 license = {file = "LICENSE"}
 keywords = ["ai", "multi-agent", "evolutionary", "machine-learning", "transformers"]
@@ -19,6 +19,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -264,8 +266,8 @@ known-first-party = ["agents", "communications", "core", "agent_forge", "utils",
 force-sort-within-sections = true
 
 [tool.black]
-line-length = 88
-target-version = ['py310', 'py311', 'py312']
+line-length = 120
+target-version = ['py38'] 
 include = '\.pyi?$'
 extend-exclude = '''
 # Exclude generated files
@@ -286,7 +288,7 @@ extend-exclude = '''
 '''
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.8"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+pre-commit
+black
+isort
+flake8
+flake8-bugbear
+mypy
+ruff
+bandit

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$dir"
+
+python -m build

--- a/scripts/ci_test.sh
+++ b/scripts/ci_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running CI test suite locally..."
+
+pre-commit run --all-files
+pytest tests/ --cov=src --cov-report=term-missing
+mypy src/ --ignore-missing-imports
+bandit -r src/ || true
+pip list --outdated
+
+echo "CI test suite complete!"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$dir"
+
+find . -type d -name __pycache__ -exec rm -rf {} +
+find . -type f -name "*.pyc" -delete
+rm -rf .pytest_cache .coverage htmlcov/ dist/ build/

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$dir"
+
+pre-commit run --all-files

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$dir"
+
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+pre-commit install

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON:-python3}"
+VENV_DIR=".venv"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "Python not found" >&2
+  exit 1
+fi
+
+$PYTHON_BIN -m venv "$VENV_DIR"
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install -r requirements.txt
+pip install -r requirements-dev.txt -r requirements-test.txt
+pre-commit install
+
+pytest tests/ || true
+
+echo "Development environment ready using $($PYTHON_BIN --version)"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$dir"
+
+pytest tests/ -v

--- a/validate_infrastructure.sh
+++ b/validate_infrastructure.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Validating development infrastructure..."
+
+python --version || { echo "Python not found"; exit 1; }
+pre-commit --version || { echo "pre-commit not installed"; exit 1; }
+pre-commit run --all-files || { echo "Pre-commit hooks failed"; exit 1; }
+pytest tests/ || { echo "Tests failed"; exit 1; }
+
+for script in scripts/*.sh; do
+    [ -x "$script" ] || { echo "$script not executable"; exit 1; }
+done
+
+echo "✅ Infrastructure validation complete!"


### PR DESCRIPTION
## Summary
- generalize pre-commit to python3 and add standard hooks
- relax python requirement to >=3.8 and standardize lint configs
- add scripts, requirements files and CI workflows for lint and tests

## Testing
- `pre-commit run --all-files` *(fails: Interrupted (KeyboardInterrupt))*
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'AIVillage')*

------
https://chatgpt.com/codex/tasks/task_e_6891505d420c832c8c3d43d6392288c1