### PR TITLE
Add anthropic dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ datasets>=2.20.0
 huggingface-hub>=0.24.5
 sentence-transformers>=3.0.1
 peft>=0.12.0
+anthropic>=0.28.0
 
 # Vector Search & Embeddings
 faiss-cpu>=1.8.0


### PR DESCRIPTION
## Summary
- add anthropic to consolidated requirements
- verify wave_bridge modules import anthropic

## Testing
- `pytest experimental/services/services/wave_bridge/test_integration.py -q` *(fails: wandb.errors.errors.Error: You must call wandb.init() before wandb.config.update)*

------
https://chatgpt.com/codex/tasks/task_e_68940239159c832c94f3c5388d9eacb6