### PR TITLE
Pin grokfast dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ dependencies = [
     # Compatibility & Type Support
     "typing-extensions>=4.12.2",
     "packaging>=24.1",
+    "grokfast @ git+https://github.com/ironjr/grokfast@5d6e21c",
 ]
 
 [project.optional-dependencies]
@@ -323,7 +324,7 @@ module = [
     "gym.*",
     "mcts.*",
     "llama_cpp.*",
-    "grokfast.*",
+    "grokfast",
     "sleep_and_dream.*",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- Pin Grokfast dependency via git commit instead of wildcard.
- Refine mypy overrides to reference Grokfast package explicitly.

## Testing
- `pytest tests/test_grokfast_opt.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689402530c0c832cbf8d63dbb5204471