### PR TITLE
Handle missing Foundation in device profiler

### DIFF
--- a/src/production/monitoring/mobile/device_profiler.py
+++ b/src/production/monitoring/mobile/device_profiler.py
@@ -14,6 +14,14 @@ from typing import Any
 import psutil
 
 # Platform-specific imports
+ANDROID_AVAILABLE = False
+MACOS_AVAILABLE = False
+
+# Default fallbacks for macOS-specific modules
+NSBundle = None  # type: ignore[assignment]
+NSProcessInfo = None  # type: ignore[assignment]
+objc = None  # type: ignore[assignment]
+
 if platform.system() == "Android":
     try:
         from jnius import autoclass
@@ -24,18 +32,16 @@ if platform.system() == "Android":
         ThermalManager = autoclass("android.os.ThermalManager")
         ANDROID_AVAILABLE = True
     except ImportError:
-        ANDROID_AVAILABLE = False
+        pass
 elif platform.system() == "Darwin":  # iOS/macOS
     try:
-        from Foundation import NSBundle, NSProcessInfo
-        import objc
+        from Foundation import NSBundle, NSProcessInfo  # type: ignore
+        import objc  # type: ignore
 
         MACOS_AVAILABLE = True
     except ImportError:
+        # Fallback when Foundation isn't available (e.g., non-macOS platforms)
         MACOS_AVAILABLE = False
-else:
-    ANDROID_AVAILABLE = False
-    MACOS_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- Gracefully handle missing macOS Foundation modules when running on non-macOS systems by providing fallback `None` values and setting availability flags.

## Testing
- `pytest tests/production -q` *(fails: `PydanticUserError: `@validator` cannot be applied to instance methods`, `TypeError: unsupported operand type(s) for |: 'builtin_function_or_method' and 'NoneType'`)*

------
https://chatgpt.com/codex/tasks/task_e_68940258fb74832cb51e618065668e81