### PR TITLE
Add helper to list required agent types

### DIFF
--- a/tests/test_required_agent_types.py
+++ b/tests/test_required_agent_types.py
@@ -1,0 +1,8 @@
+from src.production.agent_forge.agent_factory import AgentFactory
+
+
+def test_required_agent_types_count():
+    factory = AgentFactory()
+    agent_types = factory.required_agent_types()
+    assert len(agent_types) == 18
+    assert len(set(agent_types)) == 18


### PR DESCRIPTION
## Summary
- allow AgentFactory to locate template directory relative to itself when none supplied
- expose new `required_agent_types` helper that validates and returns 18 agent identifiers
- test that factory reports all 18 unique agent types

## Testing
- `pytest tests/test_required_agent_types.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68940285b43c832c9cbbc8db7d7f008b