### PR TITLE
Respect network size in evolution peer selection

### DIFF
--- a/src/core/p2p/p2p_node.py
+++ b/src/core/p2p/p2p_node.py
@@ -573,7 +573,9 @@ class P2PNode:
         # Sort by evolution priority
         suitable_peers.sort(key=lambda p: p.get_evolution_priority(), reverse=True)
 
-        return suitable_peers[: max(min_count, 5)]  # Return top 5 or min_count
+        # Respect actual network size instead of capping to a fixed number
+        network_size = len(suitable_peers)
+        return suitable_peers[: max(min_count, network_size)]
 
     def get_network_status(self) -> dict[str, Any]:
         """Get comprehensive network status."""

--- a/tests/unit/core/test_evolution_peers.py
+++ b/tests/unit/core/test_evolution_peers.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+
+# Ensure src package is importable
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.core.p2p.p2p_node import P2PNode, PeerCapabilities
+
+
+def create_peer(idx: int) -> PeerCapabilities:
+    return PeerCapabilities(
+        device_id=f"peer-{idx}",
+        cpu_cores=4,
+        ram_mb=8192,
+        battery_percent=80,
+        network_type="wifi",
+    )
+
+
+def test_get_suitable_evolution_peers_respects_network_size():
+    node = P2PNode(node_id="test-node")
+
+    # Add more than five peers to the registry
+    for i in range(7):
+        peer = create_peer(i)
+        node.peer_registry[peer.device_id] = peer
+        # Populate connections to simulate an active network
+        node.connections[peer.device_id] = None
+
+    peers = node.get_suitable_evolution_peers()
+
+    assert len(peers) == 7


### PR DESCRIPTION
## Summary
- Ensure `get_suitable_evolution_peers` scales with actual network size instead of a fixed cap
- Add unit test covering networks with more than five peers

## Testing
- `pytest tests/unit/core/test_evolution_peers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894028d1884832c874d95822a3806bc