### PR TITLE
feat: add boilerplate generator and agents

### DIFF
--- a/agent_forge/core/__init__.py
+++ b/agent_forge/core/__init__.py
@@ -1,0 +1,13 @@
+"""Core utilities for generating standardized agents."""
+
+from .generator import (
+    BaseGeneratedAgent,
+    create_agent_class,
+    AGENT_REGISTRY,
+)
+
+__all__ = [
+    "BaseGeneratedAgent",
+    "create_agent_class",
+    "AGENT_REGISTRY",
+]

--- a/agent_forge/core/generator.py
+++ b/agent_forge/core/generator.py
@@ -1,0 +1,114 @@
+"""Utility to programmatically generate standardized agents.
+
+The generated agents provide a minimal interface used in tests:
+- unique ``agent_id`` and ``metadata``
+- basic message handling via an in-memory registry
+- simple state management hooks
+- heartbeat metric emission
+- optional sandbox mode for restricted execution
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Dict, Type
+
+# ---------------------------------------------------------------------------
+# Base agent
+# ---------------------------------------------------------------------------
+
+class BaseGeneratedAgent:
+    """Lightweight base class for generated agents."""
+
+    # registry of live agent instances for message passing
+    instances: Dict[str, "BaseGeneratedAgent"] = {}
+
+    def __init__(self, name: str, sandboxed: bool = False) -> None:
+        self.name = name
+        self.role = getattr(self, "ROLE", name)
+        self.agent_id = str(uuid.uuid4())
+        self.sandboxed = sandboxed
+        self.state: Dict[str, Any] = {"status": "initialized"}
+        self.metrics: Dict[str, Any] = {"heartbeats": 0}
+        self.messages: list[tuple[str, Any]] = []
+        # register instance for simple message passing
+        BaseGeneratedAgent.instances[name] = self
+
+    # ------------------------------------------------------------------
+    # lifecycle commands
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        self.state["status"] = "running"
+        self.emit_heartbeat()
+
+    def stop(self) -> None:
+        self.state["status"] = "stopped"
+
+    def status(self) -> str:
+        return self.state["status"]
+
+    # ------------------------------------------------------------------
+    # messaging utilities
+    # ------------------------------------------------------------------
+    def send_message(self, recipient: str, content: Any) -> None:
+        """Send a message to another agent."""
+        target = BaseGeneratedAgent.instances.get(recipient)
+        if target:
+            target.handle_message(self.name, content)
+
+    def handle_message(self, sender: str, content: Any) -> None:
+        """Default message handler simply stores the message."""
+        self.messages.append((sender, content))
+
+    # ------------------------------------------------------------------
+    # metrics
+    # ------------------------------------------------------------------
+    def emit_heartbeat(self) -> None:
+        self.metrics["heartbeats"] += 1
+        self.state["last_heartbeat"] = time.time()
+
+
+# ---------------------------------------------------------------------------
+# Generator
+# ---------------------------------------------------------------------------
+
+def create_agent_class(agent_name: str, role: str) -> Type[BaseGeneratedAgent]:
+    """Dynamically create a new agent class with the given role."""
+
+    class GeneratedAgent(BaseGeneratedAgent):
+        ROLE = role
+
+        def __init__(self, sandboxed: bool = False) -> None:
+            super().__init__(agent_name, sandboxed=sandboxed)
+
+    GeneratedAgent.__name__ = f"{agent_name}Agent"
+    AGENT_REGISTRY[agent_name] = GeneratedAgent
+    return GeneratedAgent
+
+
+# registry mapping agent names to classes
+AGENT_REGISTRY: Dict[str, Type[BaseGeneratedAgent]] = {}
+
+# ---------------------------------------------------------------------------
+# Generate the ten missing agents
+# ---------------------------------------------------------------------------
+AGENT_SPECS = {
+    "Scribe": "Documentation generation and updates",
+    "Herald": "Event notifications and alerts",
+    "Curator": "Content moderation and quality control",
+    "Navigator": "Request routing and load balancing",
+    "Alchemist": "Model mixing and ensemble coordination",
+    "Guardian": "Backup and recovery operations",
+    "Chronicler": "History tracking and audit logs",
+    "Artificer": "Tool creation and integration",
+    "Emissary": "External API gateway",
+    "Steward": "Resource allocation and scheduling",
+}
+
+for _name, _role in AGENT_SPECS.items():
+    globals()[f"{_name}Agent"] = create_agent_class(_name, _role)
+
+__all__ = ["BaseGeneratedAgent", "create_agent_class", "AGENT_REGISTRY"] + [
+    f"{name}Agent" for name in AGENT_SPECS
+]

--- a/src/production/distributed_agents/agent_registry.py
+++ b/src/production/distributed_agents/agent_registry.py
@@ -4,6 +4,30 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+# Known agents in the AIVillage ecosystem. The registry recognises
+# all 18 specialised agents including those generated at runtime.
+ALL_AGENT_TYPES = [
+    "King",
+    "Sage",
+    "Magi",
+    "Sword",
+    "Shield",
+    "Logger",
+    "Profiler",
+    "Builder",
+    "Scribe",
+    "Herald",
+    "Curator",
+    "Navigator",
+    "Alchemist",
+    "Guardian",
+    "Chronicler",
+    "Artificer",
+    "Emissary",
+    "Steward",
+]
+
+
 @dataclass
 class AgentLocation:
     """Represents where agents are running."""
@@ -17,4 +41,7 @@ class DistributedAgentRegistry:
     """Minimal registry tracking agent locations."""
 
     def __init__(self) -> None:
-        self.registry: dict[Any, AgentLocation] = {}
+        # Pre-populate registry with all known agent types
+        self.registry: dict[Any, AgentLocation] = {
+            name: AgentLocation(agent_type=name, device_id="") for name in ALL_AGENT_TYPES
+        }

--- a/tests/test_generated_agents.py
+++ b/tests/test_generated_agents.py
@@ -1,0 +1,35 @@
+import pytest
+
+from agent_forge.core.generator import (
+    AGENT_REGISTRY,
+    ScribeAgent,
+    HeraldAgent,
+)
+
+
+def test_agents_register_and_basic_commands():
+    scribe = ScribeAgent()
+    herald = HeraldAgent()
+
+    # start agents and ensure status changes
+    scribe.start()
+    herald.start()
+    assert scribe.status() == "running"
+    assert herald.status() == "running"
+
+    # agents should be registered
+    assert "Scribe" in AGENT_REGISTRY
+    assert "Herald" in AGENT_REGISTRY
+
+    # test heartbeat metric emission
+    hb_before = herald.metrics["heartbeats"]
+    herald.emit_heartbeat()
+    assert herald.metrics["heartbeats"] == hb_before + 1
+
+    # test simple messaging
+    scribe.send_message("Herald", "ping")
+    assert ("Scribe", "ping") in herald.messages
+
+    # stop agent and verify status
+    herald.stop()
+    assert herald.status() == "stopped"


### PR DESCRIPTION
## Summary
- add dynamic agent generator with base class and ten generated agents
- expand distributed registry to recognize all 18 agent types
- cover generated agents with communication and heartbeat test

## Testing
- `pytest tests/test_generated_agents.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689494099344832c921fc617593af3e2