### PR TITLE
feat: add semantic RAG cache with tests

### DIFF
--- a/hyperrag/__init__.py
+++ b/hyperrag/__init__.py
@@ -1,0 +1,5 @@
+"""HyperRAG caching package."""
+
+from .hippo_cache import HippoCache, CacheEntry
+
+__all__ = ["HippoCache", "CacheEntry"]

--- a/hyperrag/hippo_cache.py
+++ b/hyperrag/hippo_cache.py
@@ -1,0 +1,149 @@
+"""High-performance RAG cache with semantic similarity search."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import threading
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Callable
+
+import numpy as np
+
+
+@dataclass
+class CacheEntry:
+    query_embedding: np.ndarray
+    retrieved_docs: List[Any]
+    relevance_scores: List[float]
+    citation_metadata: Dict[str, Any]
+    timestamp: datetime
+    access_count: int = 0
+
+
+class HippoCache:
+    """Thread-safe LRU cache with cosine-similarity search."""
+
+    def __init__(
+        self,
+        max_size: int = 10_000,
+        ttl_hours: int = 24,
+        similarity_threshold: float = 0.95,
+    ) -> None:
+        self.max_size = max_size
+        self.ttl = timedelta(hours=ttl_hours)
+        self.similarity_threshold = similarity_threshold
+
+        self._lock = threading.RLock()
+        self._cache: "OrderedDict[str, CacheEntry]" = OrderedDict()
+        self._embeddings: List[np.ndarray] = []
+        self._keys: List[str] = []
+        self._matrix: Optional[np.ndarray] = None
+
+        # Metrics
+        self._hits = 0
+        self._misses = 0
+        self._latency_total_ms = 0.0
+
+    # ------------------------------------------------------------------
+    def _normalize(self, vec: np.ndarray) -> np.ndarray:
+        vec = np.asarray(vec, dtype="float32")
+        norm = np.linalg.norm(vec)
+        if norm == 0:
+            return vec
+        return vec / norm
+
+    def _update_matrix(self) -> None:
+        if self._embeddings:
+            self._matrix = np.vstack(self._embeddings)
+        else:
+            self._matrix = None
+
+    def _is_expired(self, entry: CacheEntry) -> bool:
+        return datetime.utcnow() - entry.timestamp > self.ttl
+
+    def _evict_if_needed(self) -> None:
+        while len(self._cache) > self.max_size:
+            old_key, _ = self._cache.popitem(last=False)
+            if old_key in self._keys:
+                idx = self._keys.index(old_key)
+                self._keys.pop(idx)
+                self._embeddings.pop(idx)
+                self._update_matrix()
+
+    # ------------------------------------------------------------------
+    def get(self, query_embedding: np.ndarray) -> Optional[CacheEntry]:
+        start = datetime.utcnow()
+        with self._lock:
+            if self._matrix is None:
+                self._misses += 1
+                return None
+            query = self._normalize(query_embedding)
+            sims = self._matrix @ query
+            idx = int(np.argmax(sims))
+            score = float(sims[idx])
+            if score < self.similarity_threshold:
+                self._misses += 1
+                return None
+            key = self._keys[idx]
+            entry = self._cache.get(key)
+            if entry is None or self._is_expired(entry):
+                self._cache.pop(key, None)
+                self._hits += 0
+                self._misses += 1
+                return None
+            entry.access_count += 1
+            self._cache.move_to_end(key)
+            self._hits += 1
+        self._latency_total_ms += (datetime.utcnow() - start).total_seconds() * 1000
+        return entry
+
+    def set(self, key: str, entry: CacheEntry) -> None:
+        with self._lock:
+            normalized = self._normalize(entry.query_embedding)
+            if key in self._cache:
+                # update existing embedding
+                idx = self._keys.index(key)
+                self._embeddings[idx] = normalized
+            else:
+                self._keys.append(key)
+                self._embeddings.append(normalized)
+            self._cache[key] = entry
+            self._cache.move_to_end(key)
+            self._update_matrix()
+            self._evict_if_needed()
+
+    async def warm_cache(self, items: Iterable[Tuple[str, CacheEntry]]) -> None:
+        for key, entry in items:
+            self.set(key, entry)
+            await asyncio.sleep(0)
+
+    def get_or_retrieve(
+        self,
+        key: str,
+        query_embedding: np.ndarray,
+        retrieval_fn: Callable[[], Tuple[List[Any], List[float], Dict[str, Any]]],
+    ) -> CacheEntry:
+        start = datetime.utcnow()
+        entry = self.get(query_embedding)
+        if entry is not None:
+            return entry
+        docs, scores, meta = retrieval_fn()
+        entry = CacheEntry(
+            query_embedding=query_embedding,
+            retrieved_docs=docs,
+            relevance_scores=scores,
+            citation_metadata=meta,
+            timestamp=datetime.utcnow(),
+            access_count=1,
+        )
+        self.set(key, entry)
+        self._latency_total_ms += (datetime.utcnow() - start).total_seconds() * 1000
+        return entry
+
+    def metrics(self) -> Dict[str, float]:
+        total = self._hits + self._misses
+        hit_rate = self._hits / total if total else 0.0
+        avg_latency = self._latency_total_ms / total if total else 0.0
+        return {"hit_rate": hit_rate, "avg_latency_ms": avg_latency, "size": len(self._cache)}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+pytest-asyncio

--- a/tests/benchmarks/test_hippo_cache_benchmark.py
+++ b/tests/benchmarks/test_hippo_cache_benchmark.py
@@ -1,0 +1,23 @@
+import time
+import numpy as np
+from datetime import datetime
+
+from hyperrag.hippo_cache import CacheEntry, HippoCache
+
+
+def test_cache_hit_latency_benchmark() -> None:
+    cache = HippoCache(max_size=1000)
+    emb = np.random.rand(64).astype("float32")
+    entry = CacheEntry(
+        query_embedding=emb,
+        retrieved_docs=[],
+        relevance_scores=[],
+        citation_metadata={},
+        timestamp=datetime.utcnow(),
+    )
+    cache.set("a", entry)
+    start = time.perf_counter()
+    for _ in range(100):
+        assert cache.get(emb) is not None
+    avg = (time.perf_counter() - start) * 1000 / 100
+    assert avg < 10

--- a/tests/hyperrag/test_hippo_cache.py
+++ b/tests/hyperrag/test_hippo_cache.py
@@ -1,0 +1,99 @@
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+import threading
+import time
+
+import numpy as np
+
+from hyperrag.hippo_cache import CacheEntry, HippoCache
+
+
+@dataclass
+class Document:
+    text: str
+
+
+def _make_entry(embedding: np.ndarray) -> CacheEntry:
+    return CacheEntry(
+        query_embedding=embedding,
+        retrieved_docs=[Document("doc")],
+        relevance_scores=[1.0],
+        citation_metadata={},
+        timestamp=datetime.utcnow(),
+    )
+
+
+def test_lru_and_ttl() -> None:
+    cache = HippoCache(max_size=2, ttl_hours=0.0001)  # ~0.36s TTL
+    e1 = np.random.rand(64).astype("float32")
+    e2 = np.random.rand(64).astype("float32")
+    e3 = np.random.rand(64).astype("float32")
+    cache.set("a", _make_entry(e1))
+    cache.set("b", _make_entry(e2))
+    cache.set("c", _make_entry(e3))  # evicts "a"
+    assert cache.get(e1) is None
+    cache.set("d", _make_entry(e1))
+    time.sleep(0.5)  # expire
+    assert cache.get(e1) is None
+
+
+def test_thread_safety() -> None:
+    cache = HippoCache(max_size=100)
+    emb = np.random.rand(64).astype("float32")
+    entry = _make_entry(emb)
+
+    def worker(i: int) -> None:
+        cache.set(f"k{i}", entry)
+        cache.get(emb)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert cache.metrics()["size"] >= 1
+
+
+def test_async_warm_cache() -> None:
+    cache = HippoCache(max_size=10)
+    emb = np.random.rand(64).astype("float32")
+    entry = _make_entry(emb)
+
+    async def warm() -> None:
+        await cache.warm_cache([("a", entry)])
+
+    asyncio.run(warm())
+    assert cache.get(emb) is not None
+
+
+def test_semantic_similarity() -> None:
+    cache = HippoCache(max_size=10)
+    emb = np.random.rand(128).astype("float32")
+    cache.set("a", _make_entry(emb))
+    near = emb + np.random.normal(0, 0.001, emb.shape).astype("float32")
+    assert cache.get(near) is not None
+
+
+def test_metrics_hit_rate() -> None:
+    cache = HippoCache(max_size=10)
+    emb = np.random.rand(64).astype("float32")
+    cache.set("a", _make_entry(emb))
+    for _ in range(4):
+        cache.get(emb)
+    cache.get(np.random.rand(64).astype("float32"))  # miss
+    assert cache.metrics()["hit_rate"] >= 0.6
+
+
+def test_get_or_retrieve_latency() -> None:
+    cache = HippoCache(max_size=10)
+    emb = np.random.rand(64).astype("float32")
+
+    def retrieve():
+        return [Document("x")], [0.1], {}
+
+    cache.get_or_retrieve("a", emb, retrieve)
+    start = time.perf_counter()
+    cache.get_or_retrieve("a", emb, retrieve)
+    elapsed = (time.perf_counter() - start) * 1000
+    assert elapsed < 10


### PR DESCRIPTION
## Summary
- add thread-safe HippoCache with LRU eviction, TTL and cosine similarity lookup
- support async cache warming and basic metrics
- cover cache behaviors with unit tests and latency benchmark

## Testing
- `pytest tests/hyperrag tests/benchmarks/test_hippo_cache_benchmark.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689493ceb448832caa326b109a38fbee