### PR TITLE
Add Sword and Shield security agents with fuzzing and policy enforcement

### DIFF
--- a/src/production/agents/__init__.py
+++ b/src/production/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Specialized agent implementations."""
+
+# ruff: noqa: N999
+
+from .sword_shield import ShieldAgent, SwordAgent, SwordAndShieldAgent  # noqa: F401

--- a/src/production/agents/sword_shield.py
+++ b/src/production/agents/sword_shield.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+import random
+import time
+from trace import Trace
+import traceback
+from typing import TYPE_CHECKING, Any, ClassVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class WasiSandbox:
+    """Very small wrapper simulating WASI sandbox execution."""
+
+    def __init__(self, timeout: float = 1.0) -> None:
+        """Create sandbox with a timeout in seconds."""
+        self.timeout = timeout
+
+    def run(
+        self, func: Callable[[bytes], Any], data: bytes
+    ) -> tuple[bool, set[int], dict[str, Any]]:
+        """Execute ``func`` with ``data`` and capture coverage."""
+        tracer = Trace(count=True, trace=False)
+        crashed = False
+        info: dict[str, Any] = {}
+        try:
+            tracer.runfunc(func, data)
+        except Exception as exc:  # noqa: BLE001  # pragma: no cover - emulate crash
+            crashed = True
+            info["error"] = str(exc)
+            info["traceback"] = traceback.format_exc()
+        results = tracer.results()
+        coverage = set(results.counts.keys())
+        return crashed, coverage, info
+
+
+def _bitflip(data: bytearray) -> bytearray:
+    if not data:
+        return bytearray(b"\x00")
+    idx = random.randrange(len(data))  # noqa: S311
+    data[idx] ^= 0xFF
+    return data
+
+
+def _byte_duplicate(data: bytearray) -> bytearray:
+    if not data:
+        return bytearray(b"A")
+    idx = random.randrange(len(data))  # noqa: S311
+    data.insert(idx, data[idx])
+    return data
+
+
+MUTATORS: list[Callable[[bytearray], bytearray]] = [_bitflip, _byte_duplicate]
+
+
+class SwordAgent:
+    """Security testing specialist implementing a tiny fuzzing harness."""
+
+    common_patterns: ClassVar[list[bytes]] = [
+        b"' OR '1'='1",
+        b"../",
+        b"DROP TABLE",
+        b"CRASH",
+    ]
+
+    def __init__(self, sandbox: WasiSandbox | None = None) -> None:
+        """Initialize the fuzzing agent."""
+        self.sandbox = sandbox or WasiSandbox()
+        self.crashes: list[tuple[bytes, dict[str, Any]]] = []
+        self.coverage: set[int] = set()
+
+    def mutate(self, seed: bytes) -> bytes:
+        data = bytearray(seed)
+        mutator = random.choice(MUTATORS)  # noqa: S311
+        return bytes(mutator(data))
+
+    def fuzz(
+        self,
+        target: Callable[[bytes], Any],
+        seeds: Sequence[bytes],
+        iterations: int = 128,
+    ) -> dict[str, Any]:
+        """Run a very small AFL style fuzzing loop."""
+        start = time.time()
+        for _ in range(iterations):
+            seed = random.choice(seeds)  # noqa: S311
+            candidate = self.mutate(seed)
+            crashed, cov, info = self.sandbox.run(target, candidate)
+            self.coverage.update(cov)
+            if crashed:
+                self.crashes.append((candidate, info))
+        duration = time.time() - start
+        return {
+            "crashes_found": len(self.crashes),
+            "coverage": len(self.coverage),
+            "duration": duration,
+        }
+
+    def penetration_test(self, api_client: Any, attempts: int = 16) -> list[str]:
+        """Perform a few basic penetration tests against ``api_client``."""
+        findings: list[str] = []
+        for _ in range(attempts):
+            payload = self.mutate(b"test")
+            try:
+                api_client.request(payload.decode("utf-8", "ignore"))
+            except Exception as exc:  # noqa: BLE001
+                # pragma: no cover - fuzzing expects errors
+                findings.append(str(exc))
+        return findings
+
+
+@dataclass
+class SecurityEvent:
+    event: str
+    details: dict[str, Any]
+    blocked: bool
+    timestamp: float = field(default_factory=time.time)
+
+
+class ShieldAgent:
+    """Policy enforcement agent providing execution hooks."""
+
+    blocked_patterns: ClassVar[list[str]] = ["../", "rm -rf", "DROP TABLE"]
+
+    def __init__(self, sandbox: WasiSandbox | None = None) -> None:
+        """Create shield agent with optional sandbox."""
+        self.sandbox = sandbox or WasiSandbox()
+        self.events: list[SecurityEvent] = []
+
+    def _log(self, event: str, details: dict[str, Any], *, blocked: bool) -> None:
+        self.events.append(SecurityEvent(event, details, blocked))
+        logger.debug("%s: %s", event, details)
+        if blocked:
+            self._alert_admin(event, details)
+
+    def _alert_admin(self, event: str, details: dict[str, Any]) -> None:
+        logger.warning("ALERT %s: %s", event, details)
+
+    def _auto_remediate(self, details: dict[str, Any]) -> None:
+        details["remediated"] = True
+
+    def pre_execute(self, data: bytes) -> None:
+        text = data.decode("utf-8", "ignore")
+        for pattern in self.blocked_patterns:
+            if pattern in text:
+                self._log(
+                    "pre_execution_block",
+                    {"pattern": pattern, "data": text},
+                    blocked=True,
+                )
+                msg = "policy violation detected"
+                raise ValueError(msg)
+
+    def post_execute(self, *, crashed: bool, info: dict[str, Any]) -> None:
+        if crashed:
+            self._log("execution_crash", info, blocked=False)
+
+    def run(self, func: Callable[[bytes], Any], data: bytes) -> tuple[bool, set[int]]:
+        """Execute ``func`` under policy enforcement."""
+        self.pre_execute(data)
+        crashed, cov, info = self.sandbox.run(func, data)
+        self.post_execute(crashed=crashed, info=info)
+        return crashed, cov
+
+
+class SwordAndShieldAgent:
+    """Composite agent combining Sword and Shield capabilities."""
+
+    def __init__(self) -> None:
+        """Instantiate both Sword and Shield agents."""
+        self.sandbox = WasiSandbox()
+        self.sword = SwordAgent(self.sandbox)
+        self.shield = ShieldAgent(self.sandbox)
+
+    def fuzz(
+        self,
+        target: Callable[[bytes], Any],
+        seeds: Sequence[bytes],
+        iterations: int = 128,
+    ) -> dict[str, Any]:
+        """Delegate to :class:`SwordAgent` fuzzing."""
+        return self.sword.fuzz(target, seeds, iterations)
+
+    def secure_run(
+        self, func: Callable[[bytes], Any], data: bytes
+    ) -> tuple[bool, set[int]]:
+        """Run ``func`` through :class:`ShieldAgent` policy enforcement."""
+        return self.shield.run(func, data)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Test suite package for AIVillage."""
+
+# ruff: noqa: N999

--- a/tests/test_sword_shield.py
+++ b/tests/test_sword_shield.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import sys
+import unittest
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from production.agents.sword_shield import ShieldAgent, SwordAgent
+
+
+class DummyAPIClient:
+    def request(self, payload: str) -> None:
+        if payload != "test":
+            msg = "unexpected payload"
+            raise RuntimeError(msg)
+
+
+def vulnerable_target(data: bytes) -> None:
+    text = data.decode("utf-8", "ignore")
+    if "CRASH" in text:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+
+class TestSwordAgent(unittest.TestCase):
+    def test_fuzz_detects_crash(self) -> None:
+        sword = SwordAgent()
+        result = sword.fuzz(vulnerable_target, [b"seed", b"CRASH"], iterations=32)
+        assert result["crashes_found"] >= 1
+
+    def test_penetration_test_reports_findings(self) -> None:
+        sword = SwordAgent()
+        findings = sword.penetration_test(DummyAPIClient(), attempts=4)
+        assert findings
+
+
+class TestShieldAgent(unittest.TestCase):
+    def test_blocks_malicious_input(self) -> None:
+        shield = ShieldAgent()
+        with pytest.raises(ValueError, match="policy violation detected"):
+            shield.run(lambda _: None, b"../etc/passwd")
+        assert any(ev.event == "pre_execution_block" for ev in shield.events)
+
+    def test_allows_safe_input(self) -> None:
+        shield = ShieldAgent()
+        crashed, _ = shield.run(lambda d: d, b"hello")
+        assert not crashed
+        assert not shield.events
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `SwordAgent` with mutation-based fuzzing, crash detection, coverage tracking, and simple penetration testing
- add `ShieldAgent` with policy enforcement hooks and violation logging
- provide tests ensuring fuzzing finds crashes and policy engine avoids false positives

## Testing
- `pre-commit run --files src/production/agents/sword_shield.py tests/test_sword_shield.py tests/__init__.py`
- `pytest tests/test_sword_shield.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689497bdfafc832ca55b87a4203face9