### PR TITLE
feat: add automated import path updater

### DIFF
--- a/scripts/update_import_paths.py
+++ b/scripts/update_import_paths.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Automatically fix legacy import paths after src/ restructure.
+
+This script scans Python files, rewrites outdated imports to the new
+``src`` package layout, and attempts to validate the changes.  Any file
+that cannot be processed is reported as an ambiguous case for manual
+follow-up.
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+MODULE_PREFIXES = {
+    "agent_forge": "src.agent_forge",
+    "communications": "src.communications",
+    "production": "src.production",
+    "digital_twin": "src.digital_twin",
+    "core": "src.core",
+}
+
+SKIP_DIRS = {"venv", ".venv", "__pycache__", ".git"}
+
+
+def iter_python_files(root: Path) -> Iterable[Path]:
+    for path in root.rglob("*.py"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        yield path
+
+
+def replace_segment(lines: List[str], node: ast.AST, new_segment: str) -> None:
+    if not hasattr(node, "lineno") or not hasattr(node, "end_lineno"):
+        return
+    start, end = node.lineno - 1, node.end_lineno - 1
+    prefix = lines[start][: node.col_offset]
+    suffix = lines[end][node.end_col_offset :]
+    lines[start : end + 1] = [prefix + new_segment + suffix]
+
+
+def handle_import(node: ast.Import, lines: List[str], ambiguous: List[Tuple[Path, str]]) -> bool:
+    modified = False
+    new_parts: List[str] = []
+    for alias in node.names:
+        name = alias.name
+        as_part = f" as {alias.asname}" if alias.asname else ""
+        if name.startswith("forge_"):
+            new_parts.append(f"from src.production.agent_forge import {name}{as_part}")
+            modified = True
+            continue
+        for old, new in MODULE_PREFIXES.items():
+            if name == old or name.startswith(old + "."):
+                new_name = name.replace(old, new, 1)
+                new_parts.append(f"import {new_name}{as_part}")
+                modified = True
+                break
+        else:
+            new_parts.append(f"import {name}{as_part}")
+    if modified:
+        replace_segment(lines, node, "; ".join(new_parts))
+    return modified
+
+
+def handle_import_from(node: ast.ImportFrom, lines: List[str]) -> bool:
+    if not node.module:
+        return False
+    module = node.module
+    for old, new in MODULE_PREFIXES.items():
+        if module == old or module.startswith(old + "."):
+            new_module = module.replace(old, new, 1)
+            names = ", ".join([ast.unparse(n) for n in node.names])
+            replace_segment(lines, node, f"from {new_module} import {names}")
+            return True
+    return False
+
+
+def process_file(path: Path, ambiguous: List[Tuple[Path, str]]) -> bool:
+    source = path.read_text()
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        ambiguous.append((path, "syntax error"))
+        return False
+    lines = source.splitlines()
+    modified = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if handle_import(node, lines, ambiguous):
+                modified = True
+        elif isinstance(node, ast.ImportFrom):
+            if handle_import_from(node, lines):
+                modified = True
+    if modified:
+        path.write_text("\n".join(lines) + ("\n" if source.endswith("\n") else ""))
+    return modified
+
+
+def validate_modules(repo_root: Path, modules: Iterable[str]) -> List[str]:
+    """Attempt to import each module to ensure the new paths resolve."""
+    project_root = repo_root
+    if repo_root.name == "src":
+        project_root = repo_root.parent
+    sys.path.insert(0, str(project_root))
+    failures = []
+    for mod in modules:
+        try:
+            importlib.import_module(mod)
+        except Exception as exc:
+            failures.append(f"{mod}: {exc}")
+    return failures
+
+
+def main(root: str = ".") -> None:
+    repo_root = Path(root).resolve()
+    ambiguous: List[Tuple[Path, str]] = []
+    modified_files = []
+    for py_file in iter_python_files(repo_root):
+        if process_file(py_file, ambiguous):
+            modified_files.append(py_file)
+    if modified_files:
+        print("Modified files:")
+        for path in modified_files:
+            print(f"  {path}")
+    else:
+        print("No files required changes.")
+    if ambiguous:
+        print("\nAmbiguous cases:")
+        for path, reason in ambiguous:
+            print(f"  {path}: {reason}")
+    failures = validate_modules(repo_root, MODULE_PREFIXES.values())
+    if failures:
+        print("\nImport validation failures:")
+        for msg in failures:
+            print(f"  {msg}")
+    else:
+        print("\nAll mapped modules imported successfully.")
+
+
+if __name__ == "__main__":
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+    main(root)

--- a/src/agent_forge/adas/technique_archive.py
+++ b/src/agent_forge/adas/technique_archive.py
@@ -6,7 +6,7 @@ import types
 from typing import Any
 
 # Import necessary dependencies (adjust import paths as needed)
-from agent_forge.utils.tool_message import ToolMessage
+from src.agent_forge.utils.tool_message import ToolMessage
 
 # Safe builtins for code execution
 SAFE_BUILTINS: dict[str, Any] = {

--- a/src/agent_forge/adas_self_opt.py
+++ b/src/agent_forge/adas_self_opt.py
@@ -26,7 +26,7 @@ from torch import nn
 from transformers import AutoConfig, AutoModelForCausalLM
 import wandb
 
-from agent_forge.geometry_feedback import GeometryTracker
+from src.agent_forge.geometry_feedback import GeometryTracker
 
 logger = logging.getLogger(__name__)
 

--- a/src/agent_forge/automated_reporting.py
+++ b/src/agent_forge/automated_reporting.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 
-from agent_forge.results_analyzer import ResultsAnalyzer
+from src.agent_forge.results_analyzer import ResultsAnalyzer
 
 logger = logging.getLogger(__name__)
 

--- a/src/agent_forge/benchmark_runner.py
+++ b/src/agent_forge/benchmark_runner.py
@@ -18,11 +18,7 @@ from typing import Any
 
 import torch
 
-from agent_forge.benchmark_suite import (
-    BenchmarkConfig,
-    ComparisonReport,
-    ComprehensiveBenchmark,
-)
+from src.agent_forge.benchmark_suite import BenchmarkConfig, ComparisonReport, ComprehensiveBenchmark
 
 logger = logging.getLogger(__name__)
 

--- a/src/agent_forge/compression/hyperfn.py
+++ b/src/agent_forge/compression/hyperfn.py
@@ -5,6 +5,6 @@ implementation so that the ``agent_forge`` package exposes a hyper
 compression component alongside other stages.
 """
 
-from production.compression.compression.hyperfn import HyperCompressionEncoder
+from src.production.compression.compression.hyperfn import HyperCompressionEncoder
 
 __all__ = ["HyperCompressionEncoder"]

--- a/src/agent_forge/core/main.py
+++ b/src/agent_forge/core/main.py
@@ -1,9 +1,9 @@
 import click
 import yaml
 
-from agent_forge.mergekit.config import MergeKitConfig
-from agent_forge.mergekit.merger import MergeKitMerger
-from agent_forge.mergekit.utils import load_models, save_model
+from src.agent_forge.mergekit.config import MergeKitConfig
+from src.agent_forge.mergekit.merger import MergeKitMerger
+from src.agent_forge.mergekit.utils import load_models, save_model
 
 
 @click.command()

--- a/src/agent_forge/mastery_loop.py
+++ b/src/agent_forge/mastery_loop.py
@@ -29,12 +29,12 @@ from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import wandb
 
-from agent_forge.geometry.id_twonn import twonn
-from agent_forge.training.grokfast import GrokFastTask
-from agent_forge.training.self_modeling import SelfModelingTask
+from src.agent_forge.geometry.id_twonn import twonn
+from src.agent_forge.training.grokfast import GrokFastTask
+from src.agent_forge.training.self_modeling import SelfModelingTask
 
 # Import existing training components
-from agent_forge.training.sleep_and_dream import SleepAndDreamTask
+from src.agent_forge.training.sleep_and_dream import SleepAndDreamTask
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -748,12 +748,7 @@ async def run_self_modeling(config: dict[str, Any]) -> "PhaseResult":
     from datetime import datetime
     import time
 
-    from agent_forge.forge_orchestrator import (
-        PhaseArtifact,
-        PhaseResult,
-        PhaseStatus,
-        PhaseType,
-    )
+    from src.agent_forge.forge_orchestrator import PhaseArtifact, PhaseResult, PhaseStatus, PhaseType
 
     start_time = time.time()
 

--- a/src/agent_forge/mcp_refiner.py
+++ b/src/agent_forge/mcp_refiner.py
@@ -23,7 +23,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import wandb
 
-from agent_forge.geometry_feedback import GeometryTracker
+from src.agent_forge.geometry_feedback import GeometryTracker
 
 logger = logging.getLogger(__name__)
 

--- a/src/agent_forge/prompt_baking.py
+++ b/src/agent_forge/prompt_baking.py
@@ -589,12 +589,7 @@ async def run_prompt_baking(config: dict[str, Any]) -> "PhaseResult":
     Returns:
         PhaseResult with status, artifacts, and metrics
     """
-    from agent_forge.forge_orchestrator import (
-        PhaseArtifact,
-        PhaseResult,
-        PhaseStatus,
-        PhaseType,
-    )
+    from src.agent_forge.forge_orchestrator import PhaseArtifact, PhaseResult, PhaseStatus, PhaseType
 
     start_time = time.time()
 

--- a/src/agent_forge/self_awareness/self_guided_metacognative_baking.py
+++ b/src/agent_forge/self_awareness/self_guided_metacognative_baking.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn.functional as F
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from agent_forge.self_awareness.metacognaitve_eval import MetacognitiveEvaluatorTask
+from src.agent_forge.self_awareness.metacognaitve_eval import MetacognitiveEvaluatorTask
 
 nltk.download("punkt")
 

--- a/src/api/start_api_servers.py
+++ b/src/api/start_api_servers.py
@@ -22,10 +22,7 @@ sys.path.insert(
     0, str(Path(__file__).parent.parent / "production" / "rag" / "rag_system" / "core")
 )
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from core.security.digital_twin_encryption import (
-    DigitalTwinEncryption,
-    DigitalTwinEncryptionError,
-)
+from src.core.security.digital_twin_encryption import DigitalTwinEncryption, DigitalTwinEncryptionError
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/src/communications/community_hub.py
+++ b/src/communications/community_hub.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from core.error_handling import StandardCommunicationProtocol
+from src.core.error_handling import StandardCommunicationProtocol
 
 logger = logging.getLogger(__name__)
 

--- a/src/core/compression/advanced_pipeline.py
+++ b/src/core/compression/advanced_pipeline.py
@@ -11,16 +11,16 @@ import struct
 import torch
 
 try:  # pragma: no cover - allow running without installation
-    from agent_forge.compression.bitnet import BITNETCompressor
-    from agent_forge.compression.seedlm import SEEDLMCompressor
-    from agent_forge.compression.vptq import VPTQCompressor
+    from src.agent_forge.compression.bitnet import BITNETCompressor
+    from src.agent_forge.compression.seedlm import SEEDLMCompressor
+    from src.agent_forge.compression.vptq import VPTQCompressor
 except ModuleNotFoundError:  # pragma: no cover - tests run from repo root
     from src.agent_forge.compression.bitnet import BITNETCompressor
     from src.agent_forge.compression.seedlm import SEEDLMCompressor
     from src.agent_forge.compression.vptq import VPTQCompressor
 
 try:  # pragma: no cover - optional dependency
-    from production.compression.hyper_compression import HyperCompressionEncoder
+    from src.production.compression.hyper_compression import HyperCompressionEncoder
 except ModuleNotFoundError:  # pragma: no cover - fallback
 
     class HyperCompressionEncoder:  # type: ignore

--- a/src/core/compression/integrated_pipeline.py
+++ b/src/core/compression/integrated_pipeline.py
@@ -14,9 +14,9 @@ if TYPE_CHECKING:
     import numpy as np
 
 try:  # pragma: no cover - allow tests to run from repository root
-    from agent_forge.compression.bitnet import BITNETCompressor
-    from agent_forge.compression.seedlm import SEEDLMCompressor
-    from agent_forge.compression.vptq import VPTQCompressor
+    from src.agent_forge.compression.bitnet import BITNETCompressor
+    from src.agent_forge.compression.seedlm import SEEDLMCompressor
+    from src.agent_forge.compression.vptq import VPTQCompressor
 except ModuleNotFoundError:  # pragma: no cover
     from src.agent_forge.compression.bitnet import BITNETCompressor
     from src.agent_forge.compression.seedlm import SEEDLMCompressor

--- a/src/deployment/mobile_compressor.py
+++ b/src/deployment/mobile_compressor.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import torch
 
-from core.compression.unified_compressor import UnifiedCompressor
+from src.core.compression.unified_compressor import UnifiedCompressor
 
 logger = logging.getLogger(__name__)
 

--- a/src/digital_twin/api/service.py
+++ b/src/digital_twin/api/service.py
@@ -9,7 +9,7 @@ import uuid
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from digital_twin.core.digital_twin import DigitalTwin, LearningProfile, LearningSession
+from src.digital_twin.core.digital_twin import DigitalTwin, LearningProfile, LearningSession
 
 app = FastAPI(title="Digital Twin API")
 

--- a/src/digital_twin/deployment/edge_manager.py
+++ b/src/digital_twin/deployment/edge_manager.py
@@ -559,7 +559,7 @@ class EdgeDeploymentManager:
         """Prepare tutor model for deployment."""
         try:
             # Import deployment system
-            from agent_forge.evolution.deploy_winner import tutor_deployment
+            from src.agent_forge.evolution.deploy_winner import tutor_deployment
 
             # Get champion model (would normally load from storage)
             champion_model = {
@@ -738,7 +738,7 @@ class EdgeDeploymentManager:
         """Generate offline content package."""
         # Get student's learning profile
         try:
-            from digital_twin.core.digital_twin import digital_twin
+            from src.digital_twin.core.digital_twin import digital_twin
 
             if student_id in digital_twin.students:
                 student = digital_twin.students[student_id]

--- a/src/digital_twin/engine/personalized_tutor.py
+++ b/src/digital_twin/engine/personalized_tutor.py
@@ -381,7 +381,7 @@ class PersonalizedTutorEngine:
         """Get comprehensive student profile."""
         try:
             # Import digital twin
-            from digital_twin.core.digital_twin import digital_twin
+            from src.digital_twin.core.digital_twin import digital_twin
 
             if student_id in digital_twin.students:
                 student = digital_twin.students[student_id]
@@ -1179,7 +1179,7 @@ class PersonalizedTutorEngine:
 
         # Update parent tracker if available
         try:
-            from digital_twin.monitoring.parent_tracker import parent_progress_tracker
+            from src.digital_twin.monitoring.parent_tracker import parent_progress_tracker
 
             session_data = {
                 "session_id": session_id,

--- a/src/digital_twin/monitoring/parent_tracker.py
+++ b/src/digital_twin/monitoring/parent_tracker.py
@@ -400,7 +400,7 @@ class ParentProgressTracker:
         """Initialize learning milestones for a student."""
         # Get student's current grade/age from digital twin
         try:
-            from digital_twin.core.digital_twin import digital_twin
+            from src.digital_twin.core.digital_twin import digital_twin
 
             if student_id in digital_twin.students:
                 student = digital_twin.students[student_id]

--- a/src/federated/twin_trainer.py
+++ b/src/federated/twin_trainer.py
@@ -1,6 +1,6 @@
 import torch
 
-from communications.federated_client import FederatedClient
+from src.communications.federated_client import FederatedClient
 from ingestion.vector_ds import personal_ds
 from twin_runtime.fine_tune import run_nightly
 from twin_runtime.runner import LLM

--- a/src/production/agent_forge/agent_factory.py
+++ b/src/production/agent_forge/agent_factory.py
@@ -59,7 +59,7 @@ class AgentFactory:
 
         # King Agent
         try:
-            from production.agents.king import KingAgent
+            from src.production.agents.king import KingAgent
 
             agent_classes["king"] = KingAgent
         except ImportError:
@@ -68,7 +68,7 @@ class AgentFactory:
 
         # Magi Agent
         try:
-            from production.agents.magi import MagiAgent
+            from src.production.agents.magi import MagiAgent
 
             agent_classes["magi"] = MagiAgent
         except ImportError:
@@ -77,7 +77,7 @@ class AgentFactory:
 
         # Sage Agent
         try:
-            from production.agents.sage import SageAgent
+            from src.production.agents.sage import SageAgent
 
             agent_classes["sage"] = SageAgent
         except ImportError:
@@ -86,7 +86,7 @@ class AgentFactory:
 
         # Gardener Agent
         try:
-            from production.agents.gardener import GardenerAgent
+            from src.production.agents.gardener import GardenerAgent
 
             agent_classes["gardener"] = GardenerAgent
         except ImportError:
@@ -95,7 +95,7 @@ class AgentFactory:
 
         # Sword & Shield Agent
         try:
-            from production.agents.sword_shield import SwordAndShieldAgent
+            from src.production.agents.sword_shield import SwordAndShieldAgent
 
             agent_classes["sword_shield"] = SwordAndShieldAgent
         except ImportError:
@@ -106,7 +106,7 @@ class AgentFactory:
 
         # Legal AI Agent
         try:
-            from production.agents.legal import LegalAIAgent
+            from src.production.agents.legal import LegalAIAgent
 
             agent_classes["legal"] = LegalAIAgent
         except ImportError:
@@ -115,7 +115,7 @@ class AgentFactory:
 
         # Shaman Agent
         try:
-            from production.agents.shaman import ShamanAgent
+            from src.production.agents.shaman import ShamanAgent
 
             agent_classes["shaman"] = ShamanAgent
         except ImportError:
@@ -124,7 +124,7 @@ class AgentFactory:
 
         # Oracle Agent
         try:
-            from production.agents.oracle import OracleAgent
+            from src.production.agents.oracle import OracleAgent
 
             agent_classes["oracle"] = OracleAgent
         except ImportError:
@@ -133,7 +133,7 @@ class AgentFactory:
 
         # Maker Agent
         try:
-            from production.agents.maker import MakerAgent
+            from src.production.agents.maker import MakerAgent
 
             agent_classes["maker"] = MakerAgent
         except ImportError:
@@ -142,7 +142,7 @@ class AgentFactory:
 
         # Ensemble Agent
         try:
-            from production.agents.ensemble import EnsembleAgent
+            from src.production.agents.ensemble import EnsembleAgent
 
             agent_classes["ensemble"] = EnsembleAgent
         except ImportError:
@@ -151,7 +151,7 @@ class AgentFactory:
 
         # Curator Agent
         try:
-            from production.agents.curator import CuratorAgent
+            from src.production.agents.curator import CuratorAgent
 
             agent_classes["curator"] = CuratorAgent
         except ImportError:
@@ -160,7 +160,7 @@ class AgentFactory:
 
         # Auditor Agent
         try:
-            from production.agents.auditor import AuditorAgent
+            from src.production.agents.auditor import AuditorAgent
 
             agent_classes["auditor"] = AuditorAgent
         except ImportError:
@@ -169,7 +169,7 @@ class AgentFactory:
 
         # Medic Agent
         try:
-            from production.agents.medic import MedicAgent
+            from src.production.agents.medic import MedicAgent
 
             agent_classes["medic"] = MedicAgent
         except ImportError:
@@ -178,7 +178,7 @@ class AgentFactory:
 
         # Sustainer Agent
         try:
-            from production.agents.sustainer import SustainerAgent
+            from src.production.agents.sustainer import SustainerAgent
 
             agent_classes["sustainer"] = SustainerAgent
         except ImportError:
@@ -187,7 +187,7 @@ class AgentFactory:
 
         # Navigator Agent
         try:
-            from production.agents.navigator import NavigatorAgent
+            from src.production.agents.navigator import NavigatorAgent
 
             agent_classes["navigator"] = NavigatorAgent
         except ImportError:
@@ -196,7 +196,7 @@ class AgentFactory:
 
         # Tutor Agent
         try:
-            from production.agents.tutor import TutorAgent
+            from src.production.agents.tutor import TutorAgent
 
             agent_classes["tutor"] = TutorAgent
         except ImportError:
@@ -205,7 +205,7 @@ class AgentFactory:
 
         # Polyglot Agent
         try:
-            from production.agents.polyglot import PolyglotAgent
+            from src.production.agents.polyglot import PolyglotAgent
 
             agent_classes["polyglot"] = PolyglotAgent
         except ImportError:
@@ -214,7 +214,7 @@ class AgentFactory:
 
         # Strategist Agent
         try:
-            from production.agents.strategist import StrategistAgent
+            from src.production.agents.strategist import StrategistAgent
 
             agent_classes["strategist"] = StrategistAgent
         except ImportError:

--- a/src/production/compression/compression_pipeline.py
+++ b/src/production/compression/compression_pipeline.py
@@ -804,12 +804,7 @@ async def run_compression(config: dict[str, Any]) -> "PhaseResult":
         PhaseResult with status, artifacts, and metrics
     """
     try:
-        from agent_forge.forge_orchestrator import (
-            PhaseArtifact,
-            PhaseResult,
-            PhaseStatus,
-            PhaseType,
-        )
+        from src.agent_forge.forge_orchestrator import PhaseArtifact, PhaseResult, PhaseStatus, PhaseType
     except ImportError:
         # Fallback classes for when orchestrator is not available
         from dataclasses import dataclass

--- a/src/production/compression/model_compression/bitlinearization.py
+++ b/src/production/compression/model_compression/bitlinearization.py
@@ -2,12 +2,12 @@
 
 from typing import NoReturn
 
-from agent_forge.compression.stage1_bitnet import convert_to_bitnet
+from src.agent_forge.compression.stage1_bitnet import convert_to_bitnet
 
 # quantization helpers located in foundation and training modules
 try:
-    from agent_forge.foundation.bitnet import q_bitnet as quantize_weights
-    from agent_forge.training.sleep_and_dream import quantize_activations
+    from src.agent_forge.foundation.bitnet import q_bitnet as quantize_weights
+    from src.agent_forge.training.sleep_and_dream import quantize_activations
 except Exception:  # pragma: no cover - optional if training module unavailable
 
     def quantize_weights(x) -> NoReturn:

--- a/src/production/compression/unified_compressor.py
+++ b/src/production/compression/unified_compressor.py
@@ -25,13 +25,7 @@ from torch import nn
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # Import best implementations from agent_forge
-from agent_forge.compression import (
-    BITNETCompressor,
-    SEEDLMCompressor,
-    VPTQCompressor,
-    bitnet_compress,
-    seedlm_compress,
-)
+from src.agent_forge.compression import BITNETCompressor, SEEDLMCompressor, VPTQCompressor, bitnet_compress, seedlm_compress
 
 # Import production pipeline components
 from .compression_pipeline import CompressionConfig, CompressionPipeline

--- a/src/production/evolution/evomerge_pipeline.py
+++ b/src/production/evolution/evomerge_pipeline.py
@@ -1422,12 +1422,7 @@ async def run_evomerge(config: dict[str, Any]) -> "PhaseResult":
     Returns:
         PhaseResult with status, artifacts, and metrics.
     """
-    from agent_forge.forge_orchestrator import (
-        PhaseArtifact,
-        PhaseResult,
-        PhaseStatus,
-        PhaseType,
-    )
+    from src.agent_forge.forge_orchestrator import PhaseArtifact, PhaseResult, PhaseStatus, PhaseType
 
     start_time = time.time()
 

--- a/src/production/geometry/geometry_feedback.py
+++ b/src/production/geometry/geometry_feedback.py
@@ -24,7 +24,7 @@ import torch
 from torch import nn
 import wandb
 
-from agent_forge.geometry.id_twonn import twonn
+from src.agent_forge.geometry.id_twonn import twonn
 
 logger = logging.getLogger(__name__)
 
@@ -725,12 +725,7 @@ async def run_geometry(config: dict[str, Any]) -> "PhaseResult":
     from datetime import datetime
     import time
 
-    from agent_forge.forge_orchestrator import (
-        PhaseArtifact,
-        PhaseResult,
-        PhaseStatus,
-        PhaseType,
-    )
+    from src.agent_forge.forge_orchestrator import PhaseArtifact, PhaseResult, PhaseStatus, PhaseType
 
     start_time = time.time()
 

--- a/src/production/rag/rag_system/confidence.py
+++ b/src/production/rag/rag_system/confidence.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Rule-based confidence scoring utilities."""
 
 
-from core.evidence import ConfidenceTier, EvidencePack
+from src.core.evidence import ConfidenceTier, EvidencePack
 
 THRESHOLDS = {
     ConfidenceTier.HIGH: 0.8,

--- a/src/production/tests/benchmarking/test_benchmark_comprehensive.py
+++ b/src/production/tests/benchmarking/test_benchmark_comprehensive.py
@@ -5,8 +5,8 @@ Verifies real benchmark functionality and metrics.
 import pytest
 
 try:
-    from production.benchmarking import RealBenchmark
-    from production.benchmarking.real_benchmark import RealBenchmark as RB
+    from src.production.benchmarking import RealBenchmark
+    from src.production.benchmarking.real_benchmark import RealBenchmark as RB
 except ImportError:
     # Handle missing imports gracefully
     pytest.skip(
@@ -20,7 +20,7 @@ class TestRealBenchmark:
     def test_real_benchmark_exists(self) -> None:
         """Test that real benchmark can be imported."""
         try:
-            from production.benchmarking.real_benchmark import RealBenchmark
+            from src.production.benchmarking.real_benchmark import RealBenchmark
 
             assert RealBenchmark is not None
         except ImportError:

--- a/src/production/tests/compression/test_compression_comprehensive.py
+++ b/src/production/tests/compression/test_compression_comprehensive.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 try:
-    from production.compression import CompressionPipeline
+    from src.production.compression import CompressionPipeline
 
     if CompressionPipeline is None:
         msg = "CompressionPipeline not available"
@@ -17,15 +17,13 @@ try:
 
     # Try to import ModelCompression, but don't fail if it's not available
     try:
-        from production.compression import ModelCompression
+        from src.production.compression import ModelCompression
     except (ImportError, AttributeError):
         ModelCompression = None
 
     # Also try direct import as backup
     try:
-        from production.compression.compression_pipeline import (
-            CompressionPipeline as CP,
-        )
+        from src.production.compression.compression_pipeline import CompressionPipeline as CP
     except ImportError:
         CP = CompressionPipeline
 
@@ -68,9 +66,9 @@ class TestCompressionClaims:
     def test_compression_pipeline_exists(self) -> None:
         """Test that compression pipeline can be imported and instantiated."""
         try:
-            from production.compression.compression_pipeline import CompressionPipeline
+            from src.production.compression.compression_pipeline import CompressionPipeline
 
-            pipeline = CompressionPipeline()
+            from src.production.compression.compression_pipeline import CompressionPipeline
             assert pipeline is not None
         except ImportError:
             pytest.skip("CompressionPipeline not available")
@@ -78,9 +76,9 @@ class TestCompressionClaims:
     def test_model_compression_exists(self) -> None:
         """Test that model compression modules exist."""
         try:
-            from production.compression.model_compression import ModelCompression
+            from src.production.compression.model_compression import ModelCompression
 
-            assert ModelCompression is not None
+            from src.production.compression.model_compression import ModelCompression
         except ImportError:
             pytest.skip("ModelCompression not available")
 
@@ -126,27 +124,27 @@ class TestCompressionMethods:
     def test_seedlm_available(self) -> None:
         """Test SeedLM compression method availability."""
         try:
-            from production.compression.compression.seedlm import SeedLM
+            from src.production.compression.compression.seedlm import SeedLM
 
-            assert SeedLM is not None
+            from src.production.compression.compression.seedlm import SeedLM
         except ImportError:
             pytest.skip("SeedLM not available")
 
     def test_vptq_available(self) -> None:
         """Test VPTQ compression method availability."""
         try:
-            from production.compression.compression.vptq import VPTQ
+            from src.production.compression.compression.vptq import VPTQ
 
-            assert VPTQ is not None
+            from src.production.compression.compression.vptq import VPTQ
         except ImportError:
             pytest.skip("VPTQ not available")
 
     def test_bitnet_available(self) -> None:
         """Test BitNet compression method availability."""
         try:
-            from production.compression.model_compression.bitlinearization import BitNet
+            from src.production.compression.model_compression.bitlinearization import BitNet
 
-            assert BitNet is not None
+            from src.production.compression.model_compression.bitlinearization import BitNet
         except ImportError:
             pytest.skip("BitNet not available")
 

--- a/src/production/tests/geometry/test_geometry_comprehensive.py
+++ b/src/production/tests/geometry/test_geometry_comprehensive.py
@@ -6,9 +6,9 @@ import pytest
 import torch
 
 try:
-    from production.geometry import GeometryFeedback
-    from production.geometry.geometry import Snapshot
-    from production.geometry.geometry_feedback import GeometryFeedback as GF
+    from src.production.geometry import GeometryFeedback
+    from src.production.geometry.geometry import Snapshot
+    from src.production.geometry.geometry_feedback import GeometryFeedback as GF
 except ImportError:
     # Handle missing imports gracefully
     pytest.skip("Production geometry modules not available", allow_module_level=True)
@@ -20,7 +20,7 @@ class TestGeometryFeedback:
     def test_geometry_feedback_exists(self) -> None:
         """Test that geometry feedback can be imported."""
         try:
-            from production.geometry.geometry_feedback import GeometryFeedback
+            from src.production.geometry.geometry_feedback import GeometryFeedback
 
             assert GeometryFeedback is not None
         except ImportError:
@@ -67,7 +67,7 @@ class TestGeometrySnapshot:
     def test_snapshot_concept(self) -> None:
         """Test snapshot concept."""
         try:
-            from production.geometry.geometry.snapshot import Snapshot
+            from src.production.geometry.geometry.snapshot import Snapshot
 
             assert Snapshot is not None
         except ImportError:

--- a/src/production/tests/integration/test_production_integration.py
+++ b/src/production/tests/integration/test_production_integration.py
@@ -7,12 +7,12 @@ import torch
 
 # Import all production components
 try:
-    from production.benchmarking import RealBenchmark
-    from production.compression import CompressionPipeline
-    from production.evolution import EvolutionaryTournament
-    from production.geometry import GeometryFeedback
-    from production.memory import MemoryManager
-    from production.rag import RAGPipeline
+    from src.production.benchmarking import RealBenchmark
+    from src.production.compression import CompressionPipeline
+    from src.production.evolution import EvolutionaryTournament
+    from src.production.geometry import GeometryFeedback
+    from src.production.memory import MemoryManager
+    from src.production.rag import RAGPipeline
 except ImportError:
     pytest.skip("Production modules not available", allow_module_level=True)
 

--- a/src/production/tests/memory/test_memory_comprehensive.py
+++ b/src/production/tests/memory/test_memory_comprehensive.py
@@ -8,9 +8,9 @@ import psutil
 import pytest
 
 try:
-    from production.memory import MemoryManager, WandbManager
-    from production.memory.memory_manager import MemoryManager as MM
-    from production.memory.wandb_manager import WandbManager as WM
+    from src.production.memory import MemoryManager, WandbManager
+    from src.production.memory.memory_manager import MemoryManager as MM
+    from src.production.memory.wandb_manager import WandbManager as WM
 except ImportError:
     # Handle missing imports gracefully
     pytest.skip("Production memory modules not available", allow_module_level=True)
@@ -22,7 +22,7 @@ class TestMemoryManager:
     def test_memory_manager_exists(self) -> None:
         """Test that memory manager can be imported."""
         try:
-            from production.memory.memory_manager import MemoryManager
+            from src.production.memory.memory_manager import MemoryManager
 
             assert MemoryManager is not None
         except ImportError:
@@ -57,7 +57,7 @@ class TestWandbManager:
     def test_wandb_manager_exists(self) -> None:
         """Test that wandb manager can be imported."""
         try:
-            from production.memory.wandb_manager import WandbManager
+            from src.production.memory.wandb_manager import WandbManager
 
             assert WandbManager is not None
         except ImportError:

--- a/src/production/tests/rag/test_rag_comprehensive.py
+++ b/src/production/tests/rag/test_rag_comprehensive.py
@@ -5,8 +5,8 @@ Verifies retrieval and generation capabilities.
 import pytest
 
 try:
-    from production.rag import RAGPipeline
-    from production.rag.rag_system import RAGSystem
+    from src.production.rag import RAGPipeline
+    from src.production.rag.rag_system import RAGSystem
 except ImportError:
     # Handle missing imports gracefully
     pytest.skip("Production RAG modules not available", allow_module_level=True)
@@ -18,7 +18,7 @@ class TestRAGSystem:
     def test_rag_imports(self) -> None:
         """Test that RAG modules can be imported."""
         try:
-            from production.rag.rag_system.main import RAGSystem
+            from src.production.rag.rag_system.main import RAGSystem
 
             assert RAGSystem is not None
         except ImportError:
@@ -27,7 +27,7 @@ class TestRAGSystem:
     def test_vector_store_exists(self) -> None:
         """Test that vector store exists."""
         try:
-            from production.rag.rag_system.vector_store import VectorStore
+            from src.production.rag.rag_system.vector_store import VectorStore
 
             assert VectorStore is not None
         except ImportError:
@@ -74,7 +74,7 @@ class TestRAGRetrieval:
     def test_faiss_backend_exists(self) -> None:
         """Test FAISS backend availability."""
         try:
-            from production.rag.rag_system.faiss_backend import FAISSBackend
+            from src.production.rag.rag_system.faiss_backend import FAISSBackend
 
             assert FAISSBackend is not None
         except ImportError:
@@ -83,7 +83,7 @@ class TestRAGRetrieval:
     def test_graph_explain_exists(self) -> None:
         """Test graph explanation module."""
         try:
-            from production.rag.rag_system.graph_explain import GraphExplain
+            from src.production.rag.rag_system.graph_explain import GraphExplain
 
             assert GraphExplain is not None
         except ImportError:

--- a/src/twin_runtime/compressed_loader.py
+++ b/src/twin_runtime/compressed_loader.py
@@ -1,6 +1,6 @@
 import torch
 
-from agent_forge.compression import CompressionConfig, TwoStageCompressor
+from src.agent_forge.compression import CompressionConfig, TwoStageCompressor
 
 
 class CompressedModelLoader:

--- a/src/twin_runtime/runner.py
+++ b/src/twin_runtime/runner.py
@@ -39,7 +39,7 @@ class TwinRuntimeChat:
 
         try:
             # Try our compression pipeline first
-            from core.compression.unified_compressor import UnifiedCompressor
+            from src.core.compression.unified_compressor import UnifiedCompressor
 
             # Look for pre-compressed model
             model_path = Path("models/compressed/chat_model.bin")


### PR DESCRIPTION
## Summary
- add `scripts/update_import_paths.py` to rewrite legacy imports to new `src` structure
- prefix core modules with `src.` in agent_forge, communications, production, digital_twin, core and runtime utilities
- update production test imports to match new package layout

## Testing
- `python scripts/update_import_paths.py src`
- `pytest src/production/tests/compression/test_compression_comprehensive.py --maxfail=1 --disable-warnings --collect-only`
- `pytest src/production/tests/geometry/test_geometry_comprehensive.py --maxfail=1 --disable-warnings --collect-only`
- `python - <<'PY'
import importlib, sys
modules=['src.agent_forge','src.communications','src.production','src.digital_twin','src.core']
for m in modules:
    try:
        importlib.import_module(m)
        print(m, 'OK')
    except Exception as e:
        print(m,'FAIL',e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6898e3ffe3ac832c8d9fe08c2d4cf857