### PR TITLE
refactor: migrate pydantic v1 usage to v2

### DIFF
--- a/src/agent_forge/prompt_baking.py
+++ b/src/agent_forge/prompt_baking.py
@@ -21,7 +21,7 @@ import time
 import traceback
 from typing import Any
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 import torch
 from torch import nn
 from tqdm import tqdm
@@ -101,8 +101,9 @@ class PromptBakingConfig(BaseModel):
         default_factory=lambda: ["prompt_baking", "optimization"]
     )
 
-    @validator("device")
-    def validate_device(self, v):
+    @field_validator("device")
+    @classmethod
+    def validate_device(cls, v: str) -> str:
         if v == "auto":
             return "cuda" if torch.cuda.is_available() else "cpu"
         return v
@@ -481,7 +482,7 @@ class PromptBakingPipeline:
                 entity=self.config.wandb_entity,
                 job_type="prompt_baking",
                 tags=self.config.wandb_tags,
-                config=self.config.dict(),
+                config=self.config.model_dump(),
             )
             logger.info(f"W&B initialized: {self.wandb_run.url}")
         except Exception as e:
@@ -555,7 +556,7 @@ class PromptBakingPipeline:
                     "best_prompt_template": best_variant.template,
                     "best_performance": ab_results["best_performance"],
                     "output_model_path": str(output_path),
-                    "baking_config": self.config.dict(),
+                    "baking_config": self.config.model_dump(),
                 }
             )
 
@@ -624,7 +625,7 @@ async def run_prompt_baking(config: dict[str, Any]) -> "PhaseResult":
                         "tool_integration": results.get("tool_integration", {}),
                     },
                     metadata={
-                        "baking_config": baking_config.dict(),
+                        "baking_config": baking_config.model_dump(),
                         "baking_method": "weight_optimization",
                     },
                 )

--- a/src/agent_forge/quietstar_baker.py
+++ b/src/agent_forge/quietstar_baker.py
@@ -20,7 +20,7 @@ from typing import Any
 import click
 from datasets import load_dataset
 import numpy as np
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 import torch
 from torch import nn
 import torch.nn.functional as F
@@ -89,8 +89,9 @@ class QuietSTaRConfig(BaseModel):
     wandb_entity: str | None = None
     wandb_tags: list[str] = Field(default_factory=lambda: ["quietstar", "reasoning"])
 
-    @validator("device")
-    def validate_device(self, v):
+    @field_validator("device")
+    @classmethod
+    def validate_device(cls, v: str) -> str:
         if v == "auto":
             return "cuda" if torch.cuda.is_available() else "cpu"
         return v
@@ -812,7 +813,7 @@ class QuietSTaRBaker:
                 entity=self.config.wandb_entity,
                 job_type="quietstar",
                 tags=self.config.wandb_tags,
-                config=self.config.dict(),
+                config=self.config.model_dump(),
             )
 
             logger.info(f"W&B initialized: {self.wandb_run.url}")

--- a/src/agent_forge/unified_pipeline.py
+++ b/src/agent_forge/unified_pipeline.py
@@ -124,7 +124,7 @@ class PipelineState(BaseModel):
         checkpoint_path = checkpoint_dir / f"unified_pipeline_{self.run_id}.json"
 
         with open(checkpoint_path, "w") as f:
-            json.dump(self.dict(), f, indent=2, default=str)
+            json.dump(self.model_dump(), f, indent=2, default=str)
 
         logger.info(f"Pipeline checkpoint saved: {checkpoint_path}")
 
@@ -167,7 +167,7 @@ class UnifiedPipeline:
                 entity=self.config.wandb_entity,
                 job_type="unified_pipeline",
                 tags=[*self.config.wandb_tags, f"run-{self.state.run_id}"],
-                config=self.config.dict(),
+                config=self.config.model_dump(),
                 name=f"unified_pipeline_{self.state.run_id}",
             )
 
@@ -495,9 +495,10 @@ class UnifiedPipeline:
                 model_artifact = wandb.Artifact(
                     f"agent_forge_final_model_{self.state.run_id}",
                     type="model",
-                    description=f"Complete Agent Forge model with {
-                        self.state.total_improvement:.1f}% improvement and {
-                        self.state.compression_ratio:.1f}x compression",
+                    description=(
+                        f"Complete Agent Forge model with {self.state.total_improvement:.1f}% improvement and "
+                        f"{self.state.compression_ratio:.1f}x compression"
+                    ),
                 )
                 model_artifact.add_dir(self.state.final_model_path)
                 self.wandb_run.log_artifact(model_artifact)

--- a/src/communications/credits_api.py
+++ b/src/communications/credits_api.py
@@ -112,7 +112,7 @@ async def value_error_handler(request, exc):
             error="validation_error",
             message=str(exc),
             timestamp=datetime.now(timezone.utc),
-        ).dict(),
+        ).model_dump(),
     )
 
 
@@ -126,7 +126,7 @@ async def general_error_handler(request, exc):
             error="internal_error",
             message="An unexpected error occurred",
             timestamp=datetime.now(timezone.utc),
-        ).dict(),
+        ).model_dump(),
     )
 
 


### PR DESCRIPTION
## Summary
- refactor server and agent forge modules to use Pydantic v2 `field_validator`
- update hypergraph models to `model_config` with `ConfigDict`
- replace deprecated `.dict()` calls with `.model_dump()` across codebase

## Testing
- `PYTHONPATH=. pytest tests/test_server.py tests/test_quiet_star.py tests/test_prompt_baking_anchor.py tests/test_orchestration_simple.py tests/test_rag_system_integration.py tests/evolution/test_evolution_comprehensive.py -q` *(failed: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_6898e42334a0832c847cecdfc33050e7