### PR TITLE
Externalize service secrets for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,9 @@ services:
       dockerfile: Dockerfile.credits-api
     ports:
       - "8002:8002"
+    env_file: .env
     environment:
-      - DATABASE_URL=postgresql://aivillage_user:aivillage_pass@postgres:5432/aivillage_credits
+      - DATABASE_URL=postgresql://aivillage_user:${POSTGRES_PASSWORD}@postgres:5432/aivillage_credits
       - PROMETHEUS_URL=http://prometheus:9090
     depends_on:
       - postgres
@@ -73,8 +74,9 @@ services:
     build:
       context: ./communications
       dockerfile: Dockerfile.credits-worker
+    env_file: .env
     environment:
-      - DATABASE_URL=postgresql://aivillage_user:aivillage_pass@postgres:5432/aivillage_credits
+      - DATABASE_URL=postgresql://aivillage_user:${POSTGRES_PASSWORD}@postgres:5432/aivillage_credits
       - PROMETHEUS_URL=http://prometheus:9090
       - CREDITS_API_URL=http://credits-api:8002
       - WORKER_INTERVAL=300  # 5 minutes
@@ -91,10 +93,11 @@ services:
   postgres:
     image: postgres:15
     container_name: ai-village-postgres
+    env_file: .env
     environment:
       - POSTGRES_DB=aivillage_credits
       - POSTGRES_USER=aivillage_user
-      - POSTGRES_PASSWORD=aivillage_pass
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
@@ -109,8 +112,9 @@ services:
   neo4j:
     image: neo4j:5.11-community
     container_name: ai-village-neo4j
+    env_file: .env
     environment:
-      - NEO4J_AUTH=neo4j/aivillage_neo4j
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}
       - NEO4J_PLUGINS=["apoc"]
       - NEO4J_apoc_export_file_enabled=true
       - NEO4J_apoc_import_file_enabled=true
@@ -127,7 +131,7 @@ services:
     networks:
       - ai-village-net
     healthcheck:
-      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "aivillage_neo4j", "MATCH (n) RETURN count(n)"]
+      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "${NEO4J_PASSWORD}", "MATCH (n) RETURN count(n)"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -137,7 +141,8 @@ services:
   redis:
     image: redis:7-alpine
     container_name: ai-village-redis
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-aivillage_redis}
+    env_file: .env
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
     ports:
       - "6379:6379"
     volumes:
@@ -181,16 +186,17 @@ services:
     container_name: ai-village-hyperag-mcp
     ports:
       - "8765:8765"  # MCP WebSocket port
+    env_file: .env
     environment:
       - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=neo4j
-      - NEO4J_PASSWORD=aivillage_neo4j
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-aivillage_redis}
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - QDRANT_HOST=qdrant
       - QDRANT_PORT=6333
-      - HYPERAG_JWT_SECRET=${HYPERAG_JWT_SECRET:-change-this-in-production}
+      - HYPERAG_JWT_SECRET=${HYPERAG_JWT_SECRET}
       - HYPERAG_LOG_LEVEL=${HYPERAG_LOG_LEVEL:-INFO}
     depends_on:
       - neo4j
@@ -235,8 +241,9 @@ services:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
+    env_file: .env
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-changeme}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource
     ports:

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,26 @@
+# Deployment Environment Variables
+
+The Docker Compose stack expects sensitive configuration to be supplied via environment variables.
+Provide these values in a local `.env` file or through your container orchestrator's secret manager
+before starting the services.
+
+Required variables:
+
+- `POSTGRES_PASSWORD` – password for the PostgreSQL credits database
+- `NEO4J_PASSWORD` – password for the Neo4j graph database
+- `REDIS_PASSWORD` – password for the Redis instance
+- `GRAFANA_PASSWORD` – admin password for Grafana
+- `HYPERAG_JWT_SECRET` – secret used to sign HyperRAG JWT tokens
+
+Example `.env` file:
+
+```dotenv
+POSTGRES_PASSWORD=change-me
+NEO4J_PASSWORD=change-me
+REDIS_PASSWORD=change-me
+GRAFANA_PASSWORD=change-me
+HYPERAG_JWT_SECRET=change-me
+```
+
+Ensure the `.env` file is kept out of version control and production secrets are stored in a secure
+manager provided by your deployment platform.


### PR DESCRIPTION
## Summary
- load credentials for database, graph, cache, and monitoring services from environment variables instead of hardcoding them
- document required deployment environment variables in docs

## Implementation Notes
- docker-compose services now include `env_file: .env` and reference `${VARIABLE}` placeholders for passwords and secrets
- added deployment README outlining variables that must be set via `.env` or secret manager

## Tradeoffs
- compose stack now requires `.env` or orchestrator secrets to be configured before start up

## Tests Added
- none

## Local Run Logs (lint/type/tests)
- `ruff check .` *(fails: 36024 errors)*
- `ruff format --check .` *(fails: parse errors)*
- `mypy .` *(fails: syntax error)*
- `pytest -q` *(fails: ModuleNotFoundError: core)*
- `pytest -q tests/p2p/test_dual_path.py -q` *(file not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(collection error)*


------
https://chatgpt.com/codex/tasks/task_e_689a8c97ab68832c8576c3d3ad3f6b1e