### PR TITLE
Validate P2P message schema

### DIFF
--- a/src/production/communications/p2p/p2p_node.py
+++ b/src/production/communications/p2p/p2p_node.py
@@ -395,6 +395,25 @@ class P2PNode:
             message_data = self.cipher.decrypt(encrypted_data)
             message_dict = json.loads(message_data.decode())
 
+            required_keys = {
+                "message_type",
+                "sender_id",
+                "receiver_id",
+                "payload",
+                "timestamp",
+                "message_id",
+            }
+            message_keys = set(message_dict)
+            missing = required_keys - message_keys
+            unexpected = message_keys - required_keys
+            if missing or unexpected:
+                logger.warning(
+                    "Invalid message schema. Missing: %s, unexpected: %s",
+                    missing,
+                    unexpected,
+                )
+                return None
+
             self.stats["bytes_received"] += 4 + length
             self.stats["messages_received"] += 1
 

--- a/tests/production/test_tensor_streaming_safe.py
+++ b/tests/production/test_tensor_streaming_safe.py
@@ -1,6 +1,12 @@
+import asyncio
+import json
+import time
+
 import numpy as np
+import pytest
 
 from src.infrastructure.p2p.tensor_streaming import TensorStreamer
+from src.production.communications.p2p.p2p_node import MessageType, P2PNode
 
 
 def test_safe_serialization_round_trip():
@@ -9,3 +15,42 @@ def test_safe_serialization_round_trip():
     data = streamer._serialize_tensor(array)
     restored = streamer._deserialize_tensor(data)
     assert np.array_equal(array, restored)
+
+
+@pytest.mark.asyncio
+async def test_receive_message_missing_field_rejected():
+    node = P2PNode()
+    reader = asyncio.StreamReader()
+    message = {
+        "message_type": MessageType.DATA.value,
+        "sender_id": "sender",
+        "receiver_id": "receiver",
+        "payload": {},
+        "timestamp": time.time(),
+        # Missing "message_id"
+    }
+    encrypted = node.cipher.encrypt(json.dumps(message).encode())
+    reader.feed_data(len(encrypted).to_bytes(4, "big"))
+    reader.feed_data(encrypted)
+    reader.feed_eof()
+    assert await node._receive_message_from_reader(reader) is None
+
+
+@pytest.mark.asyncio
+async def test_receive_message_unexpected_field_rejected():
+    node = P2PNode()
+    reader = asyncio.StreamReader()
+    message = {
+        "message_type": MessageType.DATA.value,
+        "sender_id": "sender",
+        "receiver_id": "receiver",
+        "payload": {},
+        "timestamp": time.time(),
+        "message_id": "123",
+        "extra": "nope",
+    }
+    encrypted = node.cipher.encrypt(json.dumps(message).encode())
+    reader.feed_data(len(encrypted).to_bytes(4, "big"))
+    reader.feed_data(encrypted)
+    reader.feed_eof()
+    assert await node._receive_message_from_reader(reader) is None


### PR DESCRIPTION
## Summary
- ensure `_receive_message_from_reader` enforces a strict message schema and rejects messages with missing or unexpected fields
- add negative tests covering messages lacking required fields or including extra keys

## Implementation Notes
- added required-key validation before deserializing into `P2PMessage`
- tests craft encrypted payloads to exercise schema checks

## Tradeoffs
- validation currently returns `None` on schema mismatch rather than raising for finer-grained error handling

## Tests Added
- `test_receive_message_missing_field_rejected`
- `test_receive_message_unexpected_field_rejected`

## Local Run Logs (lint/type/tests)
- `ruff check .` *(fails: logging style issues and others in unrelated files)*
- `ruff format --check .` *(fails: formatting issues in unrelated files)*
- `mypy .` *(fails: syntax error in agents/atlantis_meta_agents/economy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: test path not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ModuleNotFoundError: No module named 'agent_forge.forge_orchestrator')*
- `pytest -q tests/production/test_tensor_streaming_safe.py` *(fails: TypeError in TensorStreaming class definition)*

------
https://chatgpt.com/codex/tasks/task_e_689a8c9ed2d0832cb5c8a08cee6522d2