### PR TITLE
Enforce HTTPS for Qdrant connections

### DIFF
--- a/docs/rag/SECURITY.md
+++ b/docs/rag/SECURITY.md
@@ -1,0 +1,8 @@
+# RAG Security
+
+## Qdrant TLS Configuration
+
+- Set `QDRANT_URL` to an `https://` endpoint in production.
+- Provide TLS certificate and key paths via the `TLS_CERT_FILE` and `TLS_KEY_FILE` environment variables when hosting your own Qdrant instance.
+- Supply a CA bundle with `TLS_CA_FILE` or `REQUESTS_CA_BUNDLE` if using self-signed certificates.
+- The system will fail to start in production if `QDRANT_URL` uses plain `http://`.

--- a/scripts/archive/migrate_to_qdrant.py
+++ b/scripts/archive/migrate_to_qdrant.py
@@ -29,7 +29,17 @@ from rag_system.vector_store import FaissAdapter
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("qdrant-migrator")
 
-QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
+
+def _get_qdrant_url() -> str:
+    """Return validated Qdrant URL based on environment."""
+    url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    if os.getenv("AIVILLAGE_ENV") == "production" and url.startswith("http://"):
+        msg = "QDRANT_URL must use https:// in production"
+        raise ValueError(msg)
+    return url
+
+
+QDRANT_URL = _get_qdrant_url()
 COLLECTION = os.getenv("COLLECTION_NAME", "ai_village_vectors")
 BATCH = 100
 DIMENSION = 768

--- a/src/core/config/environment_validator.py
+++ b/src/core/config/environment_validator.py
@@ -795,6 +795,18 @@ class EnvironmentValidator:
                         )
                     )
 
+            qdrant_url = env_vars.get("QDRANT_URL")
+            if qdrant_url and qdrant_url.startswith("http://"):
+                self.report.add_issue(
+                    ValidationIssue(
+                        variable="QDRANT_URL",
+                        level=ValidationLevel.ERROR,
+                        result=ValidationResult.INSECURE,
+                        message="Production requires QDRANT_URL to use https://",
+                        suggestion="Use an HTTPS Qdrant endpoint and provide proper certificates",
+                    )
+                )
+
     def generate_report(self) -> str:
         """Generate human-readable validation report."""
         report_lines = [

--- a/src/production/rag/rag_system/vector_store.py
+++ b/src/production/rag/rag_system/vector_store.py
@@ -10,8 +10,18 @@ from .faiss_backend import FaissAdapter
 
 logger = logging.getLogger(__name__)
 
+
+def _get_qdrant_url() -> str:
+    """Return validated Qdrant URL based on environment."""
+    url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    if os.getenv("AIVILLAGE_ENV") == "production" and url.startswith("http://"):
+        msg = "QDRANT_URL must use https:// in production"
+        raise ValueError(msg)
+    return url
+
+
 USE_QDRANT = os.getenv("RAG_USE_QDRANT", "0") == "1"
-QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
+QDRANT_URL = _get_qdrant_url()
 COLLECTION_NAME = os.getenv("COLLECTION_NAME", "ai_village_vectors")
 
 

--- a/tests/rag/test_qdrant_https.py
+++ b/tests/rag/test_qdrant_https.py
@@ -1,0 +1,31 @@
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+MODULE_PATH = "src.production.rag.rag_system.vector_store"
+
+
+def import_vector_store():
+    if MODULE_PATH in os.sys.modules:
+        del os.sys.modules[MODULE_PATH]
+    return importlib.import_module(MODULE_PATH)
+
+
+def test_https_endpoint_allowed(monkeypatch):
+    monkeypatch.setenv("AIVILLAGE_ENV", "production")
+    monkeypatch.setenv("RAG_USE_QDRANT", "1")
+    monkeypatch.setenv("QDRANT_URL", "https://example.com")
+    with patch("qdrant_client.QdrantClient.get_collections", return_value={}):
+        module = import_vector_store()
+        store = module.VectorStore()
+        assert module.QDRANT_URL.startswith("https://")
+        assert store.backend is not store.faiss
+
+
+def test_http_endpoint_disallowed(monkeypatch):
+    monkeypatch.setenv("AIVILLAGE_ENV", "production")
+    monkeypatch.setenv("QDRANT_URL", "http://example.com")
+    with pytest.raises(ValueError):
+        import_vector_store()


### PR DESCRIPTION
## Summary
- validate `QDRANT_URL` and reject plain HTTP in production
- document TLS certificate setup for RAG's Qdrant backend
- add integration test covering HTTPS Qdrant usage

## Implementation Notes
- added environment-level validation and runtime checks for Qdrant URLs
- test mocks `QdrantClient.get_collections` to avoid network calls

## Tradeoffs
- repo-wide linting, type checking, and unrelated tests currently fail

## Tests Added
- `tests/rag/test_qdrant_https.py`

## Local Run Logs (lint/type/tests)
- `ruff check .` *(fails: Found 36026 errors)*
- `ruff format --check .` *(fails: parse errors in unrelated files)*
- `mypy .` *(fails: Unexpected character after line continuation character)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: file or directory not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ModuleNotFoundError: No module named 'agent_forge.forge_orchestrator')*
- `pytest tests/rag/test_qdrant_https.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8ca3284c832cba3c91a8616af089