### PR TITLE
Unify P2PNode implementation

### DIFF
--- a/src/production/agent_forge/evolution/evolution_coordination_protocol.py
+++ b/src/production/agent_forge/evolution/evolution_coordination_protocol.py
@@ -8,8 +8,8 @@ import time
 from typing import Any
 import uuid
 
-from AIVillage.src.core.p2p import P2PNode
-from AIVillage.src.core.p2p.message_protocol import (
+from src.core.p2p import P2PNode
+from src.core.p2p.message_protocol import (
     EvolutionMessage,
     MessagePriority,
     MessageType,

--- a/src/production/agent_forge/evolution/infrastructure_aware_evolution.py
+++ b/src/production/agent_forge/evolution/infrastructure_aware_evolution.py
@@ -7,8 +7,8 @@ import time
 from typing import Any
 
 # Import P2P and resource management components
-from AIVillage.src.core.p2p import P2PNode
-from AIVillage.src.core.resources import (
+from src.core.p2p import P2PNode
+from src.core.resources import (
     AdaptiveLoader,
     ConstraintManager,
     DeviceProfiler,

--- a/src/production/communications/p2p/p2p_node.py
+++ b/src/production/communications/p2p/p2p_node.py
@@ -1,45 +1,23 @@
-"""P2P Node Implementation with Fallback for Windows Development."""
+"""Compatibility layer for production P2P components.
 
-import asyncio
-from collections.abc import Callable
+This module exposes lightweight message and peer data structures while
+reusing the core :class:`P2PNode` implementation.  The adapter keeps a
+subset of the legacy API to avoid widespread changes in production code.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
 from dataclasses import dataclass, field
 from enum import Enum
-import json
-import logging
-import time
-from typing import Any
-import uuid
+from typing import Any, Callable
 
-# Use local encryption instead of libp2p for Windows compatibility
-from cryptography.fernet import Fernet
-
-logger = logging.getLogger(__name__)
-
-
-class NodeStatus(Enum):
-    """Node connection status."""
-
-    OFFLINE = "offline"
-    CONNECTING = "connecting"
-    CONNECTED = "connected"
-    ERROR = "error"
-
-
-@dataclass
-class PeerInfo:
-    """Information about a peer node."""
-
-    peer_id: str
-    address: str
-    port: int
-    last_seen: float = field(default_factory=time.time)
-    status: NodeStatus = NodeStatus.OFFLINE
-    capabilities: dict[str, Any] = field(default_factory=dict)
-    latency_ms: float | None = None
+from src.core.p2p.p2p_node import P2PNode as CoreP2PNode, NodeStatus
 
 
 class MessageType(Enum):
-    """P2P message types."""
+    """Simplified message types for compatibility."""
 
     HANDSHAKE = "handshake"
     HEARTBEAT = "heartbeat"
@@ -52,7 +30,7 @@ class MessageType(Enum):
 
 @dataclass
 class P2PMessage:
-    """P2P message structure."""
+    """Lightweight P2P message structure."""
 
     message_type: MessageType
     sender_id: str
@@ -62,37 +40,33 @@ class P2PMessage:
     message_id: str = field(default_factory=lambda: str(uuid.uuid4()))
 
 
-class P2PNode:
-    """P2P Node for decentralized communication with Windows fallback."""
+@dataclass
+class PeerInfo:
+    """Information about a peer node."""
 
-    def __init__(
-        self,
-        node_id: str | None = None,
-        port: int = 8000,
-        encryption_key: bytes | None = None,
-    ) -> None:
-        self.node_id = node_id or str(uuid.uuid4())
-        self.port = port
-        self.status = NodeStatus.OFFLINE
+    peer_id: str
+    address: str
+    port: int
+    last_seen: float = field(default_factory=time.time)
+    status: NodeStatus = NodeStatus.DISCONNECTED
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    latency_ms: float | None = None
 
-        # Initialize encryption
-        self.encryption_key = encryption_key or Fernet.generate_key()
-        self.cipher = Fernet(self.encryption_key)
 
-        # Peer management
+class P2PNode(CoreP2PNode):
+    """Adapter around the core :class:`P2PNode` implementation.
+
+    The adapter preserves a small subset of the previous production API
+    by keeping attributes like ``peers`` and ``known_addresses`` while
+    delegating all networking responsibilities to the core class.
+    """
+
+    def __init__(self, node_id: str | None = None, port: int = 0, **kwargs: Any) -> None:
+        super().__init__(node_id=node_id, listen_port=port, **kwargs)
+        self.port = self.listen_port
         self.peers: dict[str, PeerInfo] = {}
         self.known_addresses: set[str] = set()
-
-        # Message handling
-        self.message_handlers: dict[MessageType, Callable] = {}
-        self.pending_responses: dict[str, asyncio.Future] = {}
-
-        # Network components
-        self.server: asyncio.Server | None = None
-        self.discovery_task: asyncio.Task | None = None
-        self.heartbeat_task: asyncio.Task | None = None
-
-        # Statistics
+        self.message_handlers: dict[MessageType, Callable[[P2PMessage], Any]] = {}
         self.stats = {
             "messages_sent": 0,
             "messages_received": 0,
@@ -100,453 +74,40 @@ class P2PNode:
             "bytes_received": 0,
             "connections_established": 0,
             "discovery_rounds": 0,
+            "start_time": time.time(),
         }
 
-        # Configuration
-        self.config = {
-            "heartbeat_interval": 30.0,  # seconds
-            "discovery_interval": 60.0,  # seconds
-            "connection_timeout": 10.0,  # seconds
-            "max_message_size": 1024 * 1024,  # 1MB
-            "max_peers": 100,
-        }
+    async def start(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - thin wrapper
+        await super().start(*args, **kwargs)
+        self.status = NodeStatus.ACTIVE
 
-        # Register default handlers
-        self._register_default_handlers()
-
-    def _register_default_handlers(self) -> None:
-        """Register default message handlers."""
-        self.message_handlers[MessageType.HANDSHAKE] = self._handle_handshake
-        self.message_handlers[MessageType.HEARTBEAT] = self._handle_heartbeat
-        self.message_handlers[MessageType.DISCOVERY] = self._handle_discovery
-
-    async def start(self) -> None:
-        """Start the P2P node."""
-        try:
-            logger.info(f"Starting P2P node {self.node_id} on port {self.port}")
-
-            # Start TCP server
-            self.server = await asyncio.start_server(self._handle_connection, "0.0.0.0", self.port)
-
-            # Start background tasks
-            self.discovery_task = asyncio.create_task(self._discovery_loop())
-            self.heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-
-            self.status = NodeStatus.CONNECTED
-            logger.info(f"P2P node {self.node_id} started successfully")
-
-        except Exception as e:
-            logger.exception(f"Failed to start P2P node: {e}")
-            self.status = NodeStatus.ERROR
-            raise
-
-    async def stop(self) -> None:
-        """Stop the P2P node."""
-        logger.info(f"Stopping P2P node {self.node_id}")
-
-        self.status = NodeStatus.OFFLINE
-
-        # Cancel background tasks
-        if self.discovery_task:
-            self.discovery_task.cancel()
-        if self.heartbeat_task:
-            self.heartbeat_task.cancel()
-
-        # Close server
-        if self.server:
-            self.server.close()
-            await self.server.wait_closed()
-
-        # Clear peers
-        self.peers.clear()
-
-        logger.info(f"P2P node {self.node_id} stopped")
-
-    async def connect_to_peer(self, address: str, port: int) -> bool:
-        """Connect to a peer node."""
-        try:
-            logger.debug(f"Connecting to peer at {address}:{port}")
-
-            reader, writer = await asyncio.wait_for(
-                asyncio.open_connection(address, port),
-                timeout=self.config["connection_timeout"],
-            )
-
-            # Send handshake
-            handshake_msg = P2PMessage(
-                message_type=MessageType.HANDSHAKE,
-                sender_id=self.node_id,
-                receiver_id="",
-                payload={
-                    "node_id": self.node_id,
-                    "capabilities": self._get_capabilities(),
-                    "timestamp": time.time(),
-                },
-            )
-
-            await self._send_message_to_writer(writer, handshake_msg)
-
-            # Wait for response
-            response = await self._receive_message_from_reader(reader)
-
-            if response and response.message_type == MessageType.HANDSHAKE:
-                peer_id = response.payload.get("node_id")
-                if peer_id:
-                    peer_info = PeerInfo(
-                        peer_id=peer_id,
-                        address=address,
-                        port=port,
-                        status=NodeStatus.CONNECTED,
-                        capabilities=response.payload.get("capabilities", {}),
-                    )
-                    self.peers[peer_id] = peer_info
-                    self.stats["connections_established"] += 1
-
-                    logger.info(f"Successfully connected to peer {peer_id}")
-                    writer.close()
-                    await writer.wait_closed()
-                    return True
-
-            writer.close()
-            await writer.wait_closed()
-            return False
-
-        except Exception as e:
-            logger.exception(f"Failed to connect to peer {address}:{port}: {e}")
-            return False
-
-    async def send_message(self, peer_id: str, message_type: MessageType, payload: dict[str, Any]) -> bool:
-        """Send a message to a specific peer."""
-        if peer_id not in self.peers:
-            logger.warning(f"Peer {peer_id} not found")
-            return False
-
-        peer = self.peers[peer_id]
-        if peer.status != NodeStatus.CONNECTED:
-            logger.warning(f"Peer {peer_id} not connected")
-            return False
-
-        try:
-            message = P2PMessage(
-                message_type=message_type,
-                sender_id=self.node_id,
-                receiver_id=peer_id,
-                payload=payload,
-            )
-
-            reader, writer = await asyncio.wait_for(
-                asyncio.open_connection(peer.address, peer.port),
-                timeout=self.config["connection_timeout"],
-            )
-
-            await self._send_message_to_writer(writer, message)
-            self.stats["messages_sent"] += 1
-
-            writer.close()
-            await writer.wait_closed()
-            return True
-
-        except Exception as e:
-            logger.exception(f"Failed to send message to peer {peer_id}: {e}")
-            peer.status = NodeStatus.ERROR
-            return False
-
-    async def broadcast_message(
-        self,
-        message_type: MessageType,
-        payload: dict[str, Any],
-        exclude_peers: set[str] | None = None,
-    ) -> int:
-        """Broadcast a message to all connected peers."""
-        exclude_peers = exclude_peers or set()
-        successful_sends = 0
-
-        for peer_id in self.peers:
-            if peer_id not in exclude_peers:
-                if await self.send_message(peer_id, message_type, payload):
-                    successful_sends += 1
-
-        return successful_sends
-
-    async def query_peer(
-        self,
-        peer_id: str,
-        query_type: str,
-        query_data: dict[str, Any],
-        timeout: float = 10.0,
-    ) -> dict[str, Any] | None:
-        """Send a query to a peer and wait for response."""
-        message_id = str(uuid.uuid4())
-
-        # Set up response future
-        response_future = asyncio.Future()
-        self.pending_responses[message_id] = response_future
-
-        try:
-            # Send query
-            payload = {
-                "query_type": query_type,
-                "query_data": query_data,
-                "message_id": message_id,
-                "expect_response": True,
-            }
-
-            success = await self.send_message(peer_id, MessageType.DATA, payload)
-
-            if not success:
-                return None
-
-            # Wait for response
-            response = await asyncio.wait_for(response_future, timeout=timeout)
-            return response
-
-        except asyncio.TimeoutError:
-            logger.warning(f"Query to peer {peer_id} timed out")
-            return None
-        except Exception as e:
-            logger.exception(f"Query to peer {peer_id} failed: {e}")
-            return None
-        finally:
-            self.pending_responses.pop(message_id, None)
+    async def stop(self) -> None:  # pragma: no cover - thin wrapper
+        await super().stop()
+        self.status = NodeStatus.DISCONNECTED
 
     def add_known_address(self, address: str, port: int) -> None:
-        """Add a known peer address for discovery."""
+        """Record a peer address for later discovery."""
         self.known_addresses.add(f"{address}:{port}")
 
     def register_handler(self, message_type: MessageType, handler: Callable[[P2PMessage], Any]) -> None:
-        """Register a custom message handler."""
+        """Register a message handler for a given type."""
         self.message_handlers[message_type] = handler
 
     def get_peer_info(self, peer_id: str) -> PeerInfo | None:
-        """Get information about a specific peer."""
+        """Return information about a specific peer."""
         return self.peers.get(peer_id)
 
     def get_connected_peers(self) -> list[PeerInfo]:
-        """Get list of all connected peers."""
-        return [peer for peer in self.peers.values() if peer.status == NodeStatus.CONNECTED]
+        """Return peers currently marked as active."""
+        return [p for p in self.peers.values() if p.status == NodeStatus.ACTIVE]
 
     def get_stats(self) -> dict[str, Any]:
-        """Get node statistics."""
+        """Return basic node statistics."""
         return {
             **self.stats,
             "node_id": self.node_id,
             "status": self.status.value,
             "connected_peers": len(self.get_connected_peers()),
             "total_peers": len(self.peers),
-            "uptime": time.time() - self.stats.get("start_time", time.time()),
-        }
-
-    async def _handle_connection(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        """Handle incoming connection."""
-        peer_address = writer.get_extra_info("peername")
-        logger.debug(f"Incoming connection from {peer_address}")
-
-        try:
-            message = await self._receive_message_from_reader(reader)
-
-            if message:
-                await self._process_message(message, writer)
-
-        except Exception as e:
-            logger.exception(f"Error handling connection from {peer_address}: {e}")
-        finally:
-            writer.close()
-            await writer.wait_closed()
-
-    async def _send_message_to_writer(self, writer: asyncio.StreamWriter, message: P2PMessage) -> None:
-        """Send a message through a writer."""
-        # Serialize and encrypt message
-        message_data = json.dumps(
-            {
-                "message_type": message.message_type.value,
-                "sender_id": message.sender_id,
-                "receiver_id": message.receiver_id,
-                "payload": message.payload,
-                "timestamp": message.timestamp,
-                "message_id": message.message_id,
-            }
-        ).encode()
-
-        encrypted_data = self.cipher.encrypt(message_data)
-
-        # Send length prefix + encrypted data
-        length = len(encrypted_data)
-        writer.write(length.to_bytes(4, byteorder="big"))
-        writer.write(encrypted_data)
-        await writer.drain()
-
-        self.stats["bytes_sent"] += 4 + length
-
-    async def _receive_message_from_reader(self, reader: asyncio.StreamReader) -> P2PMessage | None:
-        """Receive a message from a reader."""
-        try:
-            # Read length prefix
-            length_data = await reader.readexactly(4)
-            length = int.from_bytes(length_data, byteorder="big")
-
-            if length > self.config["max_message_size"]:
-                logger.warning(f"Message too large: {length} bytes")
-                return None
-
-            # Read encrypted message
-            encrypted_data = await reader.readexactly(length)
-
-            # Decrypt and deserialize
-            message_data = self.cipher.decrypt(encrypted_data)
-            message_dict = json.loads(message_data.decode())
-
-            self.stats["bytes_received"] += 4 + length
-            self.stats["messages_received"] += 1
-
-            return P2PMessage(
-                message_type=MessageType(message_dict["message_type"]),
-                sender_id=message_dict["sender_id"],
-                receiver_id=message_dict["receiver_id"],
-                payload=message_dict["payload"],
-                timestamp=message_dict["timestamp"],
-                message_id=message_dict["message_id"],
-            )
-
-        except Exception as e:
-            logger.exception(f"Failed to receive message: {e}")
-            return None
-
-    async def _process_message(self, message: P2PMessage, writer: asyncio.StreamWriter | None = None) -> None:
-        """Process an incoming message."""
-        logger.debug(f"Processing {message.message_type.value} from {message.sender_id}")
-
-        # Handle response to pending query
-        if message.payload.get("response_to"):
-            response_id = message.payload["response_to"]
-            if response_id in self.pending_responses:
-                self.pending_responses[response_id].set_result(message.payload)
-                return
-
-        # Route to appropriate handler
-        handler = self.message_handlers.get(message.message_type)
-        if handler:
-            try:
-                await handler(message, writer)
-            except Exception as e:
-                logger.exception(f"Error in handler for {message.message_type.value}: {e}")
-        else:
-            logger.warning(f"No handler for message type {message.message_type.value}")
-
-    async def _handle_handshake(self, message: P2PMessage, writer: asyncio.StreamWriter | None = None) -> None:
-        """Handle handshake message."""
-        sender_id = message.payload.get("node_id")
-
-        if sender_id and sender_id != self.node_id:
-            # Create peer info
-            peer = PeerInfo(
-                peer_id=sender_id,
-                address="",  # Will be updated
-                port=0,
-                status=NodeStatus.CONNECTED,
-                capabilities=message.payload.get("capabilities", {}),
-            )
-            self.peers[sender_id] = peer
-
-            # Send handshake response
-            if writer:
-                response = P2PMessage(
-                    message_type=MessageType.HANDSHAKE,
-                    sender_id=self.node_id,
-                    receiver_id=sender_id,
-                    payload={
-                        "node_id": self.node_id,
-                        "capabilities": self._get_capabilities(),
-                        "timestamp": time.time(),
-                    },
-                )
-                await self._send_message_to_writer(writer, response)
-
-            logger.info(f"Handshake completed with peer {sender_id}")
-
-    async def _handle_heartbeat(self, message: P2PMessage, writer: asyncio.StreamWriter | None = None) -> None:
-        """Handle heartbeat message."""
-        sender_id = message.sender_id
-
-        if sender_id in self.peers:
-            self.peers[sender_id].last_seen = time.time()
-            self.peers[sender_id].status = NodeStatus.CONNECTED
-
-    async def _handle_discovery(self, message: P2PMessage, writer: asyncio.StreamWriter | None = None) -> None:
-        """Handle peer discovery message."""
-        peer_list = message.payload.get("peers", [])
-
-        for peer_info in peer_list:
-            address = peer_info.get("address")
-            port = peer_info.get("port")
-
-            if address and port:
-                self.add_known_address(address, port)
-
-    async def _discovery_loop(self) -> None:
-        """Background task for peer discovery."""
-        while self.status == NodeStatus.CONNECTED:
-            try:
-                # Try to connect to known addresses
-                for addr_port in list(self.known_addresses):
-                    if len(self.peers) >= self.config["max_peers"]:
-                        break
-
-                    address, port = addr_port.split(":")
-                    port = int(port)
-
-                    # Skip if already connected
-                    if any(p.address == address and p.port == port for p in self.peers.values()):
-                        continue
-
-                    await self.connect_to_peer(address, port)
-
-                self.stats["discovery_rounds"] += 1
-                await asyncio.sleep(self.config["discovery_interval"])
-
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.exception(f"Error in discovery loop: {e}")
-                await asyncio.sleep(10)  # Back off on error
-
-    async def _heartbeat_loop(self) -> None:
-        """Background task for sending heartbeats."""
-        while self.status == NodeStatus.CONNECTED:
-            try:
-                # Send heartbeat to all connected peers
-                heartbeat_payload = {
-                    "timestamp": time.time(),
-                    "status": self.status.value,
-                }
-
-                await self.broadcast_message(MessageType.HEARTBEAT, heartbeat_payload)
-
-                # Check for stale peers
-                current_time = time.time()
-                stale_peers = []
-
-                for peer_id, peer in self.peers.items():
-                    if current_time - peer.last_seen > self.config["heartbeat_interval"] * 3:
-                        stale_peers.append(peer_id)
-
-                # Remove stale peers
-                for peer_id in stale_peers:
-                    del self.peers[peer_id]
-                    logger.info(f"Removed stale peer {peer_id}")
-
-                await asyncio.sleep(self.config["heartbeat_interval"])
-
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.exception(f"Error in heartbeat loop: {e}")
-                await asyncio.sleep(10)
-
-    def _get_capabilities(self) -> dict[str, Any]:
-        """Get node capabilities."""
-        return {
-            "version": "1.0.0",
-            "protocols": ["tensor_streaming", "mesh_routing"],
-            "max_message_size": self.config["max_message_size"],
-            "encryption": "fernet",
+            "uptime": time.time() - self.stats["start_time"],
         }

--- a/src/production/distributed_agents/agent_migration_manager.py
+++ b/src/production/distributed_agents/agent_migration_manager.py
@@ -13,7 +13,7 @@ import time
 from typing import Any
 import uuid
 
-from AIVillage.src.core.p2p.p2p_node import P2PNode
+from src.core.p2p import P2PNode
 
 from .distributed_agent_orchestrator import AgentInstance, AgentType, DeviceProfile
 

--- a/src/production/distributed_agents/distributed_agent_orchestrator.py
+++ b/src/production/distributed_agents/distributed_agent_orchestrator.py
@@ -12,7 +12,7 @@ import time
 from typing import Any
 import uuid
 
-from AIVillage.src.core.p2p.p2p_node import P2PNode
+from src.core.p2p import P2PNode
 from AIVillage.src.core.resources.resource_monitor import ResourceMonitor
 from AIVillage.src.production.distributed_inference.model_sharding_engine import (
     DeviceProfile,

--- a/src/production/distributed_inference/adaptive_resharding.py
+++ b/src/production/distributed_inference/adaptive_resharding.py
@@ -14,7 +14,7 @@ import time
 from typing import Any
 import uuid
 
-from AIVillage.src.core.p2p.p2p_node import P2PNode
+from src.core.p2p import P2PNode
 
 from .model_sharding_engine import ModelShard, ModelShardingEngine, ShardingPlan
 

--- a/src/production/distributed_inference/model_sharding_engine.py
+++ b/src/production/distributed_inference/model_sharding_engine.py
@@ -14,7 +14,7 @@ import uuid
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # Import Sprint 6 infrastructure
-from AIVillage.src.core.p2p.p2p_node import P2PNode, PeerCapabilities
+from src.core.p2p import P2PNode, PeerCapabilities
 from AIVillage.src.core.resources.device_profiler import DeviceProfiler
 from AIVillage.src.core.resources.resource_monitor import ResourceMonitor
 

--- a/src/production/distributed_inference/test_adaptive_resharding.py
+++ b/src/production/distributed_inference/test_adaptive_resharding.py
@@ -61,7 +61,7 @@ ReshardingReason = reshard_module.ReshardingReason
 ReshardingStrategy = reshard_module.ReshardingStrategy
 ReshardingConfig = reshard_module.ReshardingConfig
 
-from src.core.p2p.p2p_node import PeerCapabilities
+from src.core.p2p import PeerCapabilities
 
 
 class DummyP2PNode:

--- a/src/production/distributed_inference/test_memory_partitioning.py
+++ b/src/production/distributed_inference/test_memory_partitioning.py
@@ -48,7 +48,7 @@ ShardingStrategy = mse.ShardingStrategy
 DeviceProfile = mse.DeviceProfile
 ShardingPlan = mse.ShardingPlan
 
-from src.core.p2p.p2p_node import PeerCapabilities
+from src.core.p2p import PeerCapabilities
 
 
 class DummyP2PNode:

--- a/src/production/distributed_inference/test_model_sharding.py
+++ b/src/production/distributed_inference/test_model_sharding.py
@@ -49,7 +49,7 @@ ShardingStrategy = mse.ShardingStrategy
 DeviceProfile = mse.DeviceProfile
 ShardingPlan = mse.ShardingPlan
 
-from src.core.p2p.p2p_node import PeerCapabilities
+from src.core.p2p import PeerCapabilities
 
 
 class DummyP2PNode:

--- a/src/production/federated_learning/federated_coordinator.py
+++ b/src/production/federated_learning/federated_coordinator.py
@@ -18,8 +18,8 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
-from AIVillage.src.core.p2p.p2p_node import P2PNode, PeerCapabilities
-from AIVillage.src.production.evolution.infrastructure_aware_evolution import (
+from src.core.p2p import P2PNode, PeerCapabilities
+from src.production.agent_forge.evolution.infrastructure_aware_evolution import (
     InfrastructureAwareEvolution,
 )
 

--- a/tests/communications/test_p2p.py
+++ b/tests/communications/test_p2p.py
@@ -34,7 +34,7 @@ class TestP2PNode:
 
         assert node.node_id == "test-node"
         assert node.port == 8001
-        assert node.status == NodeStatus.OFFLINE
+        assert node.status == NodeStatus.STARTING
         assert len(node.peers) == 0
 
     @pytest.mark.asyncio
@@ -45,7 +45,7 @@ class TestP2PNode:
         # Test start
         try:
             await node.start()
-            assert node.status == NodeStatus.CONNECTED
+            assert node.status == NodeStatus.ACTIVE
             assert node.server is not None
         except Exception as e:
             # May fail on Windows without proper network setup
@@ -53,7 +53,7 @@ class TestP2PNode:
         finally:
             # Test stop
             await node.stop()
-            assert node.status == NodeStatus.OFFLINE
+            assert node.status == NodeStatus.DISCONNECTED
 
     @pytest.mark.asyncio
     async def test_message_serialization(self):
@@ -87,7 +87,7 @@ class TestP2PNode:
             peer_id="peer-1",
             address="127.0.0.1",
             port=8005,
-            status=NodeStatus.CONNECTED,
+            status=NodeStatus.ACTIVE,
         )
 
         node.peers["peer-1"] = peer_info
@@ -107,7 +107,7 @@ class TestP2PNode:
         assert "connected_peers" in stats
         assert "total_peers" in stats
         assert stats["node_id"] == "test-node"
-        assert stats["status"] == NodeStatus.OFFLINE.value
+        assert stats["status"] == NodeStatus.STARTING.value
 
 
 class TestDeviceMesh:


### PR DESCRIPTION
## Summary
- replace production P2PNode with adapter around core implementation
- update production modules to import P2PNode from unified core path
- align P2P tests with new NodeStatus semantics

## Implementation Notes
- adapter exposes legacy attributes while delegating networking to core P2PNode
- imports across distributed, federated and agent modules now resolve through `src.core.p2p`

## Tradeoffs
- compatibility layer offers only minimal legacy behavior; advanced features may require further adaptation

## Tests Added
- none

## Local run logs (lint/type/tests)
- `ruff check .` *(fails: experimental/services/services/wave_bridge/app_enhanced.py:159:89 E501 Line too long (91 > 88))*
- `ruff format --check .` *(fails: src/agent_forge/bakedquietiot/quiet_star.py:165:89 E501 Line too long (91 > 88))*
- `mypy .` *(fails: src/agent_forge/evolution/safe_code_modifier.py:813:23 DTZ005 datetime.datetime.now() called without tz)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: file or directory not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ModuleNotFoundError: No module named 'agent_forge.forge_orchestrator')*


------
https://chatgpt.com/codex/tasks/task_e_689a8ca49768832cb33f5ce98153319b