### PR TITLE
Add battery-aware device profiling and sharding filter

### DIFF
--- a/src/core/resources/device_profiler.py
+++ b/src/core/resources/device_profiler.py
@@ -171,6 +171,11 @@ class DeviceProfile:
     cpu_cores: int
     cpu_model: str
 
+    # Power characteristics
+    battery_capacity_wh: float | None = None
+    battery_percent: float | None = None
+    power_plugged: bool | None = None
+
     # Feature support
     supports_gpu: bool = False
     supports_bluetooth: bool = False
@@ -340,6 +345,7 @@ class DeviceProfiler:
         # Set evolution constraints based on device type and performance
         max_evolution_memory = self._calculate_max_evolution_memory(memory.total, device_type)
         max_evolution_cpu = self._calculate_max_evolution_cpu(device_type)
+        battery_percent, power_plugged, _power_state = self._get_power_info()
 
         return DeviceProfile(
             device_id=self.device_id,
@@ -350,6 +356,8 @@ class DeviceProfiler:
             total_memory_gb=memory.total / (1024**3),
             cpu_cores=psutil.cpu_count(logical=True),
             cpu_model=cpu_info.get("model", "Unknown"),
+            battery_percent=battery_percent,
+            power_plugged=power_plugged,
             supports_gpu=self._detect_gpu_support(),
             supports_bluetooth=self._detect_bluetooth_support(),
             supports_wifi=self._detect_wifi_support(),

--- a/src/production/distributed_inference/model_sharding_engine.py
+++ b/src/production/distributed_inference/model_sharding_engine.py
@@ -68,6 +68,7 @@ class DeviceProfile:
     compute_score: float
     network_latency_ms: float
     battery_level: float | None = None
+    is_charging: bool | None = None
     thermal_state: str = "normal"
     reliability_score: float = 0.8
 
@@ -269,8 +270,11 @@ class ModelShardingEngine:
                 reliability_score=peer.trust_score,
             )
 
-            # Filter out unreliable devices
-            if device_profile.reliability_score >= self.config["reliability_threshold"]:
+            # Filter out unreliable or low-battery devices
+            if (
+                device_profile.reliability_score >= self.config["reliability_threshold"]
+                and (device_profile.battery_level is None or device_profile.battery_level >= 20)
+            ):
                 device_profiles.append(device_profile)
 
         # Sort by suitability (memory + compute + reliability)

--- a/tests/distributed_inference/test_mobile_nodes.py
+++ b/tests/distributed_inference/test_mobile_nodes.py
@@ -1,0 +1,74 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.core.p2p.p2p_node import P2PNode, PeerCapabilities
+from src.core.resources.device_profiler import DeviceProfiler
+from src.core.resources.resource_monitor import ResourceMonitor
+from src.production.distributed_inference.model_sharding_engine import (
+    ModelShardingEngine,
+    ShardingStrategy,
+)
+
+
+@pytest.fixture
+def mock_p2p_node():
+    node = AsyncMock(spec=P2PNode)
+    node.node_id = "test_node_mobile"
+    node.peer_registry = {}
+    node.get_suitable_evolution_peers.return_value = []
+    node.broadcast_to_peers = AsyncMock(return_value=1)
+    return node
+
+
+@pytest.fixture
+def mock_resource_monitor():
+    return AsyncMock(spec=ResourceMonitor)
+
+
+@pytest.fixture
+def mock_device_profiler():
+    profiler = AsyncMock(spec=DeviceProfiler)
+    profiler.current_snapshot = None
+    return profiler
+
+
+@pytest.mark.asyncio
+async def test_skip_low_battery_devices(mock_p2p_node, mock_resource_monitor, mock_device_profiler):
+    engine = ModelShardingEngine(mock_p2p_node, mock_resource_monitor, mock_device_profiler)
+
+    high_peer = PeerCapabilities(
+        device_id="high",
+        cpu_cores=4,
+        ram_mb=8192,
+        battery_percent=80,
+        trust_score=0.9,
+        evolution_capacity=0.9,
+    )
+    low_peer = PeerCapabilities(
+        device_id="low",
+        cpu_cores=4,
+        ram_mb=8192,
+        battery_percent=10,
+        trust_score=0.9,
+        evolution_capacity=0.9,
+    )
+
+    mock_p2p_node.local_capabilities = high_peer
+    mock_p2p_node.get_suitable_evolution_peers.return_value = [high_peer, low_peer]
+    mock_p2p_node.peer_registry = {"high": high_peer, "low": low_peer}
+
+    analysis = {
+        "model_path": "dummy",
+        "num_layers": 4,
+        "layer_memory_mb": 10.0,
+        "layer_compute_score": 1.0,
+    }
+
+    with patch.object(
+        ModelShardingEngine, "_analyze_model", AsyncMock(return_value=analysis)
+    ), patch.object(ModelShardingEngine, "_activate_sharding_plan", AsyncMock()):
+        plan = await engine.shard_model("dummy", ShardingStrategy.MEMORY_AWARE)
+
+    used_devices = {shard.device_id for shard in plan.shards}
+    assert "low" not in used_devices
+    assert "high" in used_devices


### PR DESCRIPTION
## Summary
- Track battery capacity, level, and power status in the core `DeviceProfile`
- Ignore devices below 20% battery when generating sharding plans
- Add integration test simulating low-battery mobile nodes

## Implementation Notes
- Device profiler now records battery stats via `_get_power_info`
- Sharding engine `DeviceProfile` extended with `is_charging`
- `_get_device_profiles` filters out low-battery candidates

## Tradeoffs
- `ruff`, `ruff format`, and `mypy` report pre-existing issues in unrelated files
- Full `pytest` run fails during collection due to missing modules

## Tests Added
- `tests/distributed_inference/test_mobile_nodes.py`

## Local Run Logs (lint/type/tests)
- `ruff check .` (fails: existing lint issues)  
- `ruff format --check .` (fails: parsing issues & many files need formatting)  
- `mypy .` (fails: syntax error in unrelated file)  
- `pytest -q` (fails: ModuleNotFoundError during collection)  
- `pytest -q tests/p2p/test_dual_path.py -q` (fails: file not found)  
- `pytest -q tests/test_orchestrator_integration.py -q` (fails: missing module)  
- `pytest -q tests/distributed_inference/test_mobile_nodes.py` (passes)


------
https://chatgpt.com/codex/tasks/task_e_689a8cae1714832c8183419a4206ae84