### PR TITLE
Detect conflicting retrieval sources in EnhancedQueryProcessor

### DIFF
--- a/tests/query_processing/test_conflict_detection.py
+++ b/tests/query_processing/test_conflict_detection.py
@@ -1,0 +1,53 @@
+import sys
+
+sys.path.append("src/production/rag/rag_system/core")
+
+from codex_rag_integration import RetrievalResult
+from enhanced_query_processor import EnhancedQueryProcessor, RankedResult
+
+
+class DummyPipeline:
+    pass
+
+
+def _build_result(text: str, score: float) -> RankedResult:
+    return RankedResult(
+        result=RetrievalResult(
+            chunk_id=f"c{score}",
+            document_id=f"d{score}",
+            text=text,
+            score=score,
+            retrieval_method="vector",
+            metadata=None,
+        ),
+        semantic_score=score,
+        trust_score=score,
+        context_score=score,
+        recency_score=score,
+        idea_completeness_score=1.0,
+        final_score=score,
+    )
+
+
+def test_rank_and_select_detects_conflict() -> None:
+    processor = EnhancedQueryProcessor(rag_pipeline=DummyPipeline())
+    result1 = _build_result("The sky is blue.", 0.9)
+    result2 = _build_result("The sky is not blue.", 0.8)
+
+    primary, supporting, conflicting = processor._rank_and_select([result1, result2])
+
+    assert primary == [result1]
+    assert conflicting == [result2]
+    assert supporting == []
+
+
+def test_rank_and_select_no_conflict() -> None:
+    processor = EnhancedQueryProcessor(rag_pipeline=DummyPipeline())
+    result1 = _build_result("The sky is blue.", 0.9)
+    result2 = _build_result("Water is wet.", 0.8)
+
+    primary, supporting, conflicting = processor._rank_and_select([result1, result2])
+
+    assert primary == [result1]
+    assert supporting == [result2]
+    assert conflicting == []


### PR DESCRIPTION
## Summary
- detect conflicting retrieval sources using cosine similarity and negation rules
- surface conflicts in synthesized answers and executive summaries
- add unit tests for conflict detection ranking

## Implementation Notes
- uses TF-IDF vectors and cosine similarity with negation heuristics

## Tradeoffs
- simplistic negation-based conflict heuristic may miss nuanced contradictions

## Tests Added
- `tests/query_processing/test_conflict_detection.py`

## Local Run Logs (lint/type/tests)
- `ruff check .` *(fails: PLR2004, DTZ005, etc.)*
- `ruff format --check .` *(fails: parsing errors and formatting issues in unrelated files)*
- `mypy .` *(fails: Unexpected character after line continuation character in agents/atlantis_meta_agents/economy/__init__.py)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: file or directory not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ModuleNotFoundError: No module named 'agent_forge.forge_orchestrator')*


------
https://chatgpt.com/codex/tasks/task_e_689a8cd3fa68832c97e6ee2f91add676