### PR TITLE
Add production test failure report

### DIFF
--- a/issues/failing_production_tests.txt
+++ b/issues/failing_production_tests.txt
@@ -1,0 +1,16 @@
+# Failing Production Tests
+
+## Summary
+The production test suite fails during collection when running `pytest tests/production --cov=src/production`.
+
+## Details
+- **Test**: `tests/production/test_tensor_streaming_integration.py`
+- **Error**: `TypeError: unsupported operand type(s) for |: 'builtin_function_or_method' and 'NoneType'`
+- **Source**: `src/production/communications/p2p/tensor_streaming.py:255`
+
+## Impact
+- Coverage report is not generated.
+- Remaining tests are skipped because collection stops on error.
+
+## Suggested Action
+- Update the type hint for `progress_callback` in `tensor_streaming.py` to use `Callable` from `typing`.

--- a/production_test_report.md
+++ b/production_test_report.md
@@ -1,0 +1,15 @@
+# Production Test Report
+
+## Summary
+- Command: `pytest tests/production --cov=src/production`
+- Result: **Failed** during test collection
+- Coverage: Not reported due to collection error
+
+## Failing Tests
+1. `tests/production/test_tensor_streaming_integration.py`
+   - Error: `TypeError: unsupported operand type(s) for |: 'builtin_function_or_method' and 'NoneType'`
+   - Location: `src/production/communications/p2p/tensor_streaming.py:255`
+
+## Notes
+- Dependencies installed for test run: `torch`, `cryptography`, `bitsandbytes`.
+- Other tests in this suite were skipped due to the above error.


### PR DESCRIPTION
## Summary
- record production test results
- log failing test in issue tracker

## Implementation notes
- added `production_test_report.md` with failing test details and coverage note
- created `issues/failing_production_tests.txt` for `test_tensor_streaming_integration`

## Tradeoffs
- coverage report unavailable due to import error
- overall test suite remains failing

## Tests added
- none

## Local run logs (lint/type/tests)
- `ruff check .` (fails)  
- `ruff format --check .` (fails to parse several files)  
- `mypy .` (fails: Unexpected character after line continuation character)  
- `pytest tests/production --cov=src/production` (error: TypeError in tensor_streaming)  
- `pytest -q` (error: ModuleNotFoundError: No module named 'core')  
- `pytest -q tests/p2p/test_dual_path.py -q` (error: file or directory not found)  
- `pytest -q tests/test_orchestrator_integration.py -q` (error during collection)


------
https://chatgpt.com/codex/tasks/task_e_689a8cd5a220832cbb23ce3b382778e9