### PR TITLE
Validate P2P messages with pydantic models

### DIFF
--- a/tests/production/test_p2p_validation.py
+++ b/tests/production/test_p2p_validation.py
@@ -1,0 +1,46 @@
+import time
+
+from src.production.communications.p2p.p2p_node import P2PNode
+
+
+def test_invalid_handshake_payload_rejected() -> None:
+    node = P2PNode()
+    message = {
+        "message_type": "handshake",
+        "sender_id": "a",
+        "receiver_id": "b",
+        "payload": {"capabilities": {}},
+        "timestamp": time.time(),
+        "message_id": "1",
+    }
+    assert node._validate_message_dict(message) is None
+
+
+def test_valid_handshake_payload() -> None:
+    node = P2PNode()
+    message = {
+        "message_type": "handshake",
+        "sender_id": "a",
+        "receiver_id": "b",
+        "payload": {
+            "node_id": "a",
+            "capabilities": {},
+            "timestamp": time.time(),
+        },
+        "timestamp": time.time(),
+        "message_id": "3",
+    }
+    assert node._validate_message_dict(message) is not None
+
+
+def test_invalid_tensor_chunk_payload_rejected() -> None:
+    node = P2PNode()
+    message = {
+        "message_type": "tensor_chunk",
+        "sender_id": "a",
+        "receiver_id": "b",
+        "payload": {"tensor_id": "1", "chunk_index": 0},
+        "timestamp": time.time(),
+        "message_id": "2",
+    }
+    assert node._validate_message_dict(message) is None


### PR DESCRIPTION
Summary
- Introduced pydantic payload models for each P2P message type and validated incoming messages before constructing `P2PMessage`.
- Logged and rejected malformed messages and added tests for invalid payloads.

Implementation notes
- Validation performed via `_validate_message_dict` invoked in `_receive_message_from_reader`.
- Generic `DataPayload` allows arbitrary content while other message types enforce required fields.

Tradeoffs
- Repository contains unrelated lint/type/test failures which remain.

Tests added
- `tests/production/test_p2p_validation.py`

Local run logs (lint/type/tests)
- `ruff check .`
- `ruff format --check src/production/communications/p2p/p2p_node.py tests/production/test_p2p_validation.py`
- `mypy .` *(fails: Unexpected character after line continuation character in agents/atlantis_meta_agents/economy/__init__.py)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(file not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(error during collection)*


------
https://chatgpt.com/codex/tasks/task_e_689a8cdc90b8832cae0d6f1d63c5bb02