### PR TITLE
Add encrypted tensor caching and cleanup

### DIFF
--- a/tests/production/test_tensor_streaming_integration.py
+++ b/tests/production/test_tensor_streaming_integration.py
@@ -35,7 +35,9 @@ async def test_tensor_stream_round_trip(monkeypatch):
         return False
 
     # Bind the helper as a method on the sender node
-    monkeypatch.setattr(sender, "send_message", fake_send_message.__get__(sender, P2PNode))
+    monkeypatch.setattr(
+        sender, "send_message", fake_send_message.__get__(sender, P2PNode)
+    )
 
     tensor = np.arange(8, dtype=np.float32)
     tensor_id = await send_stream.send_tensor(tensor, "test", receiver.node_id)
@@ -106,3 +108,68 @@ async def test_corrupted_chunk_failure(monkeypatch):
 
     with pytest.raises(RuntimeError):
         await recv_stream._reconstruct_tensor(tensor_id)
+
+
+@pytest.mark.asyncio
+async def test_receive_tensor_clears_metadata(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    sender = P2PNode(node_id="sender4", port=9131)
+    receiver = P2PNode(node_id="receiver4", port=9132)
+
+    send_stream = TensorStreaming(node=sender)
+    recv_stream = TensorStreaming(node=receiver)
+
+    receiver.register_handler(MessageType.DATA, recv_stream._handle_tensor_chunk)
+
+    async def fake_send(self, peer_id, message_type, payload):
+        msg = P2PMessage(message_type, self.node_id, peer_id, payload)
+        handler = receiver.message_handlers.get(message_type)
+        if handler:
+            await handler(msg, None)
+            return True
+        return False
+
+    monkeypatch.setattr(sender, "send_message", fake_send.__get__(sender, P2PNode))
+
+    tensor = np.arange(4, dtype=np.float32)
+    tensor_id = await send_stream.send_tensor(tensor, "cleanup", receiver.node_id)
+
+    assert tensor_id in recv_stream.tensor_metadata
+
+    result = await recv_stream.receive_tensor(tensor_id, timeout=1.0)
+    assert result is not None
+    assert tensor_id not in recv_stream.tensor_metadata
+    assert tensor_id not in recv_stream.pending_chunks
+    assert not any(tmp_path.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_receive_tensor_uses_cache_dir(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "cache"
+    sender = P2PNode(node_id="sender5", port=9141)
+    receiver = P2PNode(node_id="receiver5", port=9142)
+
+    send_stream = TensorStreaming(node=sender)
+    recv_stream = TensorStreaming(node=receiver, cache_dir=str(cache_dir))
+
+    receiver.register_handler(MessageType.DATA, recv_stream._handle_tensor_chunk)
+
+    async def fake_send(self, peer_id, message_type, payload):
+        msg = P2PMessage(message_type, self.node_id, peer_id, payload)
+        handler = receiver.message_handlers.get(message_type)
+        if handler:
+            await handler(msg, None)
+            return True
+        return False
+
+    monkeypatch.setattr(sender, "send_message", fake_send.__get__(sender, P2PNode))
+
+    tensor = np.arange(4, dtype=np.float32)
+    tensor_id = await send_stream.send_tensor(tensor, "cached", receiver.node_id)
+
+    assert any(cache_dir.iterdir())
+
+    await recv_stream.receive_tensor(tensor_id, timeout=1.0)
+
+    assert tensor_id not in recv_stream.tensor_metadata
+    assert not any(cache_dir.iterdir())


### PR DESCRIPTION
## Summary
- Encrypt tensor cache files when a cache directory is provided, otherwise keep transfers in memory
- Clear cached chunk files and tensor metadata once transfers complete
- Add tests ensuring metadata and cache files are removed after successful transfers

## Implementation Notes
- Uses `cryptography.Fernet` for simple encryption of disk-cached tensor chunks
- Tensor metadata and file cache are cleaned on successful receive
- Added progress initialization to handle pre-received chunks

## Tradeoffs
- Linting and type checks fail in unrelated modules
- Repository-wide tests fail due to missing dependencies

## Tests Added
- `tests/production/test_tensor_streaming_integration.py::test_receive_tensor_clears_metadata`
- `tests/production/test_tensor_streaming_integration.py::test_receive_tensor_uses_cache_dir`

## Local Run Logs (lint/type/tests)
- `ruff check .` *(fails: numerous existing issues)*
- `ruff format --check .` *(fails: parse errors in unrelated files)*
- `mypy .` *(fails: syntax error in unrelated module)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ModuleNotFoundError: No module named 'agent_forge.forge_orchestrator')*
- `pytest tests/production/test_tensor_streaming_integration.py::test_receive_tensor_clears_metadata -q`
- `pytest tests/production/test_tensor_streaming_integration.py::test_receive_tensor_uses_cache_dir -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8ce170e4832c8a9b87a888b1af29