### PR TITLE
Handle torch tensors in tensor streaming

### DIFF
--- a/tests/production/test_tensor_streaming_integration.py
+++ b/tests/production/test_tensor_streaming_integration.py
@@ -4,6 +4,7 @@ import hashlib
 
 import numpy as np
 import pytest
+import torch
 
 from src.production.communications.p2p.p2p_node import MessageType, P2PMessage, P2PNode
 from src.production.communications.p2p.tensor_streaming import TensorStreaming
@@ -35,7 +36,9 @@ async def test_tensor_stream_round_trip(monkeypatch):
         return False
 
     # Bind the helper as a method on the sender node
-    monkeypatch.setattr(sender, "send_message", fake_send_message.__get__(sender, P2PNode))
+    monkeypatch.setattr(
+        sender, "send_message", fake_send_message.__get__(sender, P2PNode)
+    )
 
     tensor = np.arange(8, dtype=np.float32)
     tensor_id = await send_stream.send_tensor(tensor, "test", receiver.node_id)
@@ -50,6 +53,48 @@ async def test_tensor_stream_round_trip(monkeypatch):
     metadata = recv_stream.tensor_metadata[tensor_id]
     assert np.array_equal(reconstructed, tensor)
     assert metadata.tensor_id == tensor_id
+
+
+@pytest.mark.asyncio
+async def test_torch_tensor_stream_round_trip(monkeypatch):
+    sender = P2PNode(node_id="sender_torch", port=9131)
+    receiver = P2PNode(node_id="receiver_torch", port=9132)
+
+    send_stream = TensorStreaming(node=sender)
+    recv_stream = TensorStreaming(node=receiver)
+
+    receiver.register_handler(MessageType.DATA, recv_stream._handle_tensor_chunk)
+
+    async def fake_send_message(self, peer_id, message_type, payload):
+        assert peer_id == receiver.node_id
+        msg = P2PMessage(
+            message_type=message_type,
+            sender_id=self.node_id,
+            receiver_id=peer_id,
+            payload=payload,
+        )
+        handler = receiver.message_handlers.get(message_type)
+        if handler:
+            await handler(msg, None)
+            return True
+        return False
+
+    monkeypatch.setattr(
+        sender, "send_message", fake_send_message.__get__(sender, P2PNode)
+    )
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tensor = torch.arange(8, dtype=torch.float32, device=device)
+    tensor_id = await send_stream.send_tensor(tensor, "torch", receiver.node_id)
+
+    reconstructed = await recv_stream._reconstruct_tensor(tensor_id)
+    metadata = recv_stream.tensor_metadata[tensor_id]
+
+    assert isinstance(reconstructed, torch.Tensor)
+    assert reconstructed.device.type == tensor.device.type
+    assert reconstructed.dtype == tensor.dtype
+    assert torch.equal(reconstructed.cpu(), tensor.cpu())
+    assert metadata.is_torch is True
 
 
 @pytest.mark.asyncio

--- a/tests/production/test_tensor_streaming_safe.py
+++ b/tests/production/test_tensor_streaming_safe.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 from src.infrastructure.p2p.tensor_streaming import TensorStreamer
 
@@ -9,3 +10,15 @@ def test_safe_serialization_round_trip():
     data = streamer._serialize_tensor(array)
     restored = streamer._deserialize_tensor(data)
     assert np.array_equal(array, restored)
+
+
+def test_safe_torch_serialization_round_trip():
+    streamer = TensorStreamer()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tensor = torch.arange(10, dtype=torch.float32, device=device)
+    data = streamer._serialize_tensor(tensor)
+    restored = streamer._deserialize_tensor(data)
+    assert isinstance(restored, torch.Tensor)
+    assert restored.device.type == tensor.device.type
+    assert restored.dtype == tensor.dtype
+    assert torch.equal(restored.cpu(), tensor.cpu())


### PR DESCRIPTION
## Summary
- Extend tensor serialization and reconstruction to accept `torch.Tensor`
- Preserve tensor dtype and device information in metadata
- Test streaming PyTorch tensors between P2P nodes and safe serializer round-trips

## Implementation Notes
- Added `device` and `is_torch` fields to tensor metadata
- Convert torch tensors to numpy for transport and restore dtype/device on reconstruction

## Tradeoffs
- Torch support assumes availability of `torch` at runtime
- Repository-wide lint and tests currently report pre-existing errors

## Tests Added
- Streaming PyTorch tensors between nodes
- Safe serializer round-trip with torch tensors

## Local Run Logs (sanitized)
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `pytest -q`
- `pytest -q tests/p2p/test_dual_path.py -q`
- `pytest -q tests/test_orchestrator_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8cef3f28832cbeeb9711eb4f2e50