### PR TITLE
Add mobile profiling and compression benchmarks

### DIFF
--- a/mobile_readiness_report.md
+++ b/mobile_readiness_report.md
@@ -1,0 +1,17 @@
+# Mobile Readiness Report
+
+## Resource Profiling
+- **Generic 2GB Budget Phone:** CPU 60.0% | Peak Memory 501.0MB
+- **Xiaomi Redmi Note 10 (4GB):** CPU 0.0% | Peak Memory 501.0MB
+
+## Compression Benchmarks
+| Model  | Precision | Original KB | Compressed KB | Ratio |
+|-------|-----------|-------------|---------------|-------|
+| tiny  | float32   | 38.0        | 12.9          | 2.95x |
+| small | float32   | 922.5       | 235.8         | 3.91x |
+| medium| float32   | 3603.7      | 909.8         | 3.96x |
+| large | float32   | 14874.6     | 3732.9        | 3.98x |
+| tiny  | float16   | 20.7        | 12.8          | 1.62x |
+| small | float16   | 463.2       | 235.1         | 1.97x |
+| medium| float16   | 1804.2      | 907.3         | 1.99x |
+| large | float16   | 7440.1      | 3727.4        | 2.00x |

--- a/scripts/profile_mobile_resources.py
+++ b/scripts/profile_mobile_resources.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Profile memory and CPU usage on simulated mobile devices."""
+
+from __future__ import annotations
+
+import psutil
+import torch
+from torch import nn
+
+from mobile_device_simulator import DEVICE_PROFILES, MobileSimulator
+
+
+def profile_device(profile_key: str) -> dict[str, float | str]:
+    """Run inference on a tiny model and capture resource usage."""
+    profile = DEVICE_PROFILES[profile_key]
+    simulator = MobileSimulator(profile)
+    model = nn.Sequential(nn.Linear(256, 128), nn.ReLU(), nn.Linear(128, 10))
+    input_tensor = torch.randn(1, 256)
+
+    with simulator.simulate():
+        cpu_before = psutil.cpu_percent(interval=None)
+        stats = simulator.measure_inference(model, input_tensor)
+        cpu_after = psutil.cpu_percent(interval=None)
+
+    stats["cpu_percent"] = cpu_after if cpu_after else cpu_before
+    return stats
+
+
+def main() -> None:
+    for key in ["budget_2gb", "redmi_note_10"]:
+        stats = profile_device(key)
+        print(
+            f"{stats['device_profile']}: CPU {stats['cpu_percent']:.1f}% | "
+            f"Peak Memory {stats['memory_peak_mb']:.1f}MB"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `profile_mobile_resources.py` to simulate 2GB and 4GB devices and record CPU/memory usage
- extend `benchmark_compression.py` to run reduced-precision (float16) compression benchmarks
- document profiling and benchmark results in `mobile_readiness_report.md`

## Implementation Notes
- dynamically load `SimpleQuantizer` to avoid heavy package imports
- forced addition of report file due to repository ignore patterns

## Tradeoffs
- lint, format, and type checks report existing issues in unrelated modules
- pytest suite fails during collection because required modules are missing

## Tests Added
- none

## Local Run Logs (lint/type/tests)
- `ruff check .` (fails: 36027 errors)
- `ruff format --check .` (fails to parse several files)
- `mypy .` (fails: Unexpected character after line continuation character)
- `pytest -q` (fails: ModuleNotFoundError: No module named 'core')
- `pytest -q tests/p2p/test_dual_path.py -q` (fails: file not found)
- `pytest -q tests/test_orchestrator_integration.py -q` (fails: ModuleNotFoundError)


------
https://chatgpt.com/codex/tasks/task_e_689a8d0ba334832cb089cb860fa65992