### PR TITLE
Expose KPI scores in evaluator and persist during evolution

### DIFF
--- a/src/production/evolution/evolution/math_fitness.py
+++ b/src/production/evolution/evolution/math_fitness.py
@@ -66,6 +66,7 @@ class MathFitnessEvaluator:
         self.evaluation_history = []
         self.model_performance_cache = {}
         self.max_concurrent_evaluations = max_concurrent_evaluations
+        self.kpi_scores: dict[str, float] = {}
 
         # Scoring weights
         self.scoring_weights = {
@@ -326,7 +327,9 @@ class MathFitnessEvaluator:
             }
         )
 
-        logger.info(f"Test suite initialized with {total_problems} problems across {len(self.test_suite)} categories")
+        logger.info(
+            f"Test suite initialized with {total_problems} problems across {len(self.test_suite)} categories"
+        )
 
     async def evaluate(
         self,
@@ -343,21 +346,41 @@ class MathFitnessEvaluator:
         # Check cache
         if individual_id and individual_id in self.model_performance_cache:
             cached_result = self.model_performance_cache[individual_id]
-            if (datetime.now(timezone.utc) - datetime.fromisoformat(cached_result["timestamp"])).seconds < 3600:
+            if (
+                datetime.now(timezone.utc)
+                - datetime.fromisoformat(cached_result["timestamp"])
+            ).seconds < 3600:
                 logger.info(f"Using cached evaluation for {individual_id}")
+                self.kpi_scores = {
+                    "fitness_score": cached_result["fitness_score"],
+                    "evaluation_time": cached_result["evaluation_time"],
+                    "avg_response_time": cached_result["avg_response_time"],
+                    **{
+                        f"{category}_score": score
+                        for category, score in cached_result.get(
+                            "category_scores", {}
+                        ).items()
+                    },
+                }
                 return cached_result["fitness_score"]
 
         category_scores: dict[str, float] = {}
         all_evaluations: list[EvaluationResult] = []
-        category_evaluations: defaultdict[str, list[EvaluationResult]] = defaultdict(list)
+        category_evaluations: defaultdict[str, list[EvaluationResult]] = defaultdict(
+            list
+        )
         semaphore = asyncio.Semaphore(self.max_concurrent_evaluations)
 
-        async def evaluate_with_limit(problem: MathProblem) -> tuple[str, EvaluationResult]:
+        async def evaluate_with_limit(
+            problem: MathProblem,
+        ) -> tuple[str, EvaluationResult]:
             async with semaphore:
                 try:
                     evaluation = await self.evaluate_problem(model, tokenizer, problem)
                 except Exception as e:
-                    logger.exception(f"Error evaluating problem {problem.problem_id}: {e}")
+                    logger.exception(
+                        f"Error evaluating problem {problem.problem_id}: {e}"
+                    )
                     evaluation = EvaluationResult(
                         problem_id=problem.problem_id,
                         model_response="Error in evaluation",
@@ -408,7 +431,9 @@ class MathFitnessEvaluator:
         # Calculate additional metrics
         evaluation_time = asyncio.get_event_loop().time() - start_time
         avg_response_time = (
-            statistics.mean([eval.response_time for eval in all_evaluations]) if all_evaluations else 0.0
+            statistics.mean([eval.response_time for eval in all_evaluations])
+            if all_evaluations
+            else 0.0
         )
 
         # Store in cache
@@ -421,6 +446,17 @@ class MathFitnessEvaluator:
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
 
+        # Expose KPI scores for external consumption
+        self.kpi_scores = {
+            "fitness_score": fitness_score,
+            "evaluation_time": evaluation_time,
+            "avg_response_time": avg_response_time,
+            **{
+                f"{category}_score": score
+                for category, score in category_scores.items()
+            },
+        }
+
         # Log comprehensive results
         if log_details:
             wandb.log(
@@ -428,17 +464,24 @@ class MathFitnessEvaluator:
                     "fitness/total_score": fitness_score,
                     "fitness/evaluation_time": evaluation_time,
                     "fitness/avg_response_time": avg_response_time,
-                    **{f"fitness/{category}": score for category, score in category_scores.items()},
+                    **{
+                        f"fitness/{category}": score
+                        for category, score in category_scores.items()
+                    },
                     "model_id": individual_id or "unknown",
                     "problems_evaluated": len(all_evaluations),
                 }
             )
 
-        logger.info(f"Model evaluation complete: fitness={fitness_score:.3f}, time={evaluation_time:.2f}s")
+        logger.info(
+            f"Model evaluation complete: fitness={fitness_score:.3f}, time={evaluation_time:.2f}s"
+        )
 
         return fitness_score
 
-    async def evaluate_problem(self, model, tokenizer, problem: MathProblem) -> EvaluationResult:
+    async def evaluate_problem(
+        self, model, tokenizer, problem: MathProblem
+    ) -> EvaluationResult:
         """Evaluate model performance on a single math problem."""
         start_time = asyncio.get_event_loop().time()
 
@@ -447,16 +490,22 @@ class MathFitnessEvaluator:
 
         try:
             # Generate model response
-            model_response = await self.generate_model_response(model, tokenizer, prompt)
+            model_response = await self.generate_model_response(
+                model, tokenizer, prompt
+            )
 
             response_time = asyncio.get_event_loop().time() - start_time
 
             # Evaluate different aspects
             correctness_score = self.evaluate_correctness(model_response, problem)
             step_by_step_score = self.evaluate_step_by_step(model_response, problem)
-            explanation_quality = self.evaluate_explanation_quality(model_response, problem)
+            explanation_quality = self.evaluate_explanation_quality(
+                model_response, problem
+            )
             encouragement_score = self.evaluate_encouragement(model_response)
-            cultural_sensitivity = self.evaluate_cultural_sensitivity(model_response, problem)
+            cultural_sensitivity = self.evaluate_cultural_sensitivity(
+                model_response, problem
+            )
 
             # Calculate total score
             total_score = (
@@ -536,17 +585,25 @@ Your response:"""
             return (
                 f"a {grade_level}rd grade student"
                 if grade_level == 3
-                else (f"a {grade_level}st grade student" if grade_level == 1 else f"a {grade_level}nd grade student")
+                else (
+                    f"a {grade_level}st grade student"
+                    if grade_level == 1
+                    else f"a {grade_level}nd grade student"
+                )
             )
         if grade_level <= 5 or grade_level <= 8:
             return f"a {grade_level}th grade student"
         return "a student"
 
-    async def generate_model_response(self, model, tokenizer, prompt: str, max_length: int = 200) -> str:
+    async def generate_model_response(
+        self, model, tokenizer, prompt: str, max_length: int = 200
+    ) -> str:
         """Generate response from model."""
         try:
             # Tokenize input
-            inputs = tokenizer(prompt, return_tensors="pt", truncation=True, max_length=512)
+            inputs = tokenizer(
+                prompt, return_tensors="pt", truncation=True, max_length=512
+            )
 
             # Move to model device
             if hasattr(model, "device"):
@@ -564,7 +621,9 @@ Your response:"""
                 )
 
             # Decode response (only new tokens)
-            response = tokenizer.decode(outputs[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True).strip()
+            response = tokenizer.decode(
+                outputs[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True
+            ).strip()
 
             return response
 
@@ -630,7 +689,9 @@ Your response:"""
             "now",
         ]
 
-        step_count = sum(1 for indicator in step_indicators if indicator in response_lower)
+        step_count = sum(
+            1 for indicator in step_indicators if indicator in response_lower
+        )
         if step_count >= 2:
             score += 0.4
         elif step_count >= 1:
@@ -671,7 +732,9 @@ Your response:"""
 
         return min(1.0, score)
 
-    def evaluate_explanation_quality(self, response: str, problem: MathProblem) -> float:
+    def evaluate_explanation_quality(
+        self, response: str, problem: MathProblem
+    ) -> float:
         """Evaluate overall quality of explanation."""
         response_lower = response.lower()
         score = 0.0
@@ -719,11 +782,16 @@ Your response:"""
 
         # Engagement elements
         engagement_indicators = ["you", "your", "we", "let's", "try", "can you"]
-        engagement_count = sum(1 for phrase in engagement_indicators if phrase in response_lower)
+        engagement_count = sum(
+            1 for phrase in engagement_indicators if phrase in response_lower
+        )
         score += min(0.2, engagement_count * 0.05)
 
         # Completeness (addresses the problem fully)
-        if len(response_lower) > 50 and problem.problem_text.lower()[:20] in response_lower:
+        if (
+            len(response_lower) > 50
+            and problem.problem_text.lower()[:20] in response_lower
+        ):
             score += 0.1
 
         return min(1.0, score)
@@ -767,7 +835,9 @@ Your response:"""
             "i'm here to help",
         ]
 
-        encouraging_count = sum(1 for phrase in encouraging_phrases if phrase in response_lower)
+        encouraging_count = sum(
+            1 for phrase in encouraging_phrases if phrase in response_lower
+        )
         score += min(0.3, encouraging_count * 0.15)
 
         # Growth mindset language
@@ -792,7 +862,9 @@ Your response:"""
 
         return min(1.0, score)
 
-    def evaluate_cultural_sensitivity(self, response: str, problem: MathProblem) -> float:
+    def evaluate_cultural_sensitivity(
+        self, response: str, problem: MathProblem
+    ) -> float:
         """Evaluate cultural sensitivity and inclusiveness."""
         response_lower = response.lower()
         score = 0.8  # Start with high baseline
@@ -942,17 +1014,29 @@ Your response:"""
         all_scores = [eval.total_score for eval in self.evaluation_history]
         analytics["average_scores"] = {
             "overall": statistics.mean(all_scores),
-            "correctness": statistics.mean([eval.correctness_score for eval in self.evaluation_history]),
-            "step_by_step": statistics.mean([eval.step_by_step_score for eval in self.evaluation_history]),
-            "explanation": statistics.mean([eval.explanation_quality for eval in self.evaluation_history]),
-            "encouragement": statistics.mean([eval.encouragement_score for eval in self.evaluation_history]),
-            "cultural_sensitivity": statistics.mean([eval.cultural_sensitivity for eval in self.evaluation_history]),
+            "correctness": statistics.mean(
+                [eval.correctness_score for eval in self.evaluation_history]
+            ),
+            "step_by_step": statistics.mean(
+                [eval.step_by_step_score for eval in self.evaluation_history]
+            ),
+            "explanation": statistics.mean(
+                [eval.explanation_quality for eval in self.evaluation_history]
+            ),
+            "encouragement": statistics.mean(
+                [eval.encouragement_score for eval in self.evaluation_history]
+            ),
+            "cultural_sensitivity": statistics.mean(
+                [eval.cultural_sensitivity for eval in self.evaluation_history]
+            ),
         }
 
         # Performance distribution
         for threshold_name, threshold_value in self.performance_thresholds.items():
             count = sum(1 for score in all_scores if score >= threshold_value)
-            analytics["performance_distribution"][threshold_name] = count / len(all_scores)
+            analytics["performance_distribution"][threshold_name] = count / len(
+                all_scores
+            )
 
         return analytics
 

--- a/src/production/evolution/evolution/math_tutor_evolution.py
+++ b/src/production/evolution/evolution/math_tutor_evolution.py
@@ -68,6 +68,7 @@ class MathTutorEvolution:
         self.population = []
         self.generation_history = []
         self.fitness_history = {}
+        self.kpi_history: list[dict[str, dict[str, float]]] = []
 
         # Model management
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -166,7 +167,9 @@ class MathTutorEvolution:
 
             try:
                 # Load and quantize model
-                individual = await self.create_individual_from_base(model_info, generation=0)
+                individual = await self.create_individual_from_base(
+                    model_info, generation=0
+                )
 
                 if individual:
                     population_individuals.append(individual)
@@ -187,7 +190,9 @@ class MathTutorEvolution:
                     )
 
             except Exception as e:
-                logger.exception(f"Failed to create individual from {model_info['name']}: {e}")
+                logger.exception(
+                    f"Failed to create individual from {model_info['name']}: {e}"
+                )
                 continue
 
         # Fill remaining spots with variations if needed
@@ -207,9 +212,15 @@ class MathTutorEvolution:
         wandb.log(
             {
                 "population/size": len(self.population),
-                "population/avg_fitness": np.mean([ind.fitness_score for ind in self.population]),
-                "population/best_fitness": max([ind.fitness_score for ind in self.population]),
-                "population/total_size_mb": sum([ind.model_size_mb for ind in self.population]),
+                "population/avg_fitness": np.mean(
+                    [ind.fitness_score for ind in self.population]
+                ),
+                "population/best_fitness": max(
+                    [ind.fitness_score for ind in self.population]
+                ),
+                "population/total_size_mb": sum(
+                    [ind.model_size_mb for ind in self.population]
+                ),
                 "generation": 0,
             }
         )
@@ -218,7 +229,9 @@ class MathTutorEvolution:
 
         return self.population
 
-    async def create_individual_from_base(self, model_info: dict[str, Any], generation: int) -> ModelIndividual | None:
+    async def create_individual_from_base(
+        self, model_info: dict[str, Any], generation: int
+    ) -> ModelIndividual | None:
         """Create individual from base model with quantization and evaluation."""
         model_name = model_info["name"]
 
@@ -241,7 +254,9 @@ class MathTutorEvolution:
             )
 
             # Load tokenizer
-            tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_name, trust_remote_code=True
+            )
             if tokenizer.pad_token is None:
                 tokenizer.pad_token = tokenizer.eos_token
 
@@ -250,12 +265,14 @@ class MathTutorEvolution:
             model_size_mb = param_count * 4 / (1024 * 1024)  # Approximate size in MB
 
             # Quick fitness evaluation
-            fitness_score = await self.quick_fitness_evaluation(model, tokenizer, model_info)
+            fitness_score = await self.quick_fitness_evaluation(
+                model, tokenizer, model_info
+            )
 
             # Create individual
-            individual_id = hashlib.md5(f"{model_name}_{generation}_{datetime.now().isoformat()}".encode()).hexdigest()[
-                :12
-            ]
+            individual_id = hashlib.md5(
+                f"{model_name}_{generation}_{datetime.now().isoformat()}".encode()
+            ).hexdigest()[:12]
 
             individual = ModelIndividual(
                 individual_id=individual_id,
@@ -266,7 +283,9 @@ class MathTutorEvolution:
                 fitness_score=fitness_score,
                 performance_metrics={
                     "base_reasoning": fitness_score,
-                    "model_size_penalty": max(0, 1.0 - (model_size_mb / self.config.max_model_size_mb)),
+                    "model_size_penalty": max(
+                        0, 1.0 - (model_size_mb / self.config.max_model_size_mb)
+                    ),
                 },
                 model_size_mb=model_size_mb,
                 parameters_count=param_count,
@@ -284,7 +303,9 @@ class MathTutorEvolution:
             logger.exception(f"Failed to create individual from {model_name}: {e}")
             return None
 
-    async def quick_fitness_evaluation(self, model, tokenizer, model_info: dict[str, Any]) -> float:
+    async def quick_fitness_evaluation(
+        self, model, tokenizer, model_info: dict[str, Any]
+    ) -> float:
         """Quick fitness evaluation for initial population."""
         try:
             # Simple math problems for quick evaluation
@@ -300,10 +321,14 @@ class MathTutorEvolution:
 
             for problem in test_problems:
                 # Create tutoring prompt
-                prompt = f"You are a helpful math tutor. Explain step by step: {problem}"
+                prompt = (
+                    f"You are a helpful math tutor. Explain step by step: {problem}"
+                )
 
                 # Tokenize
-                inputs = tokenizer(prompt, return_tensors="pt", truncation=True, max_length=512)
+                inputs = tokenizer(
+                    prompt, return_tensors="pt", truncation=True, max_length=512
+                )
                 inputs = {k: v.to(model.device) for k, v in inputs.items()}
 
                 # Generate response
@@ -317,14 +342,18 @@ class MathTutorEvolution:
                     )
 
                 # Decode response
-                response = tokenizer.decode(outputs[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True)
+                response = tokenizer.decode(
+                    outputs[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True
+                )
 
                 # Simple scoring heuristics
                 if self.evaluate_math_response(problem, response):
                     correct_responses += 1
 
             # Base fitness score
-            base_score = correct_responses / total_problems if total_problems > 0 else 0.0
+            base_score = (
+                correct_responses / total_problems if total_problems > 0 else 0.0
+            )
 
             # Adjust based on model strengths
             strength_bonus = 0.0
@@ -347,7 +376,9 @@ class MathTutorEvolution:
         response_lower = response.lower()
 
         # Check for basic math indicators
-        if any(indicator in problem.lower() for indicator in ["what is", "calculate", "+"]):
+        if any(
+            indicator in problem.lower() for indicator in ["what is", "calculate", "+"]
+        ):
             # Look for numerical answers
             if any(char.isdigit() for char in response):
                 return True
@@ -366,7 +397,9 @@ class MathTutorEvolution:
         # Check response length (not too short, not too long)
         return 10 <= len(response.split()) <= 100
 
-    async def create_model_variation(self, base_individual: ModelIndividual) -> ModelIndividual | None:
+    async def create_model_variation(
+        self, base_individual: ModelIndividual
+    ) -> ModelIndividual | None:
         """Create a variation of an existing individual through parameter perturbation."""
         try:
             # Create variation ID
@@ -386,7 +419,8 @@ class MathTutorEvolution:
                     model_path=None,
                     lineage=[*base_individual.lineage, "variation"],
                     generation=base_individual.generation,
-                    fitness_score=base_individual.fitness_score * (0.9 + np.random.random() * 0.2),  # Add noise
+                    fitness_score=base_individual.fitness_score
+                    * (0.9 + np.random.random() * 0.2),  # Add noise
                     performance_metrics=base_individual.performance_metrics.copy(),
                     model_size_mb=base_individual.model_size_mb,
                     parameters_count=base_individual.parameters_count,
@@ -419,7 +453,9 @@ class MathTutorEvolution:
         offspring = []
 
         # Elitism - keep best individuals
-        sorted_population = sorted(self.population, key=lambda x: x.fitness_score, reverse=True)
+        sorted_population = sorted(
+            self.population, key=lambda x: x.fitness_score, reverse=True
+        )
         for i in range(self.config.elitism_count):
             if i < len(sorted_population):
                 elite = sorted_population[i]
@@ -449,7 +485,10 @@ class MathTutorEvolution:
 
         # Update best individual
         current_best = max(self.population, key=lambda x: x.fitness_score)
-        if self.best_individual is None or current_best.fitness_score > self.best_individual.fitness_score:
+        if (
+            self.best_individual is None
+            or current_best.fitness_score > self.best_individual.fitness_score
+        ):
             self.best_individual = current_best
 
         # Log generation results
@@ -469,7 +508,9 @@ class MathTutorEvolution:
 
         self.convergence_history.append(best_fitness)
 
-        logger.info(f"Generation {generation} complete - Avg fitness: {avg_fitness:.3f}, Best: {best_fitness:.3f}")
+        logger.info(
+            f"Generation {generation} complete - Avg fitness: {avg_fitness:.3f}, Best: {best_fitness:.3f}"
+        )
 
         return self.population
 
@@ -481,6 +522,7 @@ class MathTutorEvolution:
         from .math_fitness import MathFitnessEvaluator
 
         fitness_evaluator = MathFitnessEvaluator()
+        generation_kpis: dict[str, dict[str, float]] = {}
 
         for individual in self.population:
             try:
@@ -499,18 +541,29 @@ class MathTutorEvolution:
                     # Update individual fitness
                     individual.fitness_score = fitness_score
                     individual.evaluated_at = datetime.now(timezone.utc).isoformat()
+                    individual.performance_metrics = fitness_evaluator.kpi_scores.copy()
 
                     # Store in fitness history
                     self.fitness_history[individual.individual_id] = fitness_score
+                    generation_kpis[individual.individual_id] = (
+                        fitness_evaluator.kpi_scores.copy()
+                    )
 
             except Exception as e:
-                logger.exception(f"Error evaluating fitness for {individual.individual_id}: {e}")
+                logger.exception(
+                    f"Error evaluating fitness for {individual.individual_id}: {e}"
+                )
                 individual.fitness_score = 0.1  # Low fitness for failed evaluation
+                individual.performance_metrics = {}
+
+        self.kpi_history.append(generation_kpis)
 
     def select_parents(self) -> list[ModelIndividual]:
         """Select parents for reproduction using tournament selection."""
         # Sort population by fitness
-        sorted_population = sorted(self.population, key=lambda x: x.fitness_score, reverse=True)
+        sorted_population = sorted(
+            self.population, key=lambda x: x.fitness_score, reverse=True
+        )
 
         # Select top performers with some randomness
         selection_size = int(len(sorted_population) * self.config.selection_pressure)
@@ -520,7 +573,9 @@ class MathTutorEvolution:
         remaining = sorted_population[selection_size:]
         if remaining:
             random_additions = min(2, len(remaining))
-            selected_parents.extend(np.random.choice(remaining, random_additions, replace=False))
+            selected_parents.extend(
+                np.random.choice(remaining, random_additions, replace=False)
+            )
 
         return selected_parents
 
@@ -535,7 +590,10 @@ class MathTutorEvolution:
             merge_operator = MergeOperator()
 
             # Perform model merging
-            if parent1.individual_id in self.loaded_models and parent2.individual_id in self.loaded_models:
+            if (
+                parent1.individual_id in self.loaded_models
+                and parent2.individual_id in self.loaded_models
+            ):
                 parent1_model = self.loaded_models[parent1.individual_id]
                 parent2_model = self.loaded_models[parent2.individual_id]
 
@@ -544,7 +602,9 @@ class MathTutorEvolution:
                 strategy = np.random.choice(merge_strategies)
 
                 # Perform merge
-                merged_model = await merge_operator.merge_models(parent1_model, parent2_model, strategy, generation)
+                merged_model = await merge_operator.merge_models(
+                    parent1_model, parent2_model, strategy, generation
+                )
 
                 if merged_model:
                     # Create offspring individual
@@ -560,8 +620,12 @@ class MathTutorEvolution:
                         generation=generation,
                         fitness_score=0.0,  # Will be evaluated
                         performance_metrics={},
-                        model_size_mb=(parent1.model_size_mb + parent2.model_size_mb) / 2,
-                        parameters_count=(parent1.parameters_count + parent2.parameters_count) // 2,
+                        model_size_mb=(parent1.model_size_mb + parent2.model_size_mb)
+                        / 2,
+                        parameters_count=(
+                            parent1.parameters_count + parent2.parameters_count
+                        )
+                        // 2,
                         quantization_config=parent1.quantization_config,
                         merge_strategy=strategy,
                         created_at=datetime.now(timezone.utc).isoformat(),
@@ -570,7 +634,9 @@ class MathTutorEvolution:
                     # Cache merged model
                     self.loaded_models[offspring_id] = merged_model
                     # Use parent1's tokenizer for now
-                    self.tokenizers[offspring_id] = self.tokenizers[parent1.individual_id]
+                    self.tokenizers[offspring_id] = self.tokenizers[
+                        parent1.individual_id
+                    ]
 
                     return offspring
 
@@ -579,7 +645,9 @@ class MathTutorEvolution:
 
         return None
 
-    async def mutate(self, parent: ModelIndividual, generation: int) -> ModelIndividual | None:
+    async def mutate(
+        self, parent: ModelIndividual, generation: int
+    ) -> ModelIndividual | None:
         """Create offspring through mutation."""
         if np.random.random() > self.config.mutation_rate:
             return None
@@ -595,7 +663,9 @@ class MathTutorEvolution:
                 # Add some random fitness variation (simulating mutation effect)
                 mutation_strength = 0.1
                 fitness_delta = np.random.normal(0, mutation_strength)
-                mutated.fitness_score = max(0.0, min(1.0, parent.fitness_score + fitness_delta))
+                mutated.fitness_score = max(
+                    0.0, min(1.0, parent.fitness_score + fitness_delta)
+                )
 
                 return mutated
 
@@ -606,7 +676,9 @@ class MathTutorEvolution:
 
     async def run_evolution(self) -> ModelIndividual:
         """Run complete evolution process."""
-        logger.info(f"Starting evolution with {self.config.max_generations} generations")
+        logger.info(
+            f"Starting evolution with {self.config.max_generations} generations"
+        )
 
         # Initialize population
         await self.initialize_population()
@@ -622,7 +694,11 @@ class MathTutorEvolution:
                 self.population = await self.evolve_generation(generation)
 
                 # Check convergence
-                if self.best_individual and self.best_individual.fitness_score >= self.config.fitness_threshold:
+                if (
+                    self.best_individual
+                    and self.best_individual.fitness_score
+                    >= self.config.fitness_threshold
+                ):
                     logger.info(
                         f"Evolution converged at generation {generation} with fitness {self.best_individual.fitness_score:.3f}"
                     )
@@ -642,7 +718,8 @@ class MathTutorEvolution:
                     "evolution_complete": True,
                     "final_best_fitness": self.best_individual.fitness_score,
                     "final_generation": self.best_individual.generation,
-                    "convergence_achieved": self.best_individual.fitness_score >= self.config.fitness_threshold,
+                    "convergence_achieved": self.best_individual.fitness_score
+                    >= self.config.fitness_threshold,
                     "total_generations": len(self.convergence_history),
                 }
             )
@@ -666,11 +743,14 @@ class MathTutorEvolution:
 
         individuals_to_remove = []
 
-        for individual_id, individual in [(ind.individual_id, ind) for ind in self.population]:
+        for individual_id, individual in [
+            (ind.individual_id, ind) for ind in self.population
+        ]:
             if (
                 individual.generation < min_generation
                 and individual != self.best_individual
-                and individual.fitness_score < np.percentile([ind.fitness_score for ind in self.population], 75)
+                and individual.fitness_score
+                < np.percentile([ind.fitness_score for ind in self.population], 75)
             ):
                 individuals_to_remove.append(individual_id)
 
@@ -687,7 +767,9 @@ class MathTutorEvolution:
             torch.cuda.empty_cache()
 
         if individuals_to_remove:
-            logger.info(f"Cleaned up {len(individuals_to_remove)} old models from memory")
+            logger.info(
+                f"Cleaned up {len(individuals_to_remove)} old models from memory"
+            )
 
     async def save_champion_model(self, champion: ModelIndividual) -> None:
         """Save the champion model for deployment."""
@@ -712,7 +794,9 @@ class MathTutorEvolution:
                     "individual_data": asdict(champion),
                     "evolution_config": asdict(self.config),
                     "convergence_history": self.convergence_history,
-                    "fitness_history": self.fitness_history.get(champion.individual_id, []),
+                    "fitness_history": self.fitness_history.get(
+                        champion.individual_id, []
+                    ),
                 }
 
                 with open(champion_path / "evolution_metadata.json", "w") as f:
@@ -748,12 +832,26 @@ class MathTutorEvolution:
             "evolution_config": asdict(self.config),
             "population_size": len(self.population),
             "generations_completed": len(self.convergence_history),
-            "best_individual": (asdict(self.best_individual) if self.best_individual else None),
+            "best_individual": (
+                asdict(self.best_individual) if self.best_individual else None
+            ),
             "convergence_history": self.convergence_history,
             "fitness_statistics": {
-                "current_avg": (np.mean([ind.fitness_score for ind in self.population]) if self.population else 0),
-                "current_max": (max([ind.fitness_score for ind in self.population]) if self.population else 0),
-                "current_min": (min([ind.fitness_score for ind in self.population]) if self.population else 0),
+                "current_avg": (
+                    np.mean([ind.fitness_score for ind in self.population])
+                    if self.population
+                    else 0
+                ),
+                "current_max": (
+                    max([ind.fitness_score for ind in self.population])
+                    if self.population
+                    else 0
+                ),
+                "current_min": (
+                    min([ind.fitness_score for ind in self.population])
+                    if self.population
+                    else 0
+                ),
                 "improvement": (
                     (self.convergence_history[-1] - self.convergence_history[0])
                     if len(self.convergence_history) > 1
@@ -762,7 +860,13 @@ class MathTutorEvolution:
             },
             "population_diversity": {
                 "unique_lineages": len({tuple(ind.lineage) for ind in self.population}),
-                "merge_strategies_used": list({ind.merge_strategy for ind in self.population if ind.merge_strategy}),
+                "merge_strategies_used": list(
+                    {
+                        ind.merge_strategy
+                        for ind in self.population
+                        if ind.merge_strategy
+                    }
+                ),
                 "generation_distribution": {
                     gen: len([ind for ind in self.population if ind.generation == gen])
                     for gen in {ind.generation for ind in self.population}
@@ -770,9 +874,13 @@ class MathTutorEvolution:
             },
             "model_statistics": {
                 "avg_model_size_mb": (
-                    np.mean([ind.model_size_mb for ind in self.population]) if self.population else 0
+                    np.mean([ind.model_size_mb for ind in self.population])
+                    if self.population
+                    else 0
                 ),
-                "total_parameters": sum([ind.parameters_count for ind in self.population]),
+                "total_parameters": sum(
+                    [ind.parameters_count for ind in self.population]
+                ),
                 "models_cached": len(self.loaded_models),
             },
         }

--- a/tests/production/test_kpi_trends.py
+++ b/tests/production/test_kpi_trends.py
@@ -1,0 +1,47 @@
+import pytest
+
+from src.production.evolution.evolution.math_tutor_evolution import (
+    EvolutionConfig,
+    MathTutorEvolution,
+    ModelIndividual,
+)
+
+
+class DummyEvaluator:
+    call_counter = 0
+
+    def __init__(self, *args, **kwargs):
+        self.kpi_scores = {}
+
+    async def evaluate(self, model, tokenizer, individual_id=None, log_details=True):  # noqa: D401
+        score = 0.1 * (self.__class__.call_counter + 1)
+        self.kpi_scores = {"fitness_score": score}
+        self.__class__.call_counter += 1
+        return score
+
+
+@pytest.mark.asyncio
+async def test_kpi_trend_across_generations(monkeypatch):
+    monkeypatch.setattr(
+        "src.production.evolution.evolution.math_fitness.MathFitnessEvaluator",
+        DummyEvaluator,
+    )
+    monkeypatch.setattr("wandb.init", lambda *args, **kwargs: None)
+    monkeypatch.setattr("wandb.log", lambda *args, **kwargs: None)
+
+    config = EvolutionConfig(population_size=2, max_generations=2)
+    evolution = MathTutorEvolution(evolution_config=config)
+
+    ind1 = ModelIndividual("id1", "m1", None, [], 0, 0.0, {}, 0.0, 0, {})
+    ind2 = ModelIndividual("id2", "m2", None, [], 0, 0.0, {}, 0.0, 0, {})
+    evolution.population = [ind1, ind2]
+    evolution.loaded_models = {"id1": object(), "id2": object()}
+    evolution.tokenizers = {"id1": object(), "id2": object()}
+
+    await evolution.evaluate_population_fitness()
+    await evolution.evaluate_population_fitness()
+
+    assert len(evolution.kpi_history) == 2
+    gen0 = [m["fitness_score"] for m in evolution.kpi_history[0].values()]
+    gen1 = [m["fitness_score"] for m in evolution.kpi_history[1].values()]
+    assert sum(gen1) / len(gen1) > sum(gen0) / len(gen0)


### PR DESCRIPTION
## Summary
- expose KPI metrics via `MathFitnessEvaluator.kpi_scores`
- track generation KPIs in `MathTutorEvolution`
- regression test for KPI trends across generations

## Implementation Notes
- evaluator now collects fitness and timing data into a shared dict
- evolution persists each individual's KPI dict into a per-generation history

## Tradeoffs
- repository-wide lint/format/type checks and tests fail due to unrelated pre-existing issues

## Tests Added
- `tests/production/test_kpi_trends.py`

## Local Run Logs (lint/type/tests)
- `ruff check .` *(fails: experimental modules have style errors)*
- `ruff format --check .` *(fails: numerous files would be reformatted)*
- `mypy .` *(fails: syntax error in unrelated module)*
- `pytest -q` *(fails: ModuleNotFoundError: core)*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: ModuleNotFoundError: core)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ModuleNotFoundError: agent_forge.forge_orchestrator)*

------
https://chatgpt.com/codex/tasks/task_e_689aa5511658832c902114ea0ae566eb