### PR TITLE
Support torch tensors in tensor streaming

### DIFF
--- a/src/infrastructure/p2p/tensor_streaming.py
+++ b/src/infrastructure/p2p/tensor_streaming.py
@@ -77,7 +77,7 @@ class TensorStreamer:
     def _serialize_tensor(self, tensor: Any) -> bytes:
         """Serialize tensor with metadata."""
         if TORCH_AVAILABLE and isinstance(tensor, torch.Tensor):
-            np_array = tensor.cpu().numpy()
+            np_array = tensor.detach().cpu().numpy()
             metadata = {
                 "shape": list(np_array.shape),
                 "dtype": str(np_array.dtype),
@@ -119,6 +119,7 @@ class TensorStreamer:
 
         if TORCH_AVAILABLE and metadata.get("is_torch_tensor", False):
             tensor = torch.from_numpy(np_array)
+            tensor = tensor.to(metadata.get("device", "cpu"))
             if metadata.get("requires_grad", False):
                 tensor.requires_grad_(True)
             return tensor

--- a/src/production/communications/p2p/tensor_streaming.py
+++ b/src/production/communications/p2p/tensor_streaming.py
@@ -19,6 +19,14 @@ import lz4.frame
 # For tensor operations
 import numpy as np
 
+# We'll handle torch import gracefully in case it's not available
+try:
+    import torch
+
+    TORCH_AVAILABLE = True
+except ImportError:  # pragma: no cover - torch may not be installed in all environments
+    TORCH_AVAILABLE = False
+
 # For key exchange
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import x25519
@@ -80,6 +88,9 @@ class TensorMetadata:
     timestamp: float = field(default_factory=time.time)
     source_node: str = ""
     tags: dict[str, Any] = field(default_factory=dict)
+    device: str | None = None
+    is_torch: bool = False
+    requires_grad: bool = False
 
 
 @dataclass
@@ -408,6 +419,30 @@ class TensorStreaming:
     ) -> tuple[bytes, TensorMetadata]:
         """Serialize tensor to bytes."""
         if self.config.tensor_format == TensorFormat.NUMPY:
+            if TORCH_AVAILABLE and isinstance(tensor_data, torch.Tensor):
+                np_array = tensor_data.detach().cpu().numpy()
+                buffer = io.BytesIO()
+                np.save(buffer, np_array)
+                serialized = buffer.getvalue()
+
+                metadata = TensorMetadata(
+                    tensor_id=tensor_id,
+                    name=tensor_name,
+                    shape=np_array.shape,
+                    dtype=str(np_array.dtype),
+                    size_bytes=len(serialized),
+                    total_chunks=0,  # Will be set later
+                    compression=self.config.compression,
+                    format=self.config.tensor_format,
+                    checksum=hashlib.sha256(serialized).hexdigest(),
+                    source_node=self.node.node_id,
+                    tags=tags,
+                    device=str(tensor_data.device),
+                    is_torch=True,
+                    requires_grad=tensor_data.requires_grad,
+                )
+
+                return serialized, metadata
             if isinstance(tensor_data, np.ndarray):
                 buffer = io.BytesIO()
                 np.save(buffer, tensor_data)
@@ -531,6 +566,9 @@ class TensorStreaming:
                 "timestamp": metadata.timestamp,
                 "source_node": metadata.source_node,
                 "tags": metadata.tags,
+                "device": metadata.device,
+                "is_torch": metadata.is_torch,
+                "requires_grad": metadata.requires_grad,
             },
         }
 
@@ -611,6 +649,9 @@ class TensorStreaming:
             timestamp=metadata_dict["timestamp"],
             source_node=metadata_dict["source_node"],
             tags=metadata_dict["tags"],
+            device=metadata_dict.get("device"),
+            is_torch=metadata_dict.get("is_torch", False),
+            requires_grad=metadata_dict.get("requires_grad", False),
         )
 
         self.tensor_metadata[tensor_id] = metadata
@@ -717,14 +758,23 @@ class TensorStreaming:
         # Deserialize tensor
         if metadata.format == TensorFormat.NUMPY:
             buffer = io.BytesIO(combined_data)
-            tensor_data = np.load(buffer)
+            np_array = np.load(buffer)
+            if metadata.is_torch:
+                if not TORCH_AVAILABLE:
+                    logger.error("Torch not available for tensor reconstruction")
+                    return None
+                tensor = torch.from_numpy(np_array)
+                tensor = tensor.to(metadata.device or "cpu")
+                if metadata.requires_grad:
+                    tensor.requires_grad_(True)
+                return tensor
+            return np_array
         elif metadata.format == TensorFormat.JSON:
             tensor_data = json.loads(combined_data.decode("utf-8"))
+            return tensor_data
         else:
             logger.error(f"Unsupported tensor format: {metadata.format}")
             return None
-
-        return tensor_data
 
     def _find_missing_chunks(self, tensor_id: str) -> list[int]:
         """Find missing chunk indices for a tensor."""

--- a/tests/production/test_tensor_streaming_integration.py
+++ b/tests/production/test_tensor_streaming_integration.py
@@ -4,6 +4,7 @@ import hashlib
 
 import numpy as np
 import pytest
+import torch
 
 from src.production.communications.p2p.p2p_node import MessageType, P2PMessage, P2PNode
 from src.production.communications.p2p.tensor_streaming import TensorStreaming
@@ -50,6 +51,43 @@ async def test_tensor_stream_round_trip(monkeypatch):
     metadata = recv_stream.tensor_metadata[tensor_id]
     assert np.array_equal(reconstructed, tensor)
     assert metadata.tensor_id == tensor_id
+
+
+@pytest.mark.asyncio
+async def test_tensor_stream_round_trip_torch(monkeypatch):
+    sender = P2PNode(node_id="sender_t", port=9201)
+    receiver = P2PNode(node_id="receiver_t", port=9202)
+
+    send_stream = TensorStreaming(node=sender)
+    recv_stream = TensorStreaming(node=receiver)
+
+    receiver.register_handler(MessageType.DATA, recv_stream._handle_tensor_chunk)
+
+    async def fake_send_message(self, peer_id, message_type, payload):
+        assert peer_id == receiver.node_id
+        msg = P2PMessage(
+            message_type=message_type,
+            sender_id=self.node_id,
+            receiver_id=peer_id,
+            payload=payload,
+        )
+        handler = receiver.message_handlers.get(message_type)
+        if handler:
+            await handler(msg, None)
+            return True
+        return False
+
+    monkeypatch.setattr(sender, "send_message", fake_send_message.__get__(sender, P2PNode))
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tensor = torch.arange(8, dtype=torch.float32, device=device, requires_grad=True)
+    tensor_id = await send_stream.send_tensor(tensor, "torch_test", receiver.node_id)
+
+    reconstructed = await recv_stream._reconstruct_tensor(tensor_id)
+    assert torch.equal(reconstructed, tensor)
+    assert reconstructed.device.type == tensor.device.type
+    assert reconstructed.dtype == tensor.dtype
+    assert reconstructed.requires_grad == tensor.requires_grad
 
 
 @pytest.mark.asyncio

--- a/tests/production/test_tensor_streaming_safe.py
+++ b/tests/production/test_tensor_streaming_safe.py
@@ -4,6 +4,7 @@ import time
 
 import numpy as np
 import pytest
+import torch
 
 from src.infrastructure.p2p.tensor_streaming import TensorStreamer
 from src.production.communications.p2p.p2p_node import MessageType, P2PNode
@@ -15,6 +16,18 @@ def test_safe_serialization_round_trip():
     data = streamer._serialize_tensor(array)
     restored = streamer._deserialize_tensor(data)
     assert np.array_equal(array, restored)
+
+
+def test_safe_serialization_round_trip_torch():
+    streamer = TensorStreamer()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tensor = torch.arange(10, dtype=torch.float32, device=device, requires_grad=True)
+    data = streamer._serialize_tensor(tensor)
+    restored = streamer._deserialize_tensor(data)
+    assert torch.equal(restored, tensor)
+    assert restored.device.type == tensor.device.type
+    assert restored.dtype == tensor.dtype
+    assert restored.requires_grad == tensor.requires_grad
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Allow tensor streaming to serialize and reconstruct `torch.Tensor` instances
- Preserve tensor dtype, device and `requires_grad` metadata across peers
- Exercise PyTorch tensor streaming round trips

## Implementation notes
- Added optional metadata (`device`, `is_torch`, `requires_grad`) for wire format
- Restored tensors move to original device and preserve gradient tracking

## Tradeoffs
- Still relies on NumPy for transport; reconstruction requires PyTorch when flagged

## Tests added
- `tests/production/test_tensor_streaming_integration.py::test_tensor_stream_round_trip_torch`
- `tests/production/test_tensor_streaming_safe.py::test_safe_serialization_round_trip_torch`

## Local run logs (lint/type/tests)
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `pytest -q`
- `pytest -q tests/p2p/test_dual_path.py -q`
- `pytest -q tests/test_orchestrator_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa665721c832c90089bb5a83a806f