### PR TITLE
Use versioned checkpoint serialization

### DIFF
--- a/src/production/distributed_agents/serialization.py
+++ b/src/production/distributed_agents/serialization.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Safe serialization utilities for agent checkpoints."""
+
+import json
+from typing import Any, Dict
+
+import msgpack
+
+CURRENT_VERSION = 1
+
+
+def serialize_checkpoint(data: Dict[str, Any]) -> bytes:
+    """Serialize checkpoint data with version information."""
+    payload = {"version": CURRENT_VERSION, "data": data}
+    return msgpack.dumps(payload)
+
+
+def deserialize_checkpoint(payload: bytes) -> Dict[str, Any]:
+    """Deserialize checkpoint payload supporting legacy JSON format."""
+    try:
+        decoded = msgpack.loads(payload, raw=False)
+        if isinstance(decoded, dict) and "version" in decoded and "data" in decoded:
+            return decoded["data"]
+    except Exception:
+        pass
+
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except Exception as e:  # pragma: no cover - unexpected serialization
+        raise ValueError("Invalid checkpoint payload") from e


### PR DESCRIPTION
## Summary
- add safe msgpack-based serializer with JSON fallback for agent checkpoints
- rename and update checkpoint creation to store versioned payloads
- validate legacy JSON checkpoints and serialization round-trip in tests

## Implementation Notes
- new `serialization` module centralizes checkpoint encode/decode with schema versioning
- `_start_agent_locally_from_checkpoint` now uses the serializer and validates schema

## Tradeoffs
- repo-wide linting/formatting checks fail due to existing issues outside modified files
- full pytest suite fails to collect due to missing dependencies; only targeted tests were executed

## Tests Added
- `tests/distributed_agents/test_checkpoint_security.py::test_serialization_round_trip`
- `tests/distributed_agents/test_checkpoint_security.py::test_legacy_json_checkpoint_supported`

## Local Run Logs
- `ruff check .` *(fails: numerous existing style errors)*
- `ruff format --check .` *(fails: parse errors and many files would be reformatted)*
- `mypy .` *(fails: agents/atlantis_meta_agents/economy/__init__.py: Unexpected character after line continuation)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: file not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ModuleNotFoundError: No module named 'agent_forge.forge_orchestrator')*
- `pytest tests/distributed_agents/test_checkpoint_security.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689aa5ca145c832ca6db9fe9c31a0a67