### PR TITLE
Switch to relative imports for internal modules

### DIFF
--- a/AIVillage/__init__.py
+++ b/AIVillage/__init__.py
@@ -11,6 +11,8 @@ if str(_src) not in sys.path:
 
 # Expose submodules under src through this package
 __path__ = [str(_src)]
+if __spec__ is not None:
+    __spec__.submodule_search_locations = [str(_src)]
 
 # Support legacy imports like `AIVillage.src.*`
 import types

--- a/src/agent_forge/orchestration/curriculum_integration.py
+++ b/src/agent_forge/orchestration/curriculum_integration.py
@@ -10,8 +10,8 @@ from typing import Any
 
 import torch
 
-from AIVillage.src.agent_forge.training.curriculum import CurriculumGenerator, Question
-from AIVillage.src.agent_forge.training.magi_specialization import (
+from ..training.curriculum import CurriculumGenerator, Question
+from ..training.magi_specialization import (
     FrontierQuestionGenerator,
     MagiConfig,
 )

--- a/src/hyperag/education/curriculum_graph.py
+++ b/src/hyperag/education/curriculum_graph.py
@@ -11,7 +11,7 @@ import logging
 from typing import Any
 
 # Import from hyperag components
-from AIVillage.src.hyperag.core.hypergraph_kg import Hyperedge, HypergraphKG, Node
+from ..core.hypergraph_kg import Hyperedge, HypergraphKG, Node
 import wandb
 
 logger = logging.getLogger(__name__)

--- a/src/ingestion/connectors/amazon_orders.py
+++ b/src/ingestion/connectors/amazon_orders.py
@@ -13,7 +13,7 @@ from typing import Any
 import requests
 
 # from chromadb import PersistentClient  # TODO: Fix attrs dependency issue
-from AIVillage.src.ingestion import add_text
+from .. import add_text
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_servers/hyperag/guardian/gate.py
+++ b/src/mcp_servers/hyperag/guardian/gate.py
@@ -20,8 +20,8 @@ Decision = Literal["APPLY", "QUARANTINE", "REJECT"]
 
 # Type aliases for imports that may not exist yet
 try:
-    from AIVillage.src.mcp_servers.hyperag.gdc.specs import Violation
-    from AIVillage.src.mcp_servers.hyperag.repair.innovator_agent import RepairOperation
+    from ..gdc.specs import Violation
+    from ..repair.innovator_agent import RepairOperation
 except ImportError:
     # Fallback types for testing
     RepairOperation = Any

--- a/src/mcp_servers/hyperag/lora/adapter_loader.py
+++ b/src/mcp_servers/hyperag/lora/adapter_loader.py
@@ -13,7 +13,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from AIVillage.src.mcp_servers.hyperag.guardian.gate import GuardianGate
+from ..guardian.gate import GuardianGate
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_servers/hyperag/memory/consolidator.py
+++ b/src/mcp_servers/hyperag/memory/consolidator.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import numpy as np
 
-from AIVillage.src.mcp_servers.hyperag.guardian.gate import GuardianGate
+from ..guardian.gate import GuardianGate
 
 from .base import ConsolidationBatch, Edge, Node
 from .hippo_index import HippoIndex

--- a/src/mcp_servers/hyperag/planning/query_planner.py
+++ b/src/mcp_servers/hyperag/planning/query_planner.py
@@ -8,7 +8,7 @@ import logging
 import time
 from typing import Any
 
-from AIVillage.src.mcp_servers.hyperag.guardian.gate import GuardianGate
+from ..guardian.gate import GuardianGate
 
 from .plan_structures import (
     ExecutionStatus,
@@ -554,7 +554,7 @@ class QueryPlanner:
 
             # Create a mock creative bridge for validation
             # In a real implementation, this would be more sophisticated
-            from AIVillage.src.mcp_servers.hyperag.guardian.gate import CreativeBridge
+            from ..guardian.gate import CreativeBridge
 
             bridge = CreativeBridge(
                 id=f"query_answer_{hash(answer) % 10000}",

--- a/src/mcp_servers/hyperag/repair/innovator_agent.py
+++ b/src/mcp_servers/hyperag/repair/innovator_agent.py
@@ -15,7 +15,7 @@ import re
 from typing import Any
 import uuid
 
-from AIVillage.src.mcp_servers.hyperag.guardian.gate import GuardianGate
+from ..guardian.gate import GuardianGate
 
 from .llm_driver import LLMDriver, ModelConfig
 from .templates import TemplateEncoder, ViolationTemplate

--- a/src/mcp_servers/hyperag/retrieval/divergent_retriever.py
+++ b/src/mcp_servers/hyperag/retrieval/divergent_retriever.py
@@ -13,8 +13,8 @@ import random
 import time
 from typing import Any
 
-from AIVillage.src.mcp_servers.hyperag.memory.hypergraph_kg import HypergraphKG
-from AIVillage.src.mcp_servers.hyperag.models import QueryPlan
+from ..memory.hypergraph_kg import HypergraphKG
+from ..models import QueryPlan
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_servers/hyperag/retrieval/hybrid_retriever.py
+++ b/src/mcp_servers/hyperag/retrieval/hybrid_retriever.py
@@ -12,9 +12,9 @@ import logging
 import time
 from typing import Any
 
-from AIVillage.src.mcp_servers.hyperag.memory.hippo_index import HippoIndex
-from AIVillage.src.mcp_servers.hyperag.memory.hypergraph_kg import HypergraphKG
-from AIVillage.src.mcp_servers.hyperag.models import QueryPlan
+from ..memory.hippo_index import HippoIndex
+from ..memory.hypergraph_kg import HypergraphKG
+from ..models import QueryPlan
 
 from .ppr_retriever import AlphaProfileStore, PersonalizedPageRank, PPRResults
 

--- a/src/mcp_servers/hyperag/retrieval/ppr_retriever.py
+++ b/src/mcp_servers/hyperag/retrieval/ppr_retriever.py
@@ -17,9 +17,9 @@ from typing import Any
 
 import yaml
 
-from AIVillage.src.mcp_servers.hyperag.memory.hippo_index import HippoIndex
-from AIVillage.src.mcp_servers.hyperag.memory.hypergraph_kg import HypergraphKG
-from AIVillage.src.mcp_servers.hyperag.models import QueryPlan
+from ..memory.hippo_index import HippoIndex
+from ..memory.hypergraph_kg import HypergraphKG
+from ..models import QueryPlan
 
 logger = logging.getLogger(__name__)
 

--- a/src/production/agent_forge/evolution/evolution_coordination_protocol.py
+++ b/src/production/agent_forge/evolution/evolution_coordination_protocol.py
@@ -8,8 +8,8 @@ import time
 from typing import Any
 import uuid
 
-from AIVillage.src.core.p2p import P2PNode
-from AIVillage.src.core.p2p.message_protocol import (
+from ....core.p2p import P2PNode
+from ....core.p2p.message_protocol import (
     EvolutionMessage,
     MessagePriority,
     MessageType,

--- a/src/production/agent_forge/evolution/infrastructure_aware_evolution.py
+++ b/src/production/agent_forge/evolution/infrastructure_aware_evolution.py
@@ -7,8 +7,8 @@ import time
 from typing import Any
 
 # Import P2P and resource management components
-from AIVillage.src.core.p2p import P2PNode
-from AIVillage.src.core.resources import (
+from ....core.p2p import P2PNode
+from ....core.resources import (
     AdaptiveLoader,
     ConstraintManager,
     DeviceProfiler,
@@ -514,7 +514,7 @@ class InfrastructureAwareEvolution:
             return
 
         # Create loading context based on evolution plan
-        from AIVillage.src.core.resources.adaptive_loader import LoadingContext
+        from ....core.resources.adaptive_loader import LoadingContext
 
         context = LoadingContext(
             task_type=plan.evolution_type,

--- a/src/production/agent_forge/evolution/resource_constrained_evolution.py
+++ b/src/production/agent_forge/evolution/resource_constrained_evolution.py
@@ -9,13 +9,13 @@ import time
 from typing import Any
 
 # Import resource management and dual evolution
-from AIVillage.src.core.resources import (
+from ....core.resources import (
     AdaptiveLoader,
     ConstraintManager,
     DeviceProfiler,
     ResourceMonitor,
 )
-from AIVillage.src.core.resources.constraint_manager import (
+from ....core.resources.constraint_manager import (
     ConstraintSeverity,
     ConstraintViolation,
 )
@@ -587,7 +587,7 @@ class ResourceConstrainedEvolution(DualEvolutionSystem):
         if not self.adaptive_loader:
             return
 
-        from AIVillage.src.core.resources.adaptive_loader import LoadingContext
+        from ....core.resources.adaptive_loader import LoadingContext
 
         # Create context based on evolution type and current resources
         quality_preferences = {

--- a/src/production/distributed_agents/agent_migration_manager.py
+++ b/src/production/distributed_agents/agent_migration_manager.py
@@ -14,7 +14,7 @@ import uuid
 
 import msgpack
 
-from AIVillage.src.core.p2p.p2p_node import P2PNode
+from ...core.p2p.p2p_node import P2PNode
 
 from .distributed_agent_orchestrator import AgentInstance, AgentType, DeviceProfile
 

--- a/src/production/distributed_agents/distributed_agent_orchestrator.py
+++ b/src/production/distributed_agents/distributed_agent_orchestrator.py
@@ -12,9 +12,9 @@ import time
 from typing import Any
 import uuid
 
-from AIVillage.src.core.p2p.p2p_node import P2PNode
-from AIVillage.src.core.resources.resource_monitor import ResourceMonitor
-from AIVillage.src.production.distributed_inference.model_sharding_engine import (
+from ...core.p2p.p2p_node import P2PNode
+from ...core.resources.resource_monitor import ResourceMonitor
+from ..distributed_inference.model_sharding_engine import (
     DeviceProfile,
     ModelShardingEngine,
 )

--- a/src/production/distributed_inference/adaptive_resharding.py
+++ b/src/production/distributed_inference/adaptive_resharding.py
@@ -16,7 +16,7 @@ import time
 from typing import Any
 import uuid
 
-from AIVillage.src.core.p2p.p2p_node import P2PNode
+from ...core.p2p.p2p_node import P2PNode
 
 from .model_sharding_engine import ModelShard, ModelShardingEngine, ShardingPlan
 

--- a/src/production/distributed_inference/compression_integration.py
+++ b/src/production/distributed_inference/compression_integration.py
@@ -14,7 +14,7 @@ from typing import Any
 import torch
 from torch import nn
 
-from AIVillage.src.production.compression.compression_pipeline import (
+from ..compression.compression_pipeline import (
     CompressionConfig,
     CompressionPipeline,
 )

--- a/src/production/distributed_inference/model_sharding_engine.py
+++ b/src/production/distributed_inference/model_sharding_engine.py
@@ -14,9 +14,9 @@ import uuid
 from transformers import AutoConfig, AutoTokenizer
 
 # Import Sprint 6 infrastructure
-from AIVillage.src.core.p2p.p2p_node import P2PNode, PeerCapabilities
-from AIVillage.src.core.resources.device_profiler import DeviceProfiler
-from AIVillage.src.core.resources.resource_monitor import ResourceMonitor
+from ...core.p2p.p2p_node import P2PNode, PeerCapabilities
+from ...core.resources.device_profiler import DeviceProfiler
+from ...core.resources.resource_monitor import ResourceMonitor
 
 logger = logging.getLogger(__name__)
 

--- a/src/production/evolution/evomerge/merging/merger.py
+++ b/src/production/evolution/evomerge/merging/merger.py
@@ -4,16 +4,16 @@ import os
 import torch
 from transformers import AutoTokenizer
 
-from AIVillage.src.production.evolution.evomerge.config import Configuration
-from AIVillage.src.production.evolution.evomerge.cross_domain import (
+from ..config import Configuration
+from ..cross_domain import (
     merge_cross_domain_models,
 )
-from AIVillage.src.production.evolution.evomerge.instruction_tuning import (
+from ..instruction_tuning import (
     is_instruction_tuned_model,
     merge_instruction_tuned_models,
 )
-from AIVillage.src.production.evolution.evomerge.model_tracker import model_tracker
-from AIVillage.src.production.evolution.evomerge.utils import (
+from ..model_tracker import model_tracker
+from ..utils import (
     EvoMergeException,
     check_system_resources,
     clean_up_models,
@@ -194,7 +194,7 @@ class AdvancedModelMerger:
 
 if __name__ == "__main__":
     # For testing purposes
-    from AIVillage.src.production.evolution.evomerge.config import create_default_config
+    from ..config import create_default_config
 
     config = create_default_config()
     merger = AdvancedModelMerger(config)

--- a/src/production/federated_learning/federated_coordinator.py
+++ b/src/production/federated_learning/federated_coordinator.py
@@ -18,8 +18,8 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
-from AIVillage.src.core.p2p.p2p_node import P2PNode, PeerCapabilities
-from AIVillage.src.production.evolution.infrastructure_aware_evolution import (
+from ...core.p2p.p2p_node import P2PNode, PeerCapabilities
+from ..evolution.infrastructure_aware_evolution import (
     InfrastructureAwareEvolution,
 )
 

--- a/src/production/rag/rag_system/agents/latent_space_agent.py
+++ b/src/production/rag/rag_system/agents/latent_space_agent.py
@@ -5,7 +5,7 @@ from some_embedding_library import (  # Replace with actual embedding library
 )
 from some_llm_library import LLMModel  # Replace with actual LLM library
 
-from AIVillage.src.production.rag.rag_system.core.agent_interface import AgentInterface
+from ..core.agent_interface import AgentInterface
 
 
 class LatentSpaceAgent(AgentInterface):

--- a/src/production/rag/rag_system/processing/cognitive_nexus.py
+++ b/src/production/rag/rag_system/processing/cognitive_nexus.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-from AIVillage.src.production.rag.rag_system.core.agent_interface import AgentInterface
-from AIVillage.src.production.rag.rag_system.core.interface import ReasoningEngine
-from AIVillage.src.production.rag.rag_system.processing.self_referential_query_processor import (
+from ..core.agent_interface import AgentInterface
+from ..core.interface import ReasoningEngine
+from .self_referential_query_processor import (
     SelfReferentialQueryProcessor,
 )
 

--- a/src/production/rag/rag_system/processing/knowledge_constructor.py
+++ b/src/production/rag/rag_system/processing/knowledge_constructor.py
@@ -3,8 +3,8 @@
 from datetime import datetime
 from typing import Any
 
-from AIVillage.src.production.rag.rag_system.core.config import RAGConfig
-from AIVillage.src.production.rag.rag_system.core.structures import RetrievalResult
+from ..core.config import RAGConfig
+from ..core.structures import RetrievalResult
 
 
 class DefaultKnowledgeConstructor:

--- a/src/production/rag/rag_system/processing/self_referential_query_processor.py
+++ b/src/production/rag/rag_system/processing/self_referential_query_processor.py
@@ -1,6 +1,6 @@
 # rag_system/processing/self_referential_query_processor.py
 
-from AIVillage.src.production.rag.rag_system.core.pipeline import EnhancedRAGPipeline
+from ..core.pipeline import EnhancedRAGPipeline
 
 
 class SelfReferentialQueryProcessor:

--- a/src/production/rag/rag_system/retrieval/graph_store.py
+++ b/src/production/rag/rag_system/retrieval/graph_store.py
@@ -9,14 +9,14 @@ except Exception:  # pragma: no cover - handled by fallback logic
     nx = None  # type: ignore
 
 try:  # embedding dependencies are optional
-    from AIVillage.src.production.rag.rag_system.utils.embedding import (
+    from ..utils.embedding import (
         BERTEmbeddingModel,
     )
 except Exception:  # pragma: no cover - missing torch/transformers
     BERTEmbeddingModel = None  # type: ignore
 
-from AIVillage.src.production.rag.rag_system.core.config import UnifiedConfig
-from AIVillage.src.production.rag.rag_system.core.structures import RetrievalResult
+from ..core.config import UnifiedConfig
+from ..core.structures import RetrievalResult
 
 
 class GraphStore:

--- a/src/production/rag/rag_system/retrieval/vector_store.py
+++ b/src/production/rag/rag_system/retrieval/vector_store.py
@@ -15,8 +15,8 @@ import base64
 import json
 import uuid
 
-from AIVillage.src.production.rag.rag_system.core.config import UnifiedConfig
-from AIVillage.src.production.rag.rag_system.core.structures import RetrievalResult
+from ..core.config import UnifiedConfig
+from ..core.structures import RetrievalResult
 
 
 def _get_qdrant_url() -> str:

--- a/src/production/rag/rag_system/tracking/knowledge_evolution_tracker.py
+++ b/src/production/rag/rag_system/tracking/knowledge_evolution_tracker.py
@@ -4,8 +4,8 @@ import asyncio
 from datetime import datetime
 from typing import Any
 
-from AIVillage.src.production.rag.rag_system.retrieval.graph_store import GraphStore
-from AIVillage.src.production.rag.rag_system.retrieval.vector_store import VectorStore
+from ..retrieval.graph_store import GraphStore
+from ..retrieval.vector_store import VectorStore
 
 
 class KnowledgeEvolutionTracker:

--- a/src/production/rag/rag_system/tracking/unified_knowledge_tracker.py
+++ b/src/production/rag/rag_system/tracking/unified_knowledge_tracker.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from AIVillage.src.production.rag.rag_system.core.structures import RetrievalResult
+    from ..core.structures import RetrievalResult
 
 
 @dataclass

--- a/tests/test_smoke_import.py
+++ b/tests/test_smoke_import.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_smoke_imports():
+    """Ensure key modules import successfully via the AIVillage namespace."""
+    importlib.import_module("AIVillage.ingestion.connectors.amazon_orders")


### PR DESCRIPTION
## Summary
- replace `AIVillage.src` absolute imports with relative equivalents
- set package submodule locations so `AIVillage` exposes `src` modules
- add smoke test verifying module import via `AIVillage` namespace

## Implementation notes
- automated refactor to convert imports under `src/` to `..` style
- updated package init to adjust `__spec__` search locations for submodules
- added simple test importing `ingestion.connectors.amazon_orders`

## Tradeoffs
- repository-wide lint/type/test checks currently fail due to pre-existing issues
- additional path manipulation may be needed for other environments

## Tests added
- `tests/test_smoke_import.py`

## Local run logs (lint/type/tests)
- `ruff check .` *(fails: Found 36179 errors)*
- `ruff format --check .` *(fails: parse errors)*
- `mypy .` *(fails: Unexpected character after line continuation character)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: file or directory not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ModuleNotFoundError: No module named 'agent_forge.forge_orchestrator')*


------
https://chatgpt.com/codex/tasks/task_e_689aa68cbdb0832ca244be9291b4b24b