### PR TITLE
Support PyTorch tensors in P2P streaming

### DIFF
--- a/src/infrastructure/p2p/tensor_streaming.py
+++ b/src/infrastructure/p2p/tensor_streaming.py
@@ -119,6 +119,12 @@ class TensorStreamer:
 
         if TORCH_AVAILABLE and metadata.get("is_torch_tensor", False):
             tensor = torch.from_numpy(np_array)
+            # Move back to original device if available
+            device = metadata.get("device", "cpu")
+            try:
+                tensor = tensor.to(device)
+            except Exception:
+                logger.warning("Requested device %s not available", device)
             if metadata.get("requires_grad", False):
                 tensor.requires_grad_(True)
             return tensor

--- a/tests/production/test_tensor_streaming_integration.py
+++ b/tests/production/test_tensor_streaming_integration.py
@@ -4,6 +4,7 @@ import hashlib
 
 import numpy as np
 import pytest
+import torch
 
 from src.production.communications.p2p.p2p_node import MessageType, P2PMessage, P2PNode
 from src.production.communications.p2p.tensor_streaming import TensorStreaming
@@ -50,6 +51,43 @@ async def test_tensor_stream_round_trip(monkeypatch):
     metadata = recv_stream.tensor_metadata[tensor_id]
     assert np.array_equal(reconstructed, tensor)
     assert metadata.tensor_id == tensor_id
+
+
+@pytest.mark.asyncio
+async def test_torch_tensor_stream_round_trip(monkeypatch):
+    sender = P2PNode(node_id="sender_torch", port=9201)
+    receiver = P2PNode(node_id="receiver_torch", port=9202)
+
+    send_stream = TensorStreaming(node=sender)
+    recv_stream = TensorStreaming(node=receiver)
+
+    receiver.register_handler(MessageType.DATA, recv_stream._handle_tensor_chunk)
+
+    async def fake_send_message(self, peer_id, message_type, payload):
+        assert peer_id == receiver.node_id
+        msg = P2PMessage(
+            message_type=message_type,
+            sender_id=self.node_id,
+            receiver_id=peer_id,
+            payload=payload,
+        )
+        handler = receiver.message_handlers.get(message_type)
+        if handler:
+            await handler(msg, None)
+            return True
+        return False
+
+    monkeypatch.setattr(sender, "send_message", fake_send_message.__get__(sender, P2PNode))
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tensor = torch.arange(8, dtype=torch.float32, device=device)
+    tensor_id = await send_stream.send_tensor(tensor, "torch", receiver.node_id)
+
+    reconstructed = await recv_stream._reconstruct_tensor(tensor_id)
+    assert isinstance(reconstructed, torch.Tensor)
+    assert torch.equal(reconstructed, tensor)
+    assert reconstructed.device.type == device.type
+    assert reconstructed.dtype == tensor.dtype
 
 
 @pytest.mark.asyncio

--- a/tests/production/test_tensor_streaming_safe.py
+++ b/tests/production/test_tensor_streaming_safe.py
@@ -4,6 +4,7 @@ import time
 
 import numpy as np
 import pytest
+import torch
 
 from src.infrastructure.p2p.tensor_streaming import TensorStreamer
 from src.production.communications.p2p.p2p_node import MessageType, P2PNode
@@ -15,6 +16,18 @@ def test_safe_serialization_round_trip():
     data = streamer._serialize_tensor(array)
     restored = streamer._deserialize_tensor(data)
     assert np.array_equal(array, restored)
+
+
+def test_safe_serialization_round_trip_torch():
+    streamer = TensorStreamer()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tensor = torch.arange(10, dtype=torch.float32, device=device)
+    data = streamer._serialize_tensor(tensor)
+    restored = streamer._deserialize_tensor(data)
+    assert isinstance(restored, torch.Tensor)
+    assert torch.equal(restored, tensor)
+    assert restored.device.type == device.type
+    assert restored.dtype == tensor.dtype
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- serialize PyTorch tensors with device metadata for P2P streaming
- reconstruct tensors on their original device when deserializing
- test safe and P2P streaming of torch tensors

## Implementation Notes
- torch support added conditionally so environments without torch still function
- device information stored in tensor metadata tags and applied on reconstruction

## Tradeoffs
- tags now include reserved keys (`framework`, `device`)

## Tests Added
- torch tensor round-trip for infrastructure TensorStreamer
- torch tensor round-trip between P2P nodes

## Local Run Logs (lint/type/tests)
- `ruff check .` *(fails: missing annotations, logging f-strings, etc)*
- `ruff format --check .` *(fails: line length and other formatting issues)*
- `mypy .` *(fails: logging and typing warnings)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py` *(fails: file not found)*
- `pytest -q tests/test_orchestrator_integration.py` *(fails: error during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689aa7233710832cabd0135e5c9f7105