### PR TITLE
Clean tensor metadata after receive

### DIFF
--- a/src/production/communications/p2p/tensor_streaming.py
+++ b/src/production/communications/p2p/tensor_streaming.py
@@ -345,6 +345,7 @@ class TensorStreaming:
                 # Clean up
                 self.active_transfers.pop(tensor_id, None)
                 self.pending_chunks.pop(tensor_id, None)
+                self.tensor_metadata.pop(tensor_id, None)
 
                 logger.info(f"Successfully received tensor {metadata.name}")
                 return tensor_data, metadata

--- a/tests/production/test_tensor_streaming_integration.py
+++ b/tests/production/test_tensor_streaming_integration.py
@@ -46,10 +46,13 @@ async def test_tensor_stream_round_trip(monkeypatch):
     for chunk in recv_stream.pending_chunks[tensor_id].values():
         assert hashlib.md5(chunk.data).hexdigest() == chunk.checksum
 
-    reconstructed = await recv_stream._reconstruct_tensor(tensor_id)
-    metadata = recv_stream.tensor_metadata[tensor_id]
+    reconstructed, metadata = await recv_stream.receive_tensor(tensor_id)
     assert np.array_equal(reconstructed, tensor)
     assert metadata.tensor_id == tensor_id
+
+    assert recv_stream.pending_chunks == {}
+    assert recv_stream.active_transfers == {}
+    assert recv_stream.tensor_metadata == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure `receive_tensor` removes tensor IDs from metadata after successful reconstruction
- verify tensor streaming round-trip leaves no pending state

## Implementation Notes
- added `tensor_metadata.pop` during cleanup in `TensorStreaming.receive_tensor`
- adjusted integration test to call `receive_tensor` and assert empty dictionaries

## Tradeoffs
- repository-wide linting, formatting, type checks, and tests currently fail due to existing issues and missing modules

## Tests Added
- updated tensor streaming round-trip test to check cleanup of `pending_chunks`, `active_transfers`, and `tensor_metadata`

## Local Run Logs (first failure shown)
- `ruff check src/production/communications/p2p/tensor_streaming.py tests/production/test_tensor_streaming_integration.py`
- `ruff format --check src/production/communications/p2p/tensor_streaming.py tests/production/test_tensor_streaming_integration.py`
- `mypy .`
- `pytest -q`
- `pytest -q tests/p2p/test_dual_path.py -q`
- `pytest -q tests/test_orchestrator_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa759e5ec832cb812135a1f0665ee