### PR TITLE
Add locks to tensor streaming state and concurrent transfer test

### DIFF
--- a/src/production/communications/p2p/tensor_streaming.py
+++ b/src/production/communications/p2p/tensor_streaming.py
@@ -8,7 +8,7 @@ import io
 import json
 import logging
 import time
-from typing import Any
+from typing import Any, Callable
 import uuid
 import zlib
 import base64
@@ -140,6 +140,11 @@ class TensorStreaming:
         self.active_transfers: dict[str, TransferProgress] = {}
         self.pending_chunks: dict[str, dict[int, TensorChunk]] = {}  # tensor_id -> chunk_index -> chunk
         self.tensor_metadata: dict[str, TensorMetadata] = {}
+
+        # Concurrency controls
+        self._active_transfers_lock = asyncio.Lock()
+        self._pending_chunks_lock = asyncio.Lock()
+        self._tensor_metadata_lock = asyncio.Lock()
 
         # Bandwidth management
         self.bandwidth_tracker = BandwidthTracker(self.config.bandwidth_limit_kbps)
@@ -300,25 +305,25 @@ class TensorStreaming:
         self,
         tensor_id: str,
         timeout: float = 300.0,
-        progress_callback: callable | None = None,
+        progress_callback: Callable | None = None,
     ) -> tuple[Any, TensorMetadata] | None:
         """Receive a tensor from a peer node."""
-        if tensor_id not in self.tensor_metadata:
-            logger.error(f"No metadata found for tensor {tensor_id}")
-            return None
-
-        metadata = self.tensor_metadata[tensor_id]
+        async with self._tensor_metadata_lock:
+            if tensor_id not in self.tensor_metadata:
+                logger.error(f"No metadata found for tensor {tensor_id}")
+                return None
+            metadata = self.tensor_metadata[tensor_id]
 
         # Initialize transfer tracking
-        if tensor_id not in self.active_transfers:
-            self.active_transfers[tensor_id] = TransferProgress(
-                tensor_id=tensor_id,
-                total_chunks=metadata.total_chunks,
-                received_chunks=0,
-                estimated_total_bytes=metadata.size_bytes,
-            )
-
-        progress = self.active_transfers[tensor_id]
+        async with self._active_transfers_lock:
+            if tensor_id not in self.active_transfers:
+                self.active_transfers[tensor_id] = TransferProgress(
+                    tensor_id=tensor_id,
+                    total_chunks=metadata.total_chunks,
+                    received_chunks=0,
+                    estimated_total_bytes=metadata.size_bytes,
+                )
+            progress = self.active_transfers[tensor_id]
         start_time = time.time()
 
         logger.info(f"Receiving tensor {metadata.name} ({metadata.total_chunks} chunks)")
@@ -343,8 +348,9 @@ class TensorStreaming:
                 self.stats["bytes_received"] += metadata.size_bytes
 
                 # Clean up
-                self.active_transfers.pop(tensor_id, None)
-                self.pending_chunks.pop(tensor_id, None)
+                async with self._active_transfers_lock, self._pending_chunks_lock:
+                    self.active_transfers.pop(tensor_id, None)
+                    self.pending_chunks.pop(tensor_id, None)
 
                 logger.info(f"Successfully received tensor {metadata.name}")
                 return tensor_data, metadata
@@ -613,8 +619,9 @@ class TensorStreaming:
             tags=metadata_dict["tags"],
         )
 
-        self.tensor_metadata[tensor_id] = metadata
-        self.pending_chunks[tensor_id] = {}
+        async with self._tensor_metadata_lock, self._pending_chunks_lock:
+            self.tensor_metadata[tensor_id] = metadata
+            self.pending_chunks[tensor_id] = {}
 
         logger.info(f"Received metadata for tensor {metadata.name} ({metadata.total_chunks} chunks)")
 
@@ -648,22 +655,24 @@ class TensorStreaming:
         )
 
         # Store chunk
-        if tensor_id not in self.pending_chunks:
-            self.pending_chunks[tensor_id] = {}
-
-        self.pending_chunks[tensor_id][chunk_index] = chunk
+        async with self._pending_chunks_lock:
+            if tensor_id not in self.pending_chunks:
+                self.pending_chunks[tensor_id] = {}
+            self.pending_chunks[tensor_id][chunk_index] = chunk
+            received_len = len(self.pending_chunks[tensor_id])
 
         # Update progress
-        if tensor_id in self.active_transfers:
-            progress = self.active_transfers[tensor_id]
-            progress.received_chunks = len(self.pending_chunks[tensor_id])
-            progress.last_update = time.time()
-            progress.bytes_transferred += len(chunk_data)
+        async with self._active_transfers_lock:
+            if tensor_id in self.active_transfers:
+                progress = self.active_transfers[tensor_id]
+                progress.received_chunks = received_len
+                progress.last_update = time.time()
+                progress.bytes_transferred += len(chunk_data)
 
-            # Calculate transfer rate
-            elapsed = progress.last_update - progress.start_time
-            if elapsed > 0:
-                progress.transfer_rate_kbps = (progress.bytes_transferred / 1024) / elapsed
+                # Calculate transfer rate
+                elapsed = progress.last_update - progress.start_time
+                if elapsed > 0:
+                    progress.transfer_rate_kbps = (progress.bytes_transferred / 1024) / elapsed
 
         self.stats["chunks_received"] += 1
 


### PR DESCRIPTION
## Summary
- protect tensor streaming dictionaries with asyncio.Lock
- guard active transfer, metadata, and chunk mutations
- add concurrency test for simultaneous tensor transfers

## Implementation Notes
- introduce dedicated locks for `active_transfers`, `pending_chunks`, and `tensor_metadata`
- concurrency test pre-seeds transfer progress and verifies cleanup

## Tradeoffs
- global checks fail due to existing repository issues unrelated to changes

## Tests Added
- `tests/production/test_tensor_streaming_integration.py::test_simultaneous_transfers`

## Local Run Logs
- `ruff check .` *(fails: Magic value, etc.)*
- `ruff format --check .` *(fails: parse errors)*
- `mypy .` *(fails: Unexpected character after line continuation character)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(error: file or directory not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ModuleNotFoundError: No module named 'agent_forge.forge_orchestrator')*
- `pytest tests/production/test_tensor_streaming_integration.py -k simultaneous -q`

------
https://chatgpt.com/codex/tasks/task_e_689aa7738fa0832ca7f8681098068782