### PR TITLE
chore: simplify package inits

### DIFF
--- a/experimental/agents/__init__.py
+++ b/experimental/agents/__init__.py
@@ -1,5 +1,1 @@
-from .. import warn_experimental
-
-warn_experimental(__name__)
-
-"""Production/experimental code organized by Sprint 2."""
+"""Experimental agents package."""

--- a/experimental/federated/__init__.py
+++ b/experimental/federated/__init__.py
@@ -1,5 +1,1 @@
-from AIVillage.experimental import warn_experimental
-
-warn_experimental(__name__)
-
-"""Production/experimental code organized by Sprint 2."""
+"""Federated learning experimental components."""

--- a/experimental/mesh/__init__.py
+++ b/experimental/mesh/__init__.py
@@ -1,5 +1,1 @@
-from AIVillage.experimental import warn_experimental
-
-warn_experimental(__name__)
-
-"""Production/experimental code organized by Sprint 2."""
+"""Mesh network experimental components."""

--- a/production/__init__.py
+++ b/production/__init__.py
@@ -1,46 +1,13 @@
-"""AIVillage Production Components.
+"""Deprecated shim for legacy ``production`` package.
 
-This package contains production-ready components that have passed Sprint 2 quality gates:
-- Compression: Model compression with 4-8x reduction
-- Evolution: Evolutionary model optimization
-- RAG: Retrieval-augmented generation
-- Memory: Memory management and W&B logging
-- Benchmarking: Real benchmark evaluation
-- Geometry: Geometric analysis capabilities
-
-All components in this package are stable, tested, and ready for production use.
+Use :mod:`src.production` instead.
 """
+import warnings as _w
 
-from pkgutil import extend_path
+_w.warn(
+    "Deprecated module: 'production' -> 'src.production'",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-__path__ = extend_path(__path__, __name__)
-
-__version__ = "1.0.0"
-__status__ = "Production"
-
-# Quality gates enforced:
-# - No task markers or fix markers in code
-# - No imports from experimental/ or deprecated/
-# - Minimum 70% test coverage
-# - Type checking with mypy
-# - Security scanning with bandit
-# - Pre-commit hooks enforced
-
-# Import guard to prevent experimental imports
-import sys
-import warnings
-
-
-def _check_imports() -> None:
-    """Check that no experimental modules are imported."""
-    for module_name in sys.modules:
-        if module_name.startswith(("experimental.", "deprecated.")):
-            warnings.warn(
-                f"Production code should not import {module_name}",
-                UserWarning,
-                stacklevel=2,
-            )
-
-
-# Production components - these should be stable APIs
-__all__ = ["benchmarking", "compression", "evolution", "geometry", "memory", "rag"]
+from src.production import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- replace legacy `production` package with deprecation shim that forwards to `src.production`
- strip side-effect warnings from experimental package initializers for federated, mesh, and agents

## Implementation Notes
- shim warns via `DeprecationWarning` and re-exports canonical symbols
- experimental packages now expose lightweight docstrings without import-time behavior

## Tradeoffs
- leaving star import in shim introduces lint noise but maintains backward compatibility

## Tests Added
- none

## Local Run Logs (lint/type/tests)
- `ruff check .` *(fails: 25160 errors)*
- `ruff format --check .` *(fails: parse error in coordinator, 4 files would reformat)*
- `mypy .` *(fails: experimental/agents/agents/king/coordinator.py:323: error: Unexpected indent)*
- `pytest -q` *(fails: 85 errors during collection)*
- `pytest -q tests/p2p/test_dual_path.py` *(fails: file or directory not found)*
- `pytest -q tests/test_orchestrator_integration.py` *(fails: 9 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689b756056ac832c855f83c697195a84