### PR TITLE
Add production security workflow and gating scripts

### DIFF
--- a/.github/workflows/scion_production.yml
+++ b/.github/workflows/scion_production.yml
@@ -1,0 +1,57 @@
+name: Scion Production
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  scion-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
+
+      - name: Build Rust
+        run: cargo build --locked --all-targets
+
+      - name: Test Rust
+        run: cargo test --locked --all-targets
+
+      - name: Build Go
+        run: go build ./...
+
+      - name: Test Go
+        run: go test ./...
+
+      - name: Short fuzz
+        run: |
+          if [ -f fuzz/Cargo.toml ]; then
+            cargo install cargo-fuzz >/dev/null 2>&1
+            cargo fuzz run fuzz_target -- -runs=100
+          else
+            echo 'No fuzz targets; skipping.'
+          fi
+
+      - name: Check for forbidden terms
+        run: tools/linting/forbidden_checks.sh
+
+      - name: Deny insecure feature
+        run: |
+          if rustc tools/security/deny_insecure.rs --cfg feature="insecure" 2>&1 | tee /tmp/deny.log; then
+            echo "Insecure feature flag compiled" >&2
+            exit 1
+          else
+            echo "Insecure feature blocked"
+          fi

--- a/tmp_submission/tooling.txt
+++ b/tmp_submission/tooling.txt
@@ -1,0 +1,20 @@
+Default host: x86_64-unknown-linux-gnu
+rustup home:  /root/.rustup
+
+installed toolchains
+--------------------
+1.83.0-x86_64-unknown-linux-gnu
+1.84.1-x86_64-unknown-linux-gnu
+1.85.1-x86_64-unknown-linux-gnu
+1.86.0-x86_64-unknown-linux-gnu
+1.87.0-x86_64-unknown-linux-gnu (active, default)
+
+active toolchain
+----------------
+name: 1.87.0-x86_64-unknown-linux-gnu
+active because: overridden by environment variable RUSTUP_TOOLCHAIN
+installed targets:
+  x86_64-unknown-linux-gnu
+go version go1.24.3 linux/amd64
+Python 3.11.12
+523fc45433a33b25ffc2b533ebaa8e4199acf1c4

--- a/tools/linting/forbidden_checks.sh
+++ b/tools/linting/forbidden_checks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 AI Village
+# Licensed under the MIT License.
+
+set -euo pipefail
+PATTERN='TODO|FIXME|stub|not implemented|unimplemented!|panic!|expect|unwrap'
+# search repository excluding tmp_submission directory
+if rg --hidden --glob '!tmp_submission/*' --ignore-case --regexp "$PATTERN" -n .; then
+  echo "Forbidden terms found" >&2
+  exit 1
+fi

--- a/tools/security/deny_insecure.rs
+++ b/tools/security/deny_insecure.rs
@@ -1,0 +1,5 @@
+// Copyright (c) 2024 AI Village
+// Licensed under the MIT License.
+
+#![cfg(feature = "insecure")]
+compile_error!("Insecure mode disabled for production");


### PR DESCRIPTION
## Summary
- add `scion_production` workflow with Rust/Go builds, short fuzzing, forbidden-term gate, and insecure-feature block
- script linting gate for TODO/FIXME/stub/etc via `rg`
- Rust compile block when `insecure` feature is toggled

## Implementation notes
- workflow compiles Rust and Go targets, runs tests, optional fuzz target, and scans source for banned terms
- `deny_insecure.rs` intentionally fails compilation when `insecure` feature is enabled

## Tradeoffs
- `cargo fuzz` is installed conditionally and skipped when no fuzz targets exist
- lint/type/test commands currently fail due to pre-existing repository issues

## Tests added
- none

## Local run logs (lint/type/tests)
- `ruff check .` *(fails: Line too long, unsorted imports, etc.)*
- `ruff format --check .` *(fails: would reformat multiple files)*
- `mypy .` *(fails: Unterminated string literal)*
- `pytest -q` *(fails: ModuleNotFoundError for deprecated module)*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: file not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: multiple missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689c8f530190832c98760f90e64d0afd