### PR TITLE
Add Betanet compliance linter and SBOM generator

### DIFF
--- a/betanet-lint/Cargo.toml
+++ b/betanet-lint/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "betanet-lint"
+version = "0.1.0"
+edition = "2021"
+authors = ["AIVillage Team"]
+description = "Lints Betanet binaries for MUST/SHALL compliance and generates SBOMs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"

--- a/betanet-lint/action.yml
+++ b/betanet-lint/action.yml
@@ -1,0 +1,19 @@
+name: betanet-lint
+description: Lint Betanet binaries for MUST/SHALL compliance and generate SBOM
+inputs:
+  binary:
+    description: Path to Betanet binary
+    required: true
+  report:
+    description: Path to JSON report output
+    required: true
+  sbom:
+    description: Path to CycloneDX SBOM output
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Run Betanet linter
+      shell: bash
+      run: |
+        cargo run --manifest-path "${{ github.action_path }}/Cargo.toml" -- "${{ inputs.binary }}" --report "${{ inputs.report }}" --sbom "${{ inputs.sbom }}"

--- a/betanet-lint/example-workflow.yml
+++ b/betanet-lint/example-workflow.yml
@@ -1,0 +1,22 @@
+name: betanet-lint-example
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: ./betanet-lint
+        with:
+          binary: ./target/release/betanet-client
+          report: tmp_submission/lint/report.json
+          sbom: tmp_submission/lint/sbom.cdx.json
+      - uses: actions/upload-artifact@v3
+        with:
+          name: betanet-lint
+          path: tmp_submission/lint/

--- a/betanet-lint/src/main.rs
+++ b/betanet-lint/src/main.rs
@@ -1,0 +1,91 @@
+use clap::Parser;
+use serde::Serialize;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Parser)]
+struct Args {
+    /// Path to the Betanet binary or config file
+    target: String,
+    /// Optional path to explicit config file
+    #[arg(long)]
+    config: Option<String>,
+    /// Output path for JSON report
+    #[arg(long)]
+    report: String,
+    /// Output path for CycloneDX SBOM
+    #[arg(long)]
+    sbom: String,
+}
+
+#[derive(Serialize)]
+struct CheckResult {
+    passed: bool,
+    message: String,
+}
+
+#[derive(Serialize)]
+struct Report {
+    nonce_schedule: CheckResult,
+    replay_window: CheckResult,
+    per_origin_param_match: CheckResult,
+    quic_tcp_fallback: CheckResult,
+    rekey_thresholds: CheckResult,
+    cover_traffic_budget: CheckResult,
+    insecure_features_disabled: CheckResult,
+    no_placeholders_release: CheckResult,
+}
+
+fn check_has(haystack: &str, needle: &str) -> CheckResult {
+    let passed = haystack.contains(needle);
+    let message = if passed { "present" } else { "missing" };
+    CheckResult {
+        passed,
+        message: message.to_string(),
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let cfg_content = if let Some(cfg) = args.config.as_ref() {
+        fs::read_to_string(cfg).unwrap_or_default()
+    } else {
+        fs::read_to_string(&args.target).unwrap_or_default()
+    };
+
+    let binary_bytes = fs::read(&args.target).unwrap_or_default();
+    let placeholder_found = String::from_utf8_lossy(&binary_bytes).contains("TODO");
+
+    let report = Report {
+        nonce_schedule: check_has(&cfg_content, "nonce_schedule"),
+        replay_window: check_has(&cfg_content, "replay_window"),
+        per_origin_param_match: check_has(&cfg_content, "per_origin_param_match"),
+        quic_tcp_fallback: check_has(&cfg_content, "quic_tcp_fallback"),
+        rekey_thresholds: check_has(&cfg_content, "rekey_threshold"),
+        cover_traffic_budget: check_has(&cfg_content, "cover_traffic_budget"),
+        insecure_features_disabled: check_has(&cfg_content, "insecure_features=false"),
+        no_placeholders_release: CheckResult {
+            passed: !placeholder_found,
+            message: if placeholder_found {
+                "placeholder found".into()
+            } else {
+                "ok".into()
+            },
+        },
+    };
+
+    if let Some(parent) = Path::new(&args.report).parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&args.report, serde_json::to_string_pretty(&report)?)?;
+
+    // Generate SBOM via helper script
+    Command::new("python")
+        .arg("tools/sbom/generate.py")
+        .arg(&args.target)
+        .arg(&args.sbom)
+        .status()?;
+
+    Ok(())
+}

--- a/tools/sbom/generate.py
+++ b/tools/sbom/generate.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Generate a minimal CycloneDX SBOM for a binary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: generate.py <binary> <output>", file=sys.stderr)
+        return 1
+    binary_path = pathlib.Path(sys.argv[1])
+    output_path = pathlib.Path(sys.argv[2])
+    data = binary_path.read_bytes()
+    sha256 = hashlib.sha256(data).hexdigest()
+    bom: dict[str, Any] = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.3",
+        "version": 1,
+        "components": [
+            {
+                "type": "file",
+                "name": binary_path.name,
+                "hashes": [{"alg": "SHA-256", "content": sha256}],
+            }
+        ],
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(bom, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `betanet-lint` CLI for MUST/SHALL checks and SBOM output
- bundle composite GitHub Action and example workflow
- supply Python helper to emit minimal CycloneDX SBOM

## Implementation Notes
- linter performs string-based validation of nonce schedule, replay windows, per-origin params, QUIC fallback, rekey thresholds, cover-traffic budgets, insecure-feature flags, and placeholder detection
- SBOM generator computes SHA-256 hash and outputs CycloneDX JSON
- action invokes the crate with user-specified binary, report path, and SBOM path

## Tradeoffs
- checks rely on simple text search; deeper validation may be required
- global repo lint/type/test suites currently fail, so only new components were verified

## Tests Added
- none (utility CLI)

## Local Run Logs (lint/type/tests)
- `ruff check .` *(fails: F401 unused imports, etc.)*
- `ruff format --check .` *(fails: E501 line too long, etc.)*
- `mypy .` *(fails: Unterminated string literal)*
- `pytest -q` *(fails: ModuleNotFoundError: p2p_node_deprecated)*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: file not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: multiple import errors)*
- `ruff check tools/sbom/generate.py`
- `ruff format --check tools/sbom/generate.py`
- `mypy tools/sbom/generate.py`
- `cargo test --manifest-path betanet-lint/Cargo.toml`
- `cargo run --manifest-path betanet-lint/Cargo.toml -- target/release/betanet-client --report tmp_submission/lint/report.json --sbom tmp_submission/lint/sbom.cdx.json`


------
https://chatgpt.com/codex/tasks/task_e_689c8f76ea60832c8e3a54121efcf0b4