### PR TITLE
Add Prometheus rules and CI artifact publishing

### DIFF
--- a/.github/workflows/scion_production.yml
+++ b/.github/workflows/scion_production.yml
@@ -1,0 +1,69 @@
+name: scion-production
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install ruff mypy
+
+      - name: Run linters
+        run: |
+          ruff check . > lint.txt || true
+          mypy . > mypy.txt || true
+
+      - name: Upload linter reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports
+          path: |
+            lint.txt
+            mypy.txt
+
+      - name: Metrics snapshot
+        run: |
+          cd scion-sidecar
+          cat <<'GO' > snapshot.go
+package main
+import (
+  "encoding/json"
+  "os"
+  "github.com/aivillage/scion-sidecar/internal/metrics"
+)
+func main() {
+  m := metrics.NewMetricsCollector()
+  snap := m.GetSnapshot()
+  b, _ := json.MarshalIndent(snap, "", "  ")
+  os.WriteFile("metrics_snapshot.json", b, 0o644)
+}
+GO
+          go run snapshot.go
+
+      - name: Upload metrics snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: metrics-snapshot
+          path: scion-sidecar/metrics_snapshot.json
+
+      - name: Run benchmarks
+        run: |
+          python benchmarks/p2p_network_benchmark.py
+          python benchmarks/rag_latency_benchmark.py
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results
+          path: docs/benchmarks

--- a/ops/prometheus_rules.yml
+++ b/ops/prometheus_rules.yml
@@ -1,0 +1,30 @@
+groups:
+  - name: scion-sidecar
+    rules:
+      - alert: AEADAuthFailures
+        expr: increase(aead_auth_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: AEAD authentication failures detected
+      - alert: ReplayDropsSpike
+        expr: increase(antireplay_blocks_total[5m]) > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: High rate of replay-protected packet drops
+      - alert: KeyRotationStall
+        expr: time() - key_rotation_timestamp_seconds > 24 * 3600
+        labels:
+          severity: critical
+        annotations:
+          summary: No key rotation in the last 24h
+      - alert: DecryptLatencyHigh
+        expr: histogram_quantile(0.95, rate(decrypt_latency_seconds_bucket[5m])) > 2 * decrypt_latency_baseline_seconds
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Decryption latency p95 above twice baseline


### PR DESCRIPTION
## Summary
- add SCION crypto alerting rules for auth failures, replay drops, key rotation, and decrypt latency
- create scion production workflow that publishes linter reports, metrics snapshot, and benchmark results

## Implementation notes
- Prometheus rules cover AEAD auth, anti-replay drops, key rotation staleness, and decrypt p95 vs baseline
- Workflow runs ruff/mypy, generates Go metrics snapshot, executes Python benchmarks, and uploads outputs as artifacts

## Tradeoffs
- Metrics snapshot uses a small Go helper generated inline during CI
- Linting and type checking reports are uploaded even if they contain failures

## Tests added
- none

## Local run logs (lint/type/tests)
- `ruff check .` (fails: E501 etc)
- `ruff format --check .` (reports 12 files would be reformatted)
- `mypy .` (fails: Unterminated string literal)
- `pytest -q` (fails: 155 errors during collection)
- `pytest -q tests/p2p/test_dual_path.py` (file not found)
- `pytest -q tests/test_orchestrator_integration.py` (fails: OSError loading torch)


------
https://chatgpt.com/codex/tasks/task_e_689c8fb81308832c951350649c197400