### PR TITLE
Add SCION submission packaging script and signer

### DIFF
--- a/tools/scion/make_submission.sh
+++ b/tools/scion/make_submission.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMIT=$(git rev-parse --short HEAD)
+OUTDIR="dist"
+BIN="$OUTDIR/sign_receipts"
+ARCHIVE="$OUTDIR/betanet_submission_${COMMIT}.tar.gz"
+
+ARTIFACTS=(
+    "reports/htx"
+    "utls/templates"
+    "utls/diffs"
+    "linter/report.txt"
+    "sbom"
+    "benchmarks/mixnode"
+    "logs/c_lib"
+    "receipts/aead"
+    "receipts/replay"
+    "receipts/perf"
+    "logs/ci"
+    "README_SUBMISSION.md"
+)
+
+mkdir -p "$OUTDIR"
+
+# Ensure required artifacts exist
+for path in "${ARTIFACTS[@]}"; do
+    if [ ! -e "$path" ]; then
+        echo "Missing required artifact: $path" >&2
+        exit 1
+    fi
+done
+
+# Compile signer
+rustc tools/scion/sign_receipts.rs -O -o "$BIN"
+
+# Sign receipts directory
+RECEIPTS_DIR="receipts"
+$BIN "$RECEIPTS_DIR" "$OUTDIR/SIGNATURE.txt" "$OUTDIR/PUBLIC_KEY.txt"
+
+# Capture toolchain versions
+{
+    git rev-parse HEAD 2>/dev/null | head -n1
+    rustc --version 2>/dev/null || true
+    go version 2>/dev/null || true
+    python --version 2>/dev/null || true
+} > "$OUTDIR/toolchain_versions.txt"
+
+# Create tarball
+tar -czf "$ARCHIVE" \
+    reports/htx \
+    utls/templates \
+    utls/diffs \
+    linter/report.txt \
+    sbom \
+    benchmarks/mixnode \
+    logs/c_lib \
+    receipts/aead \
+    receipts/replay \
+    receipts/perf \
+    logs/ci \
+    -C "$OUTDIR" SIGNATURE.txt PUBLIC_KEY.txt toolchain_versions.txt \
+    -C "$PWD" README_SUBMISSION.md
+
+echo "Created $ARCHIVE"

--- a/tools/scion/sign_receipts.rs
+++ b/tools/scion/sign_receipts.rs
@@ -1,0 +1,61 @@
+use std::env;
+use std::fs;
+use std::process::Command;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 4 {
+        eprintln!("Usage: {} <receipts_dir> <signature_out> <public_key_out>", args[0]);
+        std::process::exit(1);
+    }
+    let receipts_dir = &args[1];
+    let sig_out = &args[2];
+    let pub_out = &args[3];
+
+    // Create a tarball of receipts for signing
+    let tar_path = "/tmp/receipts.tar";
+    let status = Command::new("tar")
+        .args(["cf", tar_path, "-C", receipts_dir, "."])
+        .status()?;
+    if !status.success() {
+        return Err("failed to create receipts tar".into());
+    }
+
+    // Generate an RSA key pair
+    let priv_key = "/tmp/private_key.pem";
+    let status = Command::new("openssl")
+        .args(["genpkey", "-algorithm", "RSA", "-pkeyopt", "rsa_keygen_bits:2048", "-out", priv_key])
+        .status()?;
+    if !status.success() {
+        return Err("failed to generate key".into());
+    }
+
+    // Export public key
+    let status = Command::new("openssl")
+        .args(["pkey", "-in", priv_key, "-pubout", "-out", pub_out])
+        .status()?;
+    if !status.success() {
+        return Err("failed to export public key".into());
+    }
+
+    // Sign the tarball using SHA256 with RSA
+    let status = Command::new("openssl")
+        .args(["dgst", "-sha256", "-sign", priv_key, "-out", sig_out, tar_path])
+        .status()?;
+    if !status.success() {
+        return Err("failed to sign receipts".into());
+    }
+
+    // Convert signature to base64 for readability
+    let status = Command::new("openssl")
+        .args(["base64", "-in", sig_out, "-out", sig_out])
+        .status()?;
+    if !status.success() {
+        return Err("failed to encode signature".into());
+    }
+
+    // Cleanup
+    let _ = fs::remove_file(priv_key);
+    let _ = fs::remove_file(tar_path);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `tools/scion/make_submission.sh` to gather SCION gateway artifacts and bundle them into a signed submission tarball
- add `tools/scion/sign_receipts.rs` to tar receipts, generate an RSA keypair, and emit base64 signatures and public keys

## Implementation notes
- packaging script checks for required artifacts, captures toolchain versions, invokes the Rust signer, and archives all outputs
- signer uses `openssl` to create an RSA keypair, signs the receipts tarball, and cleans up temporary keys

## Tradeoffs
- relies on system `openssl` for RSA key generation and signing
- script assumes artifact paths exist and will exit if any are missing

## Tests added
- none

## Local run logs (lint/type/tests)
- `ruff check .` *(fails: many existing lint errors)*
- `ruff format --check .` *(reports files needing formatting)*
- `mypy .` *(fails: Unterminated string literal)*
- `pytest -q` *(fails: 119 errors during collection)*
- `pytest -q tests/p2p/test_dual_path.py` *(fails: file not found)*
- `pytest -q tests/test_orchestrator_integration.py` *(fails: 9 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c8fbd2560832ca2159791eb6f3825