### PR TITLE
Add Scion alert rules and CI artifact uploads

### DIFF
--- a/.github/workflows/scion_production.yml
+++ b/.github/workflows/scion_production.yml
@@ -22,6 +22,19 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: stable
+      - name: Run Rust clippy
+        run: cargo clippy --message-format=json > clippy.json
+
+      - name: Run Go vet
+        run: go vet ./... 2>&1 | tee govet.txt
+
+      - name: Upload lint reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: lint-reports
+          path: |
+            clippy.json
+            govet.txt
 
       - name: Build Rust
         run: cargo build --locked --all-targets
@@ -34,6 +47,24 @@ jobs:
 
       - name: Test Go
         run: go test ./...
+
+      - name: Generate metrics snapshot
+        run: python scripts/monitor_performance.py
+
+      - name: Upload metrics snapshot
+        uses: actions/upload-artifact@v3
+        with:
+          name: metrics-snapshot
+          path: test_performance_summary.json
+
+      - name: Run benches
+        run: bash ops/bench/run_bench.sh > bench.log
+
+      - name: Upload bench results
+        uses: actions/upload-artifact@v3
+        with:
+          name: bench-results
+          path: bench.log
 
       - name: Short fuzz
         run: |

--- a/ops/prometheus_rules.yml
+++ b/ops/prometheus_rules.yml
@@ -1,0 +1,36 @@
+groups:
+  - name: scion-production
+    rules:
+      - alert: AEADAuthFailures
+        expr: increase(aead_auth_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: AEAD authentication failures detected
+      - alert: ReplayDropsSpike
+        expr: increase(replay_drops_total[5m]) > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: Replay drop count spiked above 100 in 5m
+      - alert: KeyRotationStall
+        expr: (time() - key_rotation_timestamp_seconds) > 86400
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          description: No key rotation in the last 24h
+      - alert: DecryptLatencyHigh
+        expr: |-
+          histogram_quantile(
+            0.95,
+            sum(rate(decrypt_latency_seconds_bucket[5m])) by (le)
+          )
+            > 2 * decrypt_latency_seconds:p95_baseline
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          description: Decrypt p95 latency exceeds 2x baseline


### PR DESCRIPTION
## Summary
- add production Prometheus alert rules
- publish lint, metrics, and bench outputs in Scion workflow

## Implementation notes
- new rules monitor AEAD auth failures, replay drops, key rotation, and decrypt latency
- CI now uploads clippy/go vet logs, performance snapshot, and bench results

## Tradeoffs
- lint and tests currently report numerous pre-existing failures
- added metrics script runs tests again which may increase CI time

## Tests added
- none

## Local run logs (lint/type/tests)
```
ruff check .
{tail -n20 /tmp/ruff.log}

ruff format --check .
{cat /tmp/ruff_format.log | tail -n20}

mypy .
{cat /tmp/mypy.log | tail -n20}

pytest -q
{tail -n20 /tmp/pytest.log}

pytest -q tests/p2p/test_dual_path.py -q
ERROR: file or directory not found: tests/p2p/test_dual_path.py

pytest -q tests/test_orchestrator_integration.py -q
{tail -n20 /tmp/pytest_orch.log}
```

------
https://chatgpt.com/codex/tasks/task_e_689c94fc0cb8832c88da19df4f96d2b4