### PR TITLE
Refactor CLI dispatch helpers

### DIFF
--- a/deprecated/backup_20250813/rag_system/main.py
+++ b/deprecated/backup_20250813/rag_system/main.py
@@ -1,0 +1,6 @@
+"""Deprecated RAG system wrapper.
+
+This module remains for backward compatibility and now simply re-exports
+:mod:`src.production.rag.rag_system.main`.
+"""
+from src.production.rag.rag_system.main import main  # noqa: F401

--- a/src/agent_forge/main.py
+++ b/src/agent_forge/main.py
@@ -1,65 +1,31 @@
-#!/usr/bin/env python3
-"""Agent Forge Service Entry Point.
-
-This module provides the entry point for the Agent Forge service,
-handling agent creation, training, and management operations.
-"""
-
-import argparse
+# isort: skip_file
 import sys
+from collections.abc import Sequence
 
-
-def create_parser():
-    """Create argument parser for Agent Forge service."""
-    parser = argparse.ArgumentParser(description="Agent Forge Service")
-
-    parser.add_argument(
-        "action",
-        choices=["train", "create", "list", "delete", "status"],
-        help="Action to perform",
-    )
-
-    parser.add_argument("--config", "-c", help="Configuration file path")
-
-    parser.add_argument(
-        "--agent-type",
-        choices=["king", "sage", "magi", "base"],
-        default="base",
-        help="Type of agent to create/train",
-    )
-
-    parser.add_argument("--name", help="Agent name")
-
-    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose output")
-
-    return parser
+from src.cli.base import run_cli
 
 
 def train_agent(args) -> int:
     """Train an agent."""
     print(f"Training {args.agent_type} agent: {args.name}")
-    # Implementation would go here
     return 0
 
 
 def create_agent(args) -> int:
     """Create a new agent."""
     print(f"Creating {args.agent_type} agent: {args.name}")
-    # Implementation would go here
     return 0
 
 
 def list_agents(args) -> int:
     """List all agents."""
     print("Listing all agents...")
-    # Implementation would go here
     return 0
 
 
 def delete_agent(args) -> int:
     """Delete an agent."""
     print(f"Deleting agent: {args.name}")
-    # Implementation would go here
     return 0
 
 
@@ -69,27 +35,32 @@ def get_status(args) -> int:
     return 0
 
 
-def main(args=None):
+def _configure(parser) -> None:
+    parser.add_argument("--config", "-c", help="Configuration file path")
+    parser.add_argument(
+        "--agent-type",
+        choices=["king", "sage", "magi", "base"],
+        default="base",
+        help="Type of agent to create/train",
+    )
+    parser.add_argument("--name", help="Agent name")
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Enable verbose output"
+    )
+
+
+actions = {
+    "train": train_agent,
+    "create": create_agent,
+    "list": list_agents,
+    "delete": delete_agent,
+    "status": get_status,
+}
+
+
+def main(args: Sequence[str] | None = None) -> int:
     """Main entry point for Agent Forge service."""
-    parser = create_parser()
-    args = parser.parse_args() if args is None else parser.parse_args(args)
-
-    if args.verbose:
-        print(f"Agent Forge: {args.action}")
-
-    actions = {
-        "train": train_agent,
-        "create": create_agent,
-        "list": list_agents,
-        "delete": delete_agent,
-        "status": get_status,
-    }
-
-    handler = actions.get(args.action)
-    if handler:
-        return handler(args)
-    print(f"Error: Unknown action '{args.action}'")
-    return 1
+    return run_cli("Agent Forge Service", actions, _configure, args)
 
 
 if __name__ == "__main__":

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,5 @@
+"""Shared CLI utilities for AIVillage."""
+
+from .base import build_parser, dispatch, run_cli
+
+__all__ = ["build_parser", "dispatch", "run_cli"]

--- a/src/cli/base.py
+++ b/src/cli/base.py
@@ -1,0 +1,64 @@
+"""Shared CLI parser and dispatch helpers."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Iterable
+
+Action = Callable[[argparse.Namespace], int]
+ActionMap = dict[str, Action]
+
+
+def build_parser(
+    description: str,
+    commands: Iterable[str],
+    configure: Callable[[argparse.ArgumentParser], None] | None = None,
+    command_name: str = "action",
+    command_help: str | None = None,
+) -> argparse.ArgumentParser:
+    """Create a basic :class:`argparse.ArgumentParser`.
+
+    Args:
+        description: CLI description for the parser.
+        commands: Valid command names for the positional argument.
+        configure: Optional callback to add additional arguments.
+        command_name: Name of the primary positional argument.
+        command_help: Help text for the primary positional argument.
+    """
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        command_name,
+        choices=list(commands),
+        help=command_help or f"{command_name} to perform",
+    )
+    if configure:
+        configure(parser)
+    return parser
+
+
+def dispatch(
+    commands: ActionMap, args: argparse.Namespace, attr: str = "action"
+) -> int:
+    """Dispatch to the handler mapped by ``attr`` in ``commands``."""
+    key = getattr(args, attr)
+    handler = commands.get(key)
+    if handler:
+        return handler(args)
+    print(f"Error: Unknown {attr} '{key}'")
+    return 1
+
+
+def run_cli(
+    description: str,
+    commands: ActionMap,
+    configure: Callable[[argparse.ArgumentParser], None] | None = None,
+    argv: list[str] | None = None,
+    command_name: str = "action",
+    verbose_attr: str = "verbose",
+) -> int:
+    """Run a CLI using shared parser/dispatch logic."""
+    parser = build_parser(description, commands.keys(), configure, command_name)
+    args = parser.parse_args(argv)
+    if verbose_attr and getattr(args, verbose_attr, False):
+        print(f"{description}: {getattr(args, command_name)}")
+    return dispatch(commands, args, attr=command_name)


### PR DESCRIPTION
## Summary
- centralize parser/dispatch utilities in `src/cli/base.py`
- refactor Agent Forge and RAG CLIs to use shared helpers
- add compatibility alias for deprecated RAG wrapper
- route `bin/main.py` subcommands through new dispatch framework

## Testing
- `pre-commit run --files bin/main.py src/agent_forge/main.py src/production/rag/rag_system/main.py deprecated/backup_20250813/rag_system/main.py src/cli/base.py src/cli/__init__.py`
- `pytest -q` *(fails: ImportError: cannot import name 'PeerCapabilities' from 'src.production.communications.p2p.p2p_node')*

------
https://chatgpt.com/codex/tasks/task_e_689e2a366ed0832c97977239e53be9e7