### PR TITLE
feat: add shared configuration loader

### DIFF
--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities for configuration and shared components."""

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -1,0 +1,93 @@
+"""Generic configuration loading utilities."""
+
+# ruff: noqa: I001
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _load_file(path: Path) -> dict[str, Any]:
+    """Load configuration data from a JSON or YAML file."""
+    with path.open() as f:
+        if path.suffix == ".json":
+            return json.load(f)
+        if path.suffix in {".yml", ".yaml"}:
+            return yaml.safe_load(f) or {}
+        msg = f"Unsupported config format: {path.suffix}"
+        raise ValueError(msg)
+
+
+def _dump_file(path: Path, data: Mapping[str, Any]) -> None:
+    """Persist configuration data to a JSON or YAML file."""
+    with path.open("w") as f:
+        if path.suffix == ".json":
+            json.dump(data, f, indent=2)
+        elif path.suffix in {".yml", ".yaml"}:
+            yaml.safe_dump(data, f, default_flow_style=False)
+        else:
+            msg = f"Unsupported config format: {path.suffix}"
+            raise ValueError(msg)
+
+
+def load_config(
+    defaults: Mapping[str, Any] | None = None,
+    config_path: str | None = None,
+    *,
+    env_prefix: str | None = None,
+    required: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Load configuration with optional file and environment overrides.
+
+    Parameters
+    ----------
+    defaults:
+        Base configuration values. These are overridden by values from
+        ``config_path`` and environment variables.
+    config_path:
+        Optional path to a JSON or YAML file.
+    env_prefix:
+        Optional prefix for environment variables. For example, with a prefix of
+        ``"SERVICE_"`` a config key ``"token"`` would be overridden by the
+        ``SERVICE_TOKEN`` environment variable.
+    required:
+        Keys that must be present after loading. Missing keys raise ``ValueError``.
+    """
+    config: dict[str, Any] = dict(defaults or {})
+
+    if config_path:
+        path = Path(config_path)
+        if path.exists():
+            config.update(_load_file(path))
+
+    prefix = (env_prefix or "").upper()
+    for key in list(config.keys()):
+        env_key = f"{prefix}{key}".upper()
+        if env_key in os.environ:
+            value = os.environ[env_key]
+            try:
+                config[key] = json.loads(value)
+            except json.JSONDecodeError:
+                config[key] = value
+
+    if required:
+        missing = [key for key in required if not config.get(key)]
+        if missing:
+            msg = f"Missing required configuration: {', '.join(missing)}"
+            raise ValueError(msg)
+
+    return config
+
+
+def save_config(data: Mapping[str, Any], path: str) -> None:
+    """Save configuration mapping to a JSON or YAML file."""
+    _dump_file(Path(path), data)
+
+
+__all__ = ["load_config", "save_config"]

--- a/src/production/rag/rag_system/core/config.py
+++ b/src/production/rag/rag_system/core/config.py
@@ -1,9 +1,9 @@
 from datetime import timedelta
-from pathlib import Path
 from typing import Any
 
-import yaml
 from pydantic import BaseModel, Field
+
+from common.config import load_config
 
 
 class UnifiedConfig(BaseModel):
@@ -19,7 +19,10 @@ class UnifiedConfig(BaseModel):
 
     # SageAgent configuration
     agent_name: str = "SageAgent"
-    agent_description: str = "A research and analysis agent equipped with advanced reasoning and NLP capabilities."
+    agent_description: str = (
+        "A research and analysis agent equipped with advanced reasoning "
+        "and NLP capabilities."
+    )
 
     # Retrieval configuration
     MAX_RESULTS: int = 10
@@ -64,22 +67,10 @@ class RAGConfig(UnifiedConfig):
 # You can add more specific config classes as needed
 
 
-def load_from_yaml(config_path: str) -> RAGConfig:
-    """Load configuration from a YAML file.
+_DEFAULTS = RAGConfig().model_dump()
 
-    Parameters
-    ----------
-    config_path: str
-        Path to the YAML configuration file.
 
-    Returns:
-    -------
-    RAGConfig
-        Configuration populated with values from the YAML file.
-    """
-    path = Path(config_path)
-    data = {}
-    if path.is_file():
-        with open(path, encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
+def load_rag_config(config_path: str | None = None) -> RAGConfig:
+    """Load RAG configuration using the shared loader."""
+    data = load_config(_DEFAULTS, config_path, env_prefix="RAG_")
     return RAGConfig(**data)


### PR DESCRIPTION
## Summary
- add common configuration helper that merges defaults, files, and env overrides
- switch orchestration and RAG services to use shared loader with service-specific defaults
- standardize env var prefixes and required key validation

## Testing
- `pre-commit run --files src/common/__init__.py src/common/config.py src/agent_forge/orchestration/config.py src/production/rag/rag_system/core/config.py`

------
https://chatgpt.com/codex/tasks/task_e_689e2a3cdb64832c9d01b72093ed46c6