### PR TITLE
feat: add hooks and manifest support to Agent Forge

### DIFF
--- a/agent_forge/__init__.py
+++ b/agent_forge/__init__.py
@@ -1,0 +1,19 @@
+"""Compatibility layer for Agent Forge.
+
+This package provides a thin wrapper that exposes the production
+``AgentForge`` implementation at ``production.agent_forge.core`` under the
+``agent_forge`` namespace. Existing imports like ``from agent_forge.core
+import AgentForge`` continue to work without modification.
+"""
+
+from importlib import import_module
+import sys
+
+_core_pkg = import_module("src.production.agent_forge.core")
+# Re-export ``AgentForge`` at the package level for convenience
+AgentForge = _core_pkg.AgentForge
+
+# Make ``agent_forge.core`` resolve to the production implementation
+sys.modules.setdefault(__name__ + ".core", _core_pkg)
+
+__all__ = ["AgentForge"]

--- a/src/production/agent_forge/agent_factory.py
+++ b/src/production/agent_forge/agent_factory.py
@@ -3,16 +3,15 @@
 Auto-generated from agent specifications.
 """
 
+from importlib import import_module
 import json
-import os
-import sys
+import logging
 from pathlib import Path
 from typing import Any
 
-# Add the parent directory to the path to import our modules
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 from .base import AgentRole, AgentSpecialization, BaseMetaAgent
+
+logger = logging.getLogger(__name__)
 
 
 class TemplateNotFoundError(Exception):
@@ -94,9 +93,11 @@ class AgentFactory:
                                 template = json.load(f)
                             templates[agent_id] = template
                             loaded_templates.add(agent_id)
-                            print(
-                                f"Loaded template {agent_id} from legacy location: {template_file}"
+                            msg = (
+                                f"Loaded template {agent_id} from legacy location: "
+                                f"{template_file}"
                             )
+                            print(msg)
                         except Exception as e:
                             print(f"Error loading template {template_file}: {e}")
 
@@ -120,173 +121,41 @@ class AgentFactory:
         return templates
 
     def _initialize_agent_classes(self) -> dict[str, type]:
-        """Initialize specialized agent classes."""
-        # Import specialized implementations
-        agent_classes = {}
+        """Initialize specialized agent classes with graceful fallbacks."""
+        agent_specs = {
+            "king": ("src.production.agents.king", "KingAgent"),
+            "magi": ("src.production.agents.magi", "MagiAgent"),
+            "sage": ("src.production.agents.sage", "SageAgent"),
+            "gardener": ("src.production.agents.gardener", "GardenerAgent"),
+            "sword_shield": (
+                "src.production.agents.sword_shield",
+                "SwordAndShieldAgent",
+            ),
+            "legal": ("src.production.agents.legal", "LegalAIAgent"),
+            "shaman": ("src.production.agents.shaman", "ShamanAgent"),
+            "oracle": ("src.production.agents.oracle", "OracleAgent"),
+            "maker": ("src.production.agents.maker", "MakerAgent"),
+            "ensemble": ("src.production.agents.ensemble", "EnsembleAgent"),
+            "curator": ("src.production.agents.curator", "CuratorAgent"),
+            "auditor": ("src.production.agents.auditor", "AuditorAgent"),
+            "medic": ("src.production.agents.medic", "MedicAgent"),
+            "sustainer": ("src.production.agents.sustainer", "SustainerAgent"),
+            "navigator": ("src.production.agents.navigator", "NavigatorAgent"),
+            "tutor": ("src.production.agents.tutor", "TutorAgent"),
+            "polyglot": ("src.production.agents.polyglot", "PolyglotAgent"),
+            "strategist": ("src.production.agents.strategist", "StrategistAgent"),
+        }
 
-        # King Agent
-        try:
-            from src.production.agents.king import KingAgent
-
-            agent_classes["king"] = KingAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["king"] = self._create_generic_agent_class("king")
-
-        # Magi Agent
-        try:
-            from src.production.agents.magi import MagiAgent
-
-            agent_classes["magi"] = MagiAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["magi"] = self._create_generic_agent_class("magi")
-
-        # Sage Agent
-        try:
-            from src.production.agents.sage import SageAgent
-
-            agent_classes["sage"] = SageAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["sage"] = self._create_generic_agent_class("sage")
-
-        # Gardener Agent
-        try:
-            from src.production.agents.gardener import GardenerAgent
-
-            agent_classes["gardener"] = GardenerAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["gardener"] = self._create_generic_agent_class("gardener")
-
-        # Sword & Shield Agent
-        try:
-            from src.production.agents.sword_shield import SwordAndShieldAgent
-
-            agent_classes["sword_shield"] = SwordAndShieldAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["sword_shield"] = self._create_generic_agent_class(
-                "sword_shield"
-            )
-
-        # Legal AI Agent
-        try:
-            from src.production.agents.legal import LegalAIAgent
-
-            agent_classes["legal"] = LegalAIAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["legal"] = self._create_generic_agent_class("legal")
-
-        # Shaman Agent
-        try:
-            from src.production.agents.shaman import ShamanAgent
-
-            agent_classes["shaman"] = ShamanAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["shaman"] = self._create_generic_agent_class("shaman")
-
-        # Oracle Agent
-        try:
-            from src.production.agents.oracle import OracleAgent
-
-            agent_classes["oracle"] = OracleAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["oracle"] = self._create_generic_agent_class("oracle")
-
-        # Maker Agent
-        try:
-            from src.production.agents.maker import MakerAgent
-
-            agent_classes["maker"] = MakerAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["maker"] = self._create_generic_agent_class("maker")
-
-        # Ensemble Agent
-        try:
-            from src.production.agents.ensemble import EnsembleAgent
-
-            agent_classes["ensemble"] = EnsembleAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["ensemble"] = self._create_generic_agent_class("ensemble")
-
-        # Curator Agent
-        try:
-            from src.production.agents.curator import CuratorAgent
-
-            agent_classes["curator"] = CuratorAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["curator"] = self._create_generic_agent_class("curator")
-
-        # Auditor Agent
-        try:
-            from src.production.agents.auditor import AuditorAgent
-
-            agent_classes["auditor"] = AuditorAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["auditor"] = self._create_generic_agent_class("auditor")
-
-        # Medic Agent
-        try:
-            from src.production.agents.medic import MedicAgent
-
-            agent_classes["medic"] = MedicAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["medic"] = self._create_generic_agent_class("medic")
-
-        # Sustainer Agent
-        try:
-            from src.production.agents.sustainer import SustainerAgent
-
-            agent_classes["sustainer"] = SustainerAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["sustainer"] = self._create_generic_agent_class("sustainer")
-
-        # Navigator Agent
-        try:
-            from src.production.agents.navigator import NavigatorAgent
-
-            agent_classes["navigator"] = NavigatorAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["navigator"] = self._create_generic_agent_class("navigator")
-
-        # Tutor Agent
-        try:
-            from src.production.agents.tutor import TutorAgent
-
-            agent_classes["tutor"] = TutorAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["tutor"] = self._create_generic_agent_class("tutor")
-
-        # Polyglot Agent
-        try:
-            from src.production.agents.polyglot import PolyglotAgent
-
-            agent_classes["polyglot"] = PolyglotAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["polyglot"] = self._create_generic_agent_class("polyglot")
-
-        # Strategist Agent
-        try:
-            from src.production.agents.strategist import StrategistAgent
-
-            agent_classes["strategist"] = StrategistAgent
-        except ImportError:
-            # Use generic agent if specialized not available
-            agent_classes["strategist"] = self._create_generic_agent_class("strategist")
+        agent_classes: dict[str, type] = {}
+        for agent_id, (module_path, class_name) in agent_specs.items():
+            try:
+                module = import_module(module_path)
+                agent_classes[agent_id] = getattr(module, class_name)
+            except Exception as e:  # pragma: no cover - import may fail
+                logger.warning(
+                    "Falling back to GenericAgent for %s: %s", agent_id, e
+                )
+                agent_classes[agent_id] = self._create_generic_agent_class(agent_id)
 
         return agent_classes
 
@@ -338,9 +207,11 @@ class AgentFactory:
                 available_types,
             )
 
-        print(
-            f"[PASS] All {len(required_types)} required agent templates loaded successfully"
+        msg = (
+            f"[PASS] All {len(required_types)} required agent templates "
+            f"loaded successfully"
         )
+        print(msg)
 
     def _create_generic_agent_class(self, agent_id: str) -> type:
         """Create a generic agent class for the given agent ID."""
@@ -352,6 +223,7 @@ class AgentFactory:
                 super().__init__(spec)
                 self.agent_type = agent_id
                 self.config = default_params.copy()
+                logger.debug("GenericAgent instantiated for %s", agent_id)
 
             def process(self, task: dict[str, Any]) -> dict[str, Any]:
                 return {
@@ -410,11 +282,23 @@ class AgentFactory:
             raise TypeError(msg)
 
         if agent_type not in self.templates:
-            msg = f"Unknown agent type: {agent_type}. Available: {list(self.templates.keys())}"
+            msg = (
+                f"Unknown agent type: {agent_type}. Available: "
+                f"{list(self.templates.keys())}"
+            )
             raise ValueError(msg)
 
         template = self.templates[agent_type]
         agent_class = self.agent_classes[agent_type]
+
+        if config:
+            unknown = set(config) - set(template.get("default_params", {}))
+            if unknown:
+                msg = (
+                    f"Unknown config parameters for {agent_type}: "
+                    f"{sorted(unknown)}"
+                )
+                raise ValueError(msg)
 
         try:
             role = AgentRole(agent_type)

--- a/src/production/agent_forge/core/hooks.py
+++ b/src/production/agent_forge/core/hooks.py
@@ -1,0 +1,45 @@
+"""Hook interfaces for Agent Forge lifecycle events.
+
+The functions defined here act as extension points.  Production deployments
+may monkeypatch these hooks with custom behaviour.  The default
+implementations are intentionally lightweight and side-effect free.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Patch:
+    """Represents a mutation suggested during an evolution step."""
+
+    description: str = ""
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Artifact:
+    """Artifact produced by a compression step."""
+
+    engine: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+def on_agent_created(agent: Any) -> None:
+    """Called whenever a new agent is created."""
+    # Default implementation is a no-op.
+    return None
+
+
+def evolution_step(agent: Any, kpis: dict[str, Any]) -> Patch | None:
+    """Called after KPIs are evaluated for an agent.
+
+    Returning a :class:`Patch` signals that the agent should be modified.
+    """
+    return None
+
+
+def apply_compression(agent: Any, engine_name: str) -> Artifact:
+    """Called to apply compression to an agent using the given engine."""
+    return Artifact(engine=engine_name)

--- a/tests/unit/agent_forge/test_agent_forge_smoke.py
+++ b/tests/unit/agent_forge/test_agent_forge_smoke.py
@@ -1,6 +1,7 @@
+from pathlib import Path
 import sys
 import tempfile
-from pathlib import Path
+from unittest import mock
 
 # Ensure the top-level package is preferred over the similarly named one under src/
 ROOT = Path(__file__).resolve().parents[2]
@@ -23,3 +24,58 @@ def test_agent_forge_manifest_roundtrip():
         loaded = forge.load_manifest(path)
         assert loaded is not None
         assert loaded.to_dict() == manifest.to_dict()
+
+        # Recreate agent from loaded manifest to ensure parity
+        forge2 = AgentForge(enable_evolution=False, enable_compression=False)
+        agent_spec = loaded.agents[0]
+        agent2 = forge2.create_agent(
+            {"agent_type": agent_spec["type"], "config": agent_spec["config"]}
+        )
+        assert agent2 is not None
+        assert getattr(agent2, "config", {}) == getattr(agent, "config", {})
+
+
+class DummyKPIEngine:
+    def register_agent(self, *a, **k):
+        return None
+
+    def update_agent_kpi(self, *a, **k):
+        return None
+
+    def evaluate_population(self):
+        return {}
+
+    def start_evolution_scheduler(self):
+        return None
+
+    def stop_evolution_scheduler(self):
+        return None
+
+
+def test_hook_invocations():
+    forge = AgentForge(enable_evolution=False, enable_compression=False)
+
+    with mock.patch(
+        "src.production.agent_forge.core.forge.on_agent_created"
+    ) as created_hook:
+        agent = forge.create_agent({"agent_type": "navigator"})
+        assert agent is not None
+        created_hook.assert_called_once()
+
+    # Evolution hook
+    forge.kpi_engine = DummyKPIEngine()
+    manifest = forge.create_manifest()
+    with mock.patch(
+        "src.production.agent_forge.core.forge.evolution_step"
+    ) as evo_hook:
+        forge.run_kpi_cycle(manifest)
+        assert evo_hook.called
+
+    # Compression hook
+    forge.compression_engines["dummy"] = object()
+    agent_id = next(iter(forge.created_agents))
+    with mock.patch(
+        "src.production.agent_forge.core.forge.apply_compression"
+    ) as comp_hook:
+        forge.compress_agent(agent_id, "dummy")
+        comp_hook.assert_called_once()


### PR DESCRIPTION
## Summary
- add pluggable hooks for agent creation, evolution and compression
- validate & persist Agent Forge manifests with a CLI helper
- expand smoke tests for manifest round‑trips and hook invocation

## Implementation Notes
- dynamic agent class registry falls back to GenericAgent with logging
- dataclass-based manifest enforces schema before save/load
- simple hook interfaces allow external patches without long-running loops

## Tradeoffs
- project-level coverage run fails due to missing `distributed_agents.agent_registry`

## Tests Added
- `tests/unit/agent_forge/test_agent_forge_smoke.py`

## Local Run Logs
- `ruff check agent_forge/__init__.py src/production/agent_forge/agent_factory.py src/production/agent_forge/core/forge.py src/production/agent_forge/core/hooks.py tests/unit/agent_forge/test_agent_forge_smoke.py`
- `ruff format --check agent_forge/__init__.py src/production/agent_forge/agent_factory.py src/production/agent_forge/core/forge.py src/production/agent_forge/core/hooks.py tests/unit/agent_forge/test_agent_forge_smoke.py`
- `mypy agent_forge/__init__.py src/production/agent_forge/agent_factory.py src/production/agent_forge/core/forge.py src/production/agent_forge/core/hooks.py tests/unit/agent_forge/test_agent_forge_smoke.py`
- `pytest -q tests/unit/agent_forge/test_agent_forge_smoke.py`
- `python src/communications/test_credits_standalone.py -q || true`
- `pytest -q tmp_codex_audit_v3/tests/test_p2p_reliability.py -q`
- `PYTHONPATH=/workspace/AIVillage/src:/workspace/AIVillage pytest -q tmp_codex_audit_v3/tests/test_agent_forge_smoke.py -q`
- `RAG_LOCAL_MODE=1 PYTHONPATH=.:src pytest -q tmp_codex_audit_v3/tests/test_rag_defaults.py -q`
- `pytest -q tmp_codex_audit_v3/tests/test_no_http_in_prod.py tmp_codex_audit_v3/tests/test_no_pickle_loads.py -q`
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_mobile_policy.py -q`
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_tokenomics_db_lock.py -q`
- `PYTHONPATH=. pytest -q --maxfail=1 --disable-warnings --cov=src --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_689e8ef2a864832cbd5b9f739853b154