### PR TITLE
Add local mesh network shim and Android RAG service

### DIFF
--- a/AIVillageEducation/README.md
+++ b/AIVillageEducation/README.md
@@ -27,3 +27,27 @@ cd android
 1. Ensure Android SDK is installed.
 2. Clone repository and install dependencies.
 3. Build and install APK using commands above.
+
+## Local HyperRAG and MeshNetwork
+
+During development the app can query a locally running HyperRAG MCP server and
+exchange messages on the mesh via WebSocket.
+
+### Query HyperRAG
+
+```bash
+curl -X POST localhost:8000/mcp/hyperrag \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "What is HyperRAG?"}'
+```
+
+### Mesh WebSocket
+
+```bash
+# In one terminal subscribe and send messages
+websocat ws://localhost:8000/ws
+{"topic":"demo","data":"hello"}
+```
+
+These endpoints are only exposed in development and allow the Android service
+to mirror Python agent behaviour.

--- a/AIVillageEducation/src/services/RAGService.ts
+++ b/AIVillageEducation/src/services/RAGService.ts
@@ -1,6 +1,37 @@
 export default class RAGService {
+  private socket?: WebSocket;
+
+  private ensureSocket() {
+    if (this.socket) return;
+    const proto = typeof location !== 'undefined' && location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const host = typeof location !== 'undefined' ? location.host : 'localhost:8000';
+    this.socket = new WebSocket(`${proto}//${host}/ws`);
+  }
+
   async answer(query: string): Promise<string> {
-    // Placeholder offline RAG service
-    return `I don't know about "${query}" yet.`;
+    const res = await fetch('/mcp/hyperrag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query }),
+    });
+    const data = await res.json();
+    return data.answer ?? '';
+  }
+
+  publish(topic: string, data: string): void {
+    this.ensureSocket();
+    this.socket?.send(JSON.stringify({ topic, data }));
+  }
+
+  subscribe(topic: string, handler: (data: string) => void): void {
+    this.ensureSocket();
+    this.socket?.addEventListener('message', (evt) => {
+      try {
+        const msg = JSON.parse(evt.data);
+        if (msg.topic === topic) handler(msg.data);
+      } catch {
+        /* ignore malformed messages */
+      }
+    });
   }
 }

--- a/src/core/p2p/mesh.py
+++ b/src/core/p2p/mesh.py
@@ -1,0 +1,134 @@
+"""Minimal mesh networking interface and local shim.
+
+Provides a small, in-process pub/sub implementation that mirrors the
+expected interface of the future LibP2P mesh.  When the optional betanet
+process is available (signaled by ``BETANET_ENABLED=1`` and an open local
+port), an RPC based mesh client is returned instead.  This keeps local
+agents functional while allowing drop-in replacement with the real mesh
+later.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+from typing import Awaitable, Callable, Dict, List, Protocol
+
+
+Handler = Callable[[bytes], Awaitable[None]]
+
+
+class MeshNetwork(Protocol):
+    """Basic mesh network interface."""
+
+    async def join(self, topic: str) -> None:
+        """Join a topic so it can be published or subscribed to."""
+
+    async def publish(self, topic: str, payload: bytes) -> None:
+        """Publish a message to a topic."""
+
+    async def subscribe(self, topic: str, handler: Handler) -> None:
+        """Subscribe to a topic with an async message handler."""
+
+    def peers(self) -> List[str]:
+        """Return known peer identifiers."""
+
+
+class LocalMeshNetwork(MeshNetwork):
+    """In-process pub/sub mesh implementation.
+
+    Maintains per-topic queues for subscribers.  Message history is stored
+    so late subscribers receive previously published messages.  ``publish``
+    will apply backpressure by awaiting on subscriber queues when they are
+    full.
+    """
+
+    def __init__(self, queue_size: int = 10) -> None:
+        self._queues: Dict[str, List[asyncio.Queue[bytes]]] = {}
+        self._history: Dict[str, List[bytes]] = {}
+        self._queue_size = queue_size
+
+    async def join(self, topic: str) -> None:  # pragma: no cover - trivial
+        self._queues.setdefault(topic, [])
+        self._history.setdefault(topic, [])
+
+    async def publish(self, topic: str, payload: bytes) -> None:
+        queues = self._queues.get(topic, [])
+        for q in queues:
+            await q.put(payload)  # apply backpressure
+        self._history.setdefault(topic, []).append(payload)
+
+        # Wait for subscribers to process the message before returning
+        for q in queues:
+            await q.join()
+
+    async def subscribe(self, topic: str, handler: Handler) -> None:
+        queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=self._queue_size)
+        self._queues.setdefault(topic, []).append(queue)
+
+        # Replay history for offline messages
+        for msg in self._history.get(topic, []):
+            await handler(msg)
+
+        async def _consumer() -> None:
+            while True:
+                msg = await queue.get()
+                try:
+                    await handler(msg)
+                finally:
+                    queue.task_done()
+
+        asyncio.create_task(_consumer())
+
+    def peers(self) -> List[str]:  # pragma: no cover - constant
+        return ["local"]
+
+
+class RPCMeshNetwork(MeshNetwork):
+    """Very small JSON-line RPC client for a betanet process.
+
+    This is intentionally minimal; it simply encodes operations as JSON
+    objects and sends them over a TCP socket.
+    """
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+        self._lock = asyncio.Lock()
+
+    async def join(self, topic: str) -> None:
+        await self._send({"cmd": "join", "topic": topic})
+
+    async def publish(self, topic: str, payload: bytes) -> None:
+        await self._send({"cmd": "publish", "topic": topic, "data": payload.decode("latin1")})
+
+    async def subscribe(self, topic: str, handler: Handler) -> None:  # pragma: no cover - stub
+        await self.join(topic)
+        # Incoming messages handled by external process
+
+    def peers(self) -> List[str]:  # pragma: no cover - placeholder
+        return []
+
+    async def _send(self, msg: dict) -> None:
+        data = json.dumps(msg).encode() + b"\n"
+        async with self._lock:
+            self._sock.sendall(data)
+
+
+def get_mesh_network() -> MeshNetwork:
+    """Return an appropriate mesh network implementation.
+
+    If ``BETANET_ENABLED=1`` and the betanet port is open, an RPC client is
+    returned.  Otherwise a local in-process mesh is used.
+    """
+
+    if os.getenv("BETANET_ENABLED") == "1":
+        port = int(os.getenv("BETANET_PORT", "8777"))
+        try:
+            sock = socket.create_connection(("127.0.0.1", port), timeout=0.5)
+            sock.setblocking(False)
+            return RPCMeshNetwork(sock)
+        except OSError:
+            pass
+    return LocalMeshNetwork()

--- a/src/core/p2p/test_mesh_shim.py
+++ b/src/core/p2p/test_mesh_shim.py
@@ -1,0 +1,35 @@
+import asyncio
+import time
+
+import pytest
+
+from .mesh import LocalMeshNetwork
+
+
+@pytest.mark.asyncio
+async def test_local_mesh_broadcast_backpressure_replay() -> None:
+    mesh = LocalMeshNetwork(queue_size=1)
+    await mesh.join("demo")
+    await mesh.publish("demo", b"early")
+
+    messages_a: list[bytes] = []
+    messages_b: list[bytes] = []
+
+    async def handler_a(data: bytes) -> None:
+        messages_a.append(data)
+
+    async def handler_b(data: bytes) -> None:
+        await asyncio.sleep(0.05)
+        messages_b.append(data)
+
+    await mesh.subscribe("demo", handler_a)
+    await mesh.subscribe("demo", handler_b)
+
+    start = time.monotonic()
+    await mesh.publish("demo", b"one")
+    await mesh.publish("demo", b"two")
+    elapsed = time.monotonic() - start
+
+    assert elapsed >= 0.05
+    assert messages_a == [b"early", b"one", b"two"]
+    assert messages_b == [b"early", b"one", b"two"]


### PR DESCRIPTION
## Summary
- implement lightweight `MeshNetwork` interface with in-process `LocalMeshNetwork` and optional betanet RPC
- expose HyperRAG fetch and WebSocket mesh hooks in Android `RAGService`
- document local dev curl and WebSocket steps
- test local mesh broadcast/backpressure/offline replay

## Testing
- `python src/communications/test_credits_standalone.py -q || true`
- `pytest -q tmp_codex_audit_v3/tests/test_p2p_reliability.py -q`
- `PYTHONPATH=/workspace/AIVillage/src:/workspace/AIVillage pytest -q tmp_codex_audit_v3/tests/test_agent_forge_smoke.py -q` *(fails: cannot import HTTPError from requests)*
- `RAG_LOCAL_MODE=1 PYTHONPATH=.:src pytest -q tmp_codex_audit_v3/tests/test_rag_defaults.py -q` *(file not found)*
- `pytest -q tmp_codex_audit_v3/tests/test_no_http_in_prod.py tmp_codex_audit_v3/tests/test_no_pickle_loads.py -q` *(file not found)*
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_mobile_policy.py -q`
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_tokenomics_db_lock.py -q` *(file not found)*
- `PYTHONPATH=. pytest -q src/core/p2p/test_mesh_shim.py`
- `PYTHONPATH=. pytest -q --maxfail=1 --disable-warnings --cov=src --cov-report=term-missing` *(fails: missing distributed_agents.agent_registry)*

------
https://chatgpt.com/codex/tasks/task_e_689e8f9c94b8832ca451e4c2702fe9fa