### PR TITLE
feat: add persistent distributed agent registry

### DIFF
--- a/src/production/distributed_agents/agent_registry.py
+++ b/src/production/distributed_agents/agent_registry.py
@@ -1,0 +1,96 @@
+"""Distributed agent registry with local/remote persistence.
+
+This module tracks locations of distributed agents and persists registry
+information to ``.cache/agent_registry.json``.  The registry distinguishes
+between agents available locally and those reachable remotely.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+REGISTRY_FILE = Path(".cache/agent_registry.json")
+
+
+@dataclass
+class AgentLocation:
+    """Represents a registered agent."""
+
+    name: str
+    endpoint: str
+    local: bool = True
+
+
+class DistributedAgentRegistry:
+    """Registry for distributed agents."""
+
+    def __init__(self, cache_path: Path | str = REGISTRY_FILE) -> None:
+        self.cache_path = Path(cache_path)
+        self.local_agents: Dict[str, str] = {}
+        self.remote_agents: Dict[str, str] = {}
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        """Load registry data from cache."""
+        if not self.cache_path.exists():
+            self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+            return
+
+        try:
+            data = json.loads(self.cache_path.read_text())
+            self.local_agents = data.get("local", {})
+            self.remote_agents = data.get("remote", {})
+        except Exception:
+            # Corrupt cache – start with empty registry
+            self.local_agents = {}
+            self.remote_agents = {}
+
+    def _save(self) -> None:
+        """Persist registry data to cache."""
+        data = {"local": self.local_agents, "remote": self.remote_agents}
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self.cache_path.write_text(json.dumps(data, indent=2))
+
+    # ------------------------------------------------------------------
+    # Registry operations
+    # ------------------------------------------------------------------
+    def register(self, name: str, endpoint: str, *, local: bool = True) -> AgentLocation:
+        """Register a new agent.
+
+        Parameters
+        ----------
+        name:
+            Agent identifier.
+        endpoint:
+            Network endpoint for the agent.
+        local:
+            If ``True`` store in the local registry, otherwise remote.
+        """
+
+        registry = self.local_agents if local else self.remote_agents
+        registry[name] = endpoint
+        self._save()
+        return AgentLocation(name=name, endpoint=endpoint, local=local)
+
+    def resolve(self, name: str) -> Optional[AgentLocation]:
+        """Resolve an agent by name."""
+        if name in self.local_agents:
+            return AgentLocation(name, self.local_agents[name], True)
+        if name in self.remote_agents:
+            return AgentLocation(name, self.remote_agents[name], False)
+        return None
+
+    def list(self) -> List[AgentLocation]:
+        """List all registered agents."""
+        agents: List[AgentLocation] = []
+        for n, e in self.local_agents.items():
+            agents.append(AgentLocation(n, e, True))
+        for n, e in self.remote_agents.items():
+            agents.append(AgentLocation(n, e, False))
+        return agents

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path("src/production/distributed_agents/agent_registry.py")
+spec = importlib.util.spec_from_file_location("agent_registry", MODULE_PATH)
+agent_registry = importlib.util.module_from_spec(spec)
+sys.modules["agent_registry"] = agent_registry
+spec.loader.exec_module(agent_registry)  # type: ignore
+
+AgentLocation = agent_registry.AgentLocation
+DistributedAgentRegistry = agent_registry.DistributedAgentRegistry
+
+
+def test_agent_registry_persistence(tmp_path: Path) -> None:
+    cache_file = tmp_path / "agents.json"
+    registry = DistributedAgentRegistry(cache_path=cache_file)
+
+    registry.register("alpha", "local-endpoint", local=True)
+    registry.register("beta", "remote-endpoint", local=False)
+
+    assert registry.resolve("alpha") == AgentLocation("alpha", "local-endpoint", True)
+    assert registry.resolve("beta") == AgentLocation("beta", "remote-endpoint", False)
+    assert {a.name for a in registry.list()} == {"alpha", "beta"}
+
+    registry2 = DistributedAgentRegistry(cache_path=cache_file)
+    assert registry2.resolve("beta") == AgentLocation("beta", "remote-endpoint", False)
+    assert len(registry2.list()) == 2


### PR DESCRIPTION
## Summary
- add `AgentLocation` dataclass and `DistributedAgentRegistry` for tracking local and remote agents with JSON persistence
- exercise registry behaviour with a basic persistence unit test

## Testing
- `python src/communications/test_credits_standalone.py -q || true`
- `pytest -q tmp_codex_audit_v3/tests/test_p2p_reliability.py -q`
- `PYTHONPATH=/workspace/AIVillage/src:/workspace/AIVillage pytest -q tmp_codex_audit_v3/tests/test_agent_forge_smoke.py -q`
- `RAG_LOCAL_MODE=1 PYTHONPATH=.:src pytest -q tmp_codex_audit_v3/tests/test_rag_defaults.py -q` *(fails: file or directory not found)*
- `pytest -q tmp_codex_audit_v3/tests/test_no_http_in_prod.py tmp_codex_audit_v3/tests/test_no_pickle_loads.py -q` *(fails: file or directory not found)*
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_mobile_policy.py -q`
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_tokenomics_db_lock.py -q` *(fails: file or directory not found)*
- `PYTHONPATH=. pytest -q --maxfail=1 --disable-warnings --cov=src --cov-report=term-missing` *(fails: ModuleNotFoundError: No module named 'src.android.p2p')*
- `pytest tests/test_agent_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e90212e78832cbcbb6af6b2c253cc