### PR TITLE
Add benchmark evaluation utilities and docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -234,6 +234,20 @@ python stress_tests/production_simulation.py --devices 100 --duration 60 --failu
 
 Both utilities emit JSON reports for reproducible performance analysis.
 
+## Math Benchmark Evaluation
+
+Download benchmark datasets and evaluate prediction files:
+
+```bash
+# Download selected benchmarks
+python scripts/download_benchmarks.py --benchmarks gsm8k math
+
+# Evaluate predictions on a benchmark
+python benchmarks/evaluate_model.py --model-path predictions.json --benchmarks gsm8k
+```
+
+Use `--benchmarks` to choose which datasets to download or evaluate.
+
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:


### PR DESCRIPTION
## Summary
- implement GSM8K, MATH, and MathQA evaluation helpers
- allow selecting benchmarks via `--benchmarks` flag
- document how to download and evaluate math benchmarks

## Implementation Notes
- evaluation functions expect prediction files and compute simple accuracy metrics
- evaluation script is generated when downloading benchmarks

## Tradeoffs
- full model inference is not implemented; metrics assume precomputed predictions

## Tests Added
- none

## Local run logs (lint/type/tests)
- `ruff check .` *(fails: numerous existing style issues)*
- `ruff format --check .` *(fails: parsing errors in unrelated files)*
- `mypy .` *(fails: unterminated string in archive script)*
- `pytest -q` *(fails: ModuleNotFoundError for distributed agent registry)*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: file not found)*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: ImportError for AdamW)*

------
https://chatgpt.com/codex/tasks/task_e_689e910ba624832c88a0683571a48bac