### PR TITLE
Compress lessons and verify integrity

### DIFF
--- a/AIVillageEducation/package.json
+++ b/AIVillageEducation/package.json
@@ -13,7 +13,8 @@
     "react": "^18.2.0",
     "react-native": "^0.73.0",
     "@react-native-async-storage/async-storage": "^1.23.1",
-    "react-native-sqlite-storage": "^6.1.2"
+    "react-native-sqlite-storage": "^6.1.2",
+    "pako": "^2.1.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0"


### PR DESCRIPTION
## Summary
- Use pako to compress lessons before sending
- Add SHA-256 checksums with Node crypto
- Bundle compressed data and checksum together when sharing lessons

## Testing
- `cd AIVillageEducation && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e91206184832c987f83192441940d