### PR TITLE
feat: implement LibP2P bridge for React Native

### DIFF
--- a/AIVillageEducation/src/native/LibP2PBridge.java
+++ b/AIVillageEducation/src/native/LibP2PBridge.java
@@ -3,15 +3,27 @@ package com.aivillageeducation;
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import ai.atlantis.aivillage.mesh.LibP2PJNIBridge;
 
 public class LibP2PBridge extends ReactContextBaseJavaModule {
+    private final ReactApplicationContext reactContext;
+    private final LibP2PJNIBridge nativeBridge = new LibP2PJNIBridge();
+    private Callback peerFoundCallback;
+
     public LibP2PBridge(ReactApplicationContext context) {
         super(context);
+        this.reactContext = context;
     }
 
     @NonNull
@@ -22,18 +34,64 @@ public class LibP2PBridge extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void initialize(WritableMap config, Promise promise) {
-        // TODO: integrate LibP2P
-        promise.resolve(null);
+        try {
+            String configJson = mapToJson(config);
+            boolean ok = nativeBridge.initialize(configJson);
+            if (ok) {
+                nativeBridge.registerHandler(this::handleNativeMessage);
+                promise.resolve(null);
+            } else {
+                promise.reject("INIT_FAILED", "Failed to initialize LibP2P node");
+            }
+        } catch (Exception e) {
+            promise.reject("INIT_ERROR", e);
+        }
     }
 
     @ReactMethod
-    public void onPeerFound(String peerId) {
-        // Placeholder callback registration
+    public void onPeerFound(Callback callback) {
+        this.peerFoundCallback = callback;
+    }
+
+    private void handleNativeMessage(String messageJson) {
+        try {
+            JSONObject obj = new JSONObject(messageJson);
+            if ("peerFound".equals(obj.optString("type"))) {
+                WritableMap peer = Arguments.createMap();
+                peer.putString("id", obj.getString("peerId"));
+                if (peerFoundCallback != null) {
+                    peerFoundCallback.invoke(peer);
+                }
+                sendEvent("peerFound", peer);
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void sendEvent(String eventName, WritableMap params) {
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+            .emit(eventName, params);
     }
 
     @ReactMethod
     public void sendMessage(String peerId, WritableMap message, Promise promise) {
-        // TODO: send message via mesh
-        promise.resolve(null);
+        try {
+            JSONObject obj = new JSONObject();
+            obj.put("peerId", peerId);
+            obj.put("message", new JSONObject(message.toHashMap()));
+            boolean ok = nativeBridge.sendMessage(obj.toString());
+            if (ok) {
+                promise.resolve(null);
+            } else {
+                promise.reject("SEND_FAILED", "Failed to send message");
+            }
+        } catch (JSONException e) {
+            promise.reject("SEND_ERROR", e);
+        }
+    }
+
+    private String mapToJson(WritableMap map) throws JSONException {
+        return new JSONObject(map.toHashMap()).toString();
     }
 }


### PR DESCRIPTION
## Summary
- start LibP2P node via JNI bridge and register native callbacks
- emit `peerFound` events to JS and allow callback registration
- send serialized messages through LibP2P mesh with error handling

## Testing
- `pre-commit run --files AIVillageEducation/src/native/LibP2PBridge.java`
- `pytest tests/integration/test_libp2p_bridge.py` *(fails: OSError: [Errno 98] error while attempting to bind on address ('0.0.0.0', 4001): address already in use)*

------
https://chatgpt.com/codex/tasks/task_e_689e9121e0b4832c80783fbf4520bbed