### PR TITLE
feat: add simple distributed agent registry

### DIFF
--- a/src/production/distributed_agents/agent_registry.py
+++ b/src/production/distributed_agents/agent_registry.py
@@ -1,21 +1,119 @@
+from __future__ import annotations
+
+import json
 from dataclasses import dataclass
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Dict, List, Optional
+
+__all__ = ["AgentLocation", "DistributedAgentRegistry"]
+
+
+REGISTRY_PATH = Path(".cache/agent_registry.json")
 
 
 @dataclass
 class AgentLocation:
+    """Represents where an agent can be reached."""
+
     agent_id: str
-    url: str
+    endpoint: str
+    location: str = "local"
+
+    @property
+    def url(self) -> str:  # Backwards compatibility with older imports
+        return self.endpoint
 
 
 class DistributedAgentRegistry:
-    """In-memory registry for distributed agents."""
+    """Simple file-backed registry for distributed agents.
 
-    def __init__(self) -> None:
-        self._agents: Dict[str, AgentLocation] = {}
+    Agents can be registered as either ``local`` or ``remote``. The registry is
+    persisted on disk in :mod:`.cache/agent_registry.json` so that subsequent
+    runs can resolve previously registered agents.
+    """
 
-    def register(self, agent_id: str, url: str) -> None:
-        self._agents[agent_id] = AgentLocation(agent_id, url)
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = Path(path) if path else REGISTRY_PATH
+        # mapping of {"local": {name: endpoint}, "remote": {...}}
+        self._agents: Dict[str, Dict[str, str]] = {"local": {}, "remote": {}}
+        self._load()
 
-    def lookup(self, agent_id: str) -> Optional[AgentLocation]:
-        return self._agents.get(agent_id)
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            data = json.loads(self.path.read_text())
+        except Exception:
+            return
+        for location in ("local", "remote"):
+            section = data.get(location, {}) if isinstance(data, dict) else {}
+            if isinstance(section, dict):
+                self._agents[location].update(
+                    {str(name): str(endpoint) for name, endpoint in section.items()}
+                )
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self._agents))
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def register(self, name: str, endpoint: str, location: str = "local") -> None:
+        """Register an agent endpoint under ``name``.
+
+        Parameters
+        ----------
+        name:
+            Identifier for the agent.
+        endpoint:
+            Connection information for reaching the agent.
+        location:
+            Either ``"local"`` or ``"remote"``. Defaults to ``"local"``.
+        """
+
+        loc = "remote" if location == "remote" else "local"
+        self._agents[loc][name] = endpoint
+        self._save()
+
+    def resolve(self, name: str) -> Optional[AgentLocation]:
+        """Resolve an agent by name.
+
+        Returns ``None`` if the agent is unknown."""
+
+        for loc in ("local", "remote"):
+            endpoint = self._agents[loc].get(name)
+            if endpoint is not None:
+                return AgentLocation(name, endpoint, loc)
+        return None
+
+    # Backwards compatibility with older code
+    def lookup(self, name: str) -> Optional[AgentLocation]:
+        return self.resolve(name)
+
+    def list(self, location: str | None = None) -> List[AgentLocation]:
+        """List registered agents.
+
+        Parameters
+        ----------
+        location:
+            Optional filter of ``"local"`` or ``"remote"``. If omitted all
+            agents are returned.
+        """
+
+        if location:
+            loc = "remote" if location == "remote" else "local"
+            return [
+                AgentLocation(name, ep, loc)
+                for name, ep in self._agents.get(loc, {}).items()
+            ]
+        agents: List[AgentLocation] = []
+        for loc in ("local", "remote"):
+            agents.extend(
+                AgentLocation(name, ep, loc)
+                for name, ep in self._agents[loc].items()
+            )
+        return agents

--- a/tests/distributed_agents/test_agent_registry_persistence.py
+++ b/tests/distributed_agents/test_agent_registry_persistence.py
@@ -1,0 +1,22 @@
+import os
+
+from src.production.distributed_agents.agent_registry import DistributedAgentRegistry
+
+
+def test_register_and_persist(tmp_path, monkeypatch):
+    # Use a temporary working directory so we don't affect real cache
+    monkeypatch.chdir(tmp_path)
+
+    registry = DistributedAgentRegistry()
+    registry.register("alpha", "ipc://alpha")
+    registry.register("beta", "tcp://beta", location="remote")
+
+    # New instance should load persisted data
+    registry2 = DistributedAgentRegistry()
+    alpha = registry2.resolve("alpha")
+    beta = registry2.resolve("beta")
+
+    assert alpha is not None and alpha.endpoint == "ipc://alpha"
+    assert alpha.location == "local"
+    assert beta is not None and beta.location == "remote"
+    assert sorted([a.agent_id for a in registry2.list()]) == ["alpha", "beta"]


### PR DESCRIPTION
## Summary
- add file-backed agent registry supporting local and remote entries
- persist registry to `.cache/agent_registry.json`
- cover basic register/resolve/list behavior with unit test

## Testing
- `python src/communications/test_credits_standalone.py -q || true`
- `pytest -q tmp_codex_audit_v3/tests/test_p2p_reliability.py`
- `PYTHONPATH=/workspace/AIVillage/src:/workspace/AIVillage pytest -q tmp_codex_audit_v3/tests/test_agent_forge_smoke.py -q` *(fails: Error importing huggingface_hub.hf_api: cannot import name 'HTTPError')*
- `RAG_LOCAL_MODE=1 PYTHONPATH=.:src pytest -q tmp_codex_audit_v3/tests/test_rag_defaults.py -q`
- `pytest -q tmp_codex_audit_v3/tests/test_no_http_in_prod.py tmp_codex_audit_v3/tests/test_no_pickle_loads.py -q` *(fails: file or directory not found)*
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_mobile_policy.py -q`
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_tokenomics_db_lock.py -q` *(fails: file or directory not found)*
- `PYTHONPATH=. pytest -q --maxfail=1 --disable-warnings --cov=src --cov-report=term-missing` *(fails: ModuleNotFoundError: No module named 'agents.king.planning')*
- `pytest -q tests/distributed_agents/test_agent_registry_persistence.py`


------
https://chatgpt.com/codex/tasks/task_e_689e9abf4188832c873cf73c60a5cf1b