### PR TITLE
Add stub lister and replace pass stubs

### DIFF
--- a/src/communications/standard_protocol.py
+++ b/src/communications/standard_protocol.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+import logging
 
 
 class StandardCommunicationProtocol:
@@ -28,9 +29,10 @@ class StandardCommunicationProtocol:
             handler = self._subscribers[receiver]
             try:
                 await handler(message)
-            except Exception:
-                # Ignore handler errors in test protocol
-                pass
+            except Exception as exc:  # pragma: no cover - test helper
+                logging.getLogger(__name__).exception(
+                    "Handler error for %s: %s", receiver, exc
+                )
 
         # Also queue for manual retrieval
         if receiver:

--- a/src/core/security/secure_serializer.py
+++ b/src/core/security/secure_serializer.py
@@ -47,13 +47,9 @@ logger = logging.getLogger(__name__)
 class SerializationError(Exception):
     """Raised when serialization/deserialization fails."""
 
-    pass
-
 
 class SecurityViolationError(Exception):
     """Raised when security validation fails."""
-
-    pass
 
 
 class SerializationType(Enum):

--- a/src/production/monitoring/mobile/device_profiler.py
+++ b/src/production/monitoring/mobile/device_profiler.py
@@ -407,8 +407,8 @@ class DeviceProfile:
                 )
                 if "nvidia" in result.stdout.lower() or "amd" in result.stdout.lower():
                     self.supports_gpu = True
-        except:
-            pass
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.debug("GPU detection failed: %s", exc)
 
     def start_monitoring(self, interval: float = 5.0) -> None:
         """Start real-time resource monitoring."""
@@ -637,8 +637,8 @@ class DeviceProfile:
                 # ARM/Mobile CPUs
                 for entry in temps["cpu_thermal"]:
                     return entry.current
-        except Exception:  # pragma: no cover
-            pass
+        except Exception as exc:  # pragma: no cover
+            logger.debug("CPU temperature unavailable: %s", exc)
         return None
 
     def update_profile(self, snapshot: ResourceSnapshot) -> None:
@@ -745,8 +745,8 @@ class DeviceProfiler:
             try:
                 identifiers.append(Build.SERIAL)
                 identifiers.append(Build.MODEL)
-            except:
-                pass
+            except Exception as exc:  # pragma: no cover - platform optional
+                logger.debug("Android identifiers unavailable: %s", exc)
         elif MACOS_AVAILABLE:
             try:
                 # Use system profiler for Mac hardware UUID
@@ -761,8 +761,8 @@ class DeviceProfiler:
                     if "Hardware UUID" in line:
                         identifiers.append(line.split(":")[1].strip())
                         break
-            except:
-                pass
+            except Exception as exc:  # pragma: no cover - platform optional
+                logger.debug("Mac hardware UUID unavailable: %s", exc)
 
         # Create hash from identifiers
         combined = "".join(str(i) for i in identifiers if i)

--- a/src/production/monitoring/mobile/resource_allocator.py
+++ b/src/production/monitoring/mobile/resource_allocator.py
@@ -412,9 +412,9 @@ class ResourceAllocator:
             memory_bytes = allocation.memory_limit_mb * 1024 * 1024
             try:
                 sys_resource.setrlimit(sys_resource.RLIMIT_AS, (memory_bytes, -1))
-            except:
+            except Exception as exc:
                 # macOS may not support RLIMIT_AS
-                pass
+                logger.debug("RLIMIT_AS not supported: %s", exc)
 
             return True
         except Exception as e:

--- a/src/production/rag/rag_system/core/interface.py
+++ b/src/production/rag/rag_system/core/interface.py
@@ -7,7 +7,7 @@ from typing import Any
 class Retriever(ABC):
     @abstractmethod
     async def retrieve(self, query: str, k: int) -> list[dict[str, Any]]:
-        pass
+        raise NotImplementedError("Retriever.retrieve must be implemented")
 
 
 class KnowledgeConstructor(ABC):
@@ -15,16 +15,16 @@ class KnowledgeConstructor(ABC):
     async def construct(
         self, query: str, retrieved_docs: list[dict[str, Any]]
     ) -> dict[str, Any]:
-        pass
+        raise NotImplementedError("KnowledgeConstructor.construct must be implemented")
 
 
 class ReasoningEngine(ABC):
     @abstractmethod
     async def reason(self, query: str, constructed_knowledge: dict[str, Any]) -> str:
-        pass
+        raise NotImplementedError("ReasoningEngine.reason must be implemented")
 
 
 class EmbeddingModel(ABC):
     @abstractmethod
     async def get_embedding(self, text: str) -> list[float]:
-        pass
+        raise NotImplementedError("EmbeddingModel.get_embedding must be implemented")

--- a/tools/list_stubs.py
+++ b/tools/list_stubs.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""List common stub patterns in the repository."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+from typing import Iterable
+
+PATTERNS: dict[str, re.Pattern[str]] = {
+    "def-pass": re.compile(r"^\s*def .+:\s*pass\s*$"),
+    "class-pass": re.compile(r"^\s*class .+:\s*pass\s*$"),
+    "not-implemented": re.compile(r"raise NotImplementedError"),
+    "todo": re.compile(r"#\s*TODO", re.IGNORECASE),
+    "return-none-todo": re.compile(r"return None\s*#\s*TODO", re.IGNORECASE),
+}
+
+
+def iter_python_files(root: pathlib.Path) -> Iterable[pathlib.Path]:
+    for path in root.rglob("*.py"):
+        yield path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", default=".", help="root directory")
+    args = parser.parse_args()
+    root = pathlib.Path(args.path)
+
+    total = 0
+    for file in iter_python_files(root):
+        try:
+            lines = file.read_text().splitlines()
+        except Exception:  # pragma: no cover - unreadable file
+            continue
+        for lineno, line in enumerate(lines, 1):
+            for name, pattern in PATTERNS.items():
+                if pattern.search(line):
+                    print(f"{file}:{lineno}:{line.strip()}")
+                    total += 1
+    print(f"Total matches: {total}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- add tools/list_stubs.py to report common stub patterns
- replace `pass` stubs in RAG interface definitions with explicit `NotImplementedError`
- harden communication protocol and device profilers with logging and optional GPU detection

## Testing
- `python src/communications/test_credits_standalone.py -q || true`
- `pytest -q tmp_codex_audit_v3/tests/test_p2p_reliability.py -q` *(no tests found)*
- `PYTHONPATH=/workspace/AIVillage/src:/workspace/AIVillage pytest -q tmp_codex_audit_v3/tests/test_agent_forge_smoke.py -q` *(import error: urllib3)*
- `RAG_LOCAL_MODE=1 PYTHONPATH=.:src pytest -q tmp_codex_audit_v3/tests/test_rag_defaults.py -q`
- `pytest -q tmp_codex_audit_v3/tests/test_no_http_in_prod.py tmp_codex_audit_v3/tests/test_no_pickle_loads.py -q` *(files not found)*
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_mobile_policy.py -q`
- `PYTHONPATH=. pytest -q tmp_codex_audit_v3/tests/test_tokenomics_db_lock.py -q` *(file not found)*
- `PYTHONPATH=. pytest -q --maxfail=1 --disable-warnings --cov=src --cov-report=term-missing` *(missing package agents.king.planning)*
- `python tools/list_stubs.py`

------
https://chatgpt.com/codex/tasks/task_e_689e9afaa2b0832c8dc5193d50d99f5e