### PR TITLE
Capture JA3/JA4 during HTX calibration

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 pytest-asyncio
+scapy

--- a/tests/htx/test_calibrate_origin.py
+++ b/tests/htx/test_calibrate_origin.py
@@ -1,0 +1,24 @@
+import importlib.util
+import pathlib
+import pytest
+
+# Import HTXTransport directly to avoid heavy package initialization
+spec = importlib.util.spec_from_file_location(
+    "betanet_htx_transport",
+    pathlib.Path(__file__).resolve().parents[2]
+    / "src/core/p2p/betanet_htx_transport.py",
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+HTXTransport = mod.HTXTransport
+
+
+@pytest.mark.asyncio
+async def test_calibrate_origin_example_com():
+    transport = HTXTransport()
+    calibration = await transport.calibrate_origin("example.com")
+    assert calibration.origin_host == "example.com"
+    assert len(calibration.ja3_fingerprint) == 32
+    assert len(calibration.ja4_fingerprint) == 16
+    assert calibration.cipher_suites
+    assert calibration.extensions_order


### PR DESCRIPTION
## Summary
- derive JA3/JA4 fingerprints by performing a raw TLS ClientHello via scapy
- store calculated fingerprint data instead of hard-coded strings
- add integration test exercising calibration against example.com

## Testing
- `pytest tests/htx/test_calibrate_origin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0d01eaa4832c85e4955d98403baf