### PR TITLE
feat: extend loss computation

### DIFF
--- a/tests/agent_forge/test_forge_train_loss.py
+++ b/tests/agent_forge/test_forge_train_loss.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+import torch
+
+from src.agent_forge.training.forge_train import ForgeTrainConfig, ForgeTrainer
+
+
+def test_regression_loss():
+    config = ForgeTrainConfig(task_type="regression")
+    trainer = SimpleNamespace(config=config)
+    outputs = torch.tensor([[0.5]])
+    batch = {"labels": torch.tensor([[1.0]])}
+    loss = ForgeTrainer.compute_task_loss(trainer, outputs, batch)
+    assert torch.allclose(loss, torch.tensor(0.25))
+
+
+def test_custom_loss_fn():
+    def l1_loss(outputs, batch):
+        return torch.nn.functional.l1_loss(outputs, batch["labels"])
+
+    config = ForgeTrainConfig(task_type="regression", custom_loss_fn=l1_loss)
+    trainer = SimpleNamespace(config=config)
+    outputs = torch.tensor([[0.5]])
+    batch = {"labels": torch.tensor([[1.0]])}
+    loss = ForgeTrainer.compute_task_loss(trainer, outputs, batch)
+    assert torch.allclose(loss, torch.tensor(0.5))


### PR DESCRIPTION
## Summary
- support regression and seq2seq losses and custom loss functions via configuration
- add regression loss tests and custom loss override test

## Testing
- `pre-commit run --files src/agent_forge/training/forge_train.py tests/agent_forge/test_forge_train_loss.py`
- `pytest tests/agent_forge/test_forge_train_loss.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0d067440832caf9dea55818aabcf