### PR TITLE
Improve health scoring with runtime diagnostics

### DIFF
--- a/tests/test_system_health_scoring.py
+++ b/tests/test_system_health_scoring.py
@@ -1,0 +1,32 @@
+import textwrap
+from pathlib import Path
+
+from monitoring.system_health_dashboard import ComponentHealthChecker
+
+
+def test_legitimate_scores_higher_than_stub(tmp_path: Path) -> None:
+    real_code = textwrap.dedent(
+        """
+        def add(a, b):
+            return a + b
+        """
+    )
+    stub_code = textwrap.dedent(
+        """
+        def add(a, b):
+            return None
+        """
+    )
+
+    real_file = tmp_path / "real.py"
+    stub_file = tmp_path / "stub.py"
+    real_file.write_text(real_code)
+    stub_file.write_text(stub_code)
+
+    checker = ComponentHealthChecker(project_root=tmp_path)
+    checker._get_runtime_metrics = lambda: {"ping_success": 1.0, "error_rate": 0.0}  # type: ignore
+
+    real_score = checker.check_component_health(real_file, "real")["implementation_score"]
+    stub_score = checker.check_component_health(stub_file, "stub")["implementation_score"]
+
+    assert real_score > stub_score


### PR DESCRIPTION
## Summary
- derive implementation score penalties from runtime diagnostics instead of placeholder negative patterns
- detect stub returns via AST analysis for more accurate stub reporting
- add regression test ensuring real implementations score higher than stubs

## Testing
- `pytest tests/test_system_health_scoring.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0d090168832c8d6f25bf2b9f6d78