### PR TITLE
Handle correlated AI service responses in federation manager

### DIFF
--- a/tests/test_federation_comprehensive.py
+++ b/tests/test_federation_comprehensive.py
@@ -1038,18 +1038,23 @@ class TestEndToEndIntegration:
                 manager, "_select_optimal_service_node", return_value="edge_node_1"
             ):
                 with patch.object(manager, "send_federated_message", return_value=True):
-                    # Request translation service
-                    result = await manager.request_ai_service(
-                        service_name="translate",
-                        request_data={
-                            "text": "Hello",
-                            "source_lang": "en",
-                            "target_lang": "es",
-                        },
-                        privacy_level=PrivacyLevel.PRIVATE,
-                    )
+                    with patch.object(
+                        manager,
+                        "_wait_for_correlated_response",
+                        AsyncMock(return_value={"result": "ok"}),
+                    ):
+                        # Request translation service
+                        result = await manager.request_ai_service(
+                            service_name="translate",
+                            request_data={
+                                "text": "Hello",
+                                "source_lang": "en",
+                                "target_lang": "es",
+                            },
+                            privacy_level=PrivacyLevel.PRIVATE,
+                        )
 
-                    assert result is not None
+                        assert result is not None
 
     @pytest.mark.asyncio
     async def test_offline_mesh_communication(self):

--- a/tests/test_federation_integration.py
+++ b/tests/test_federation_integration.py
@@ -413,14 +413,19 @@ class TestFederationManager:
                 manager, "_select_optimal_service_node", return_value="edge_node_1"
             ):
                 with patch.object(manager, "send_federated_message", return_value=True):
-                    result = await manager.request_ai_service(
-                        service_name="translate",
-                        request_data={"text": "Hello", "target_lang": "es"},
-                        privacy_level=PrivacyLevel.PRIVATE,
-                    )
+                    with patch.object(
+                        manager,
+                        "_wait_for_correlated_response",
+                        AsyncMock(return_value={"result": "ok"}),
+                    ):
+                        result = await manager.request_ai_service(
+                            service_name="translate",
+                            request_data={"text": "Hello", "target_lang": "es"},
+                            privacy_level=PrivacyLevel.PRIVATE,
+                        )
 
-                    # Should return some result (even if mocked)
-                    assert result is not None
+                        # Should return some result (even if mocked)
+                        assert result is not None
 
     @pytest.mark.asyncio
     async def test_privacy_tunnel_creation(self):


### PR DESCRIPTION
## Summary
- Track pending AI service responses and wait for correlated `ai_service_response` messages
- Use generated `request_id` when sending service requests and return actual response payloads
- Add tests mocking response correlation behavior

## Testing
- `pytest tests/test_federation_integration.py::TestFederationManager::test_ai_service_request_routing -q`
- `pytest tests/test_federation_comprehensive.py::TestEndToEndIntegration::test_complete_ai_service_request_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_689f19308210832c93b6c91fd0fd6066