### PR TITLE
Add onion routing and Tor/I2P path support

### DIFF
--- a/src/federation/core/federation_manager.py
+++ b/src/federation/core/federation_manager.py
@@ -6,8 +6,10 @@ privacy features.
 """
 
 import asyncio
+import base64
 import json
 import logging
+import secrets
 import time
 import uuid
 from typing import Any
@@ -76,7 +78,9 @@ class FederationManager:
 
         # VPN-like privacy tunnels
         self.active_tunnels: dict[str, dict[str, Any]] = {}
-        self.privacy_circuits: dict[str, list[str]] = {}  # destination -> path
+        self.privacy_circuits: dict[
+            str, list[dict[str, str]]
+        ] = {}  # destination -> path
 
         # Beacon coordination (for beacon nodes)
         self.coordinated_devices: set[str] = set()
@@ -621,8 +625,8 @@ class FederationManager:
 
     async def _build_privacy_circuit(
         self, destination: str, min_hops: int = 3
-    ) -> list[str] | None:
-        """Build privacy circuit through relay nodes"""
+    ) -> list[dict[str, str]] | None:
+        """Build privacy circuit through relay nodes with per-hop keys"""
         relay_nodes = self.device_registry.get_devices_by_role(DeviceRole.RELAY)
 
         if len(relay_nodes) < min_hops - 1:
@@ -631,19 +635,37 @@ class FederationManager:
             )
             return None
 
-        # Select random relay nodes for circuit
         import random
 
         selected_relays = random.sample(
-            [r.identity.device_id for r in relay_nodes],
-            min(min_hops - 1, len(relay_nodes)),
+            relay_nodes, min(min_hops - 1, len(relay_nodes))
         )
 
-        # Circuit: source -> relays -> destination
-        circuit = selected_relays + [destination]
+        available_protocols = self._get_available_protocols()
+        circuit: list[dict[str, str]] = []
+
+        for relay in selected_relays:
+            circuit.append(
+                {
+                    "node": relay.identity.device_id,
+                    "key": secrets.token_hex(16),
+                    "protocol": random.choice(available_protocols),
+                }
+            )
+
+        circuit.append(
+            {
+                "node": destination,
+                "key": secrets.token_hex(16),
+                "protocol": random.choice(available_protocols),
+            }
+        )
+
         return circuit
 
-    async def _build_paranoid_circuit(self, destination: str) -> list[str] | None:
+    async def _build_paranoid_circuit(
+        self, destination: str
+    ) -> list[dict[str, str]] | None:
         """Build multi-protocol paranoid circuit"""
         # For PARANOID level, chain different protocols
         # This would involve Tor -> Betanet -> I2P routing
@@ -651,8 +673,7 @@ class FederationManager:
         return await self._build_privacy_circuit(destination, min_hops=5)
 
     async def _send_via_privacy_circuit(self, destination: str, message: dict) -> bool:
-        """Send message through privacy circuit"""
-        # Create tunnel if needed
+        """Send message through privacy circuit using onion routing"""
         tunnel_id = await self.create_privacy_tunnel(
             destination, PrivacyLevel.ANONYMOUS
         )
@@ -663,11 +684,50 @@ class FederationManager:
         tunnel = self.active_tunnels[tunnel_id]
         circuit_path = tunnel["circuit_path"]
 
-        # For now, just send through regular dual-path (would implement onion routing)
+        # Build onion layers from destination backwards
+        onion_payload: Any = message
+        for hop in reversed(circuit_path):
+            key_bytes = bytes.fromhex(hop["key"])
+            raw = json.dumps(onion_payload).encode()
+            encrypted = bytes(
+                b ^ key_bytes[i % len(key_bytes)] for i, b in enumerate(raw)
+            )
+            onion_payload = {
+                "data": base64.b64encode(encrypted).decode(),
+            }
+
+        current_layer = onion_payload
+        for hop in circuit_path:
+            success = await self._send_via_protocol(
+                hop["node"], current_layer, hop.get("protocol", "bitchat")
+            )
+            if not success:
+                return False
+
+            key_bytes = bytes.fromhex(hop["key"])
+            encrypted = base64.b64decode(current_layer["data"])
+            decrypted = bytes(
+                b ^ key_bytes[i % len(key_bytes)] for i, b in enumerate(encrypted)
+            )
+            current_layer = json.loads(decrypted.decode())
+
+        return True
+
+    async def _send_via_protocol(
+        self, recipient: str, payload: Any, protocol: str
+    ) -> bool:
+        """Send payload via specified transport protocol"""
+        if protocol == "tor" and self.tor_transport:
+            return await self.tor_transport.send_message(recipient, payload)
+        if protocol == "i2p" and self.i2p_transport:
+            return await self.i2p_transport.send_message(recipient, payload)
+
+        preferred = protocol if protocol in {"bitchat", "betanet"} else None
         return await self.dual_path_transport.send_message(
-            recipient=circuit_path[0],  # First hop
-            payload=message,
+            recipient=recipient,
+            payload=payload,
             privacy_required=True,
+            preferred_protocol=preferred,
         )
 
     def _update_federation_stats(self):

--- a/tests/test_privacy_routing.py
+++ b/tests/test_privacy_routing.py
@@ -1,0 +1,76 @@
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from federation.core.federation_manager import (
+    FederationManager,
+    PrivacyLevel,
+)
+from federation.core.device_registry import DeviceRole
+
+
+@pytest.mark.asyncio
+async def test_build_privacy_circuit_generates_keys():
+    manager = FederationManager("test_node")
+
+    # create mock relay devices
+    mock_relays = []
+    for i in range(2):
+        relay = MagicMock()
+        relay.identity.device_id = f"relay_{i}"
+        relay.role = DeviceRole.RELAY
+        mock_relays.append(relay)
+
+    with patch.object(
+        manager.device_registry, "get_devices_by_role", return_value=mock_relays
+    ):
+        circuit = await manager._build_privacy_circuit("dest", min_hops=3)
+
+    assert circuit is not None
+    assert len(circuit) == 3
+    for hop in circuit:
+        assert set(hop.keys()) == {"node", "key", "protocol"}
+        assert hop["key"]
+
+
+@pytest.mark.asyncio
+async def test_send_federated_message_routes_by_protocol():
+    manager = FederationManager("test_node", enable_tor=True, enable_i2p=True)
+    manager.is_running = True
+
+    manager.dual_path_transport = MagicMock()
+    manager.dual_path_transport.send_message = AsyncMock(return_value=True)
+    manager.tor_transport = MagicMock()
+    manager.tor_transport.send_message = AsyncMock(return_value=True)
+    manager.i2p_transport = MagicMock()
+    manager.i2p_transport.send_message = AsyncMock(return_value=True)
+
+    tunnel_id = "t1"
+    manager.active_tunnels[tunnel_id] = {
+        "destination": "dest",
+        "circuit_path": [
+            {"node": "tor_hop", "key": "aa", "protocol": "tor"},
+            {"node": "i2p_hop", "key": "bb", "protocol": "i2p"},
+            {"node": "dest", "key": "cc", "protocol": "bitchat"},
+        ],
+        "privacy_level": PrivacyLevel.ANONYMOUS,
+        "created_at": time.time(),
+        "last_used": time.time(),
+    }
+
+    async def fake_create_privacy_tunnel(*args, **kwargs):
+        return tunnel_id
+
+    manager.create_privacy_tunnel = fake_create_privacy_tunnel
+
+    payload = {"hello": "world"}
+    success = await manager.send_federated_message(
+        "dest", payload, privacy_level=PrivacyLevel.ANONYMOUS
+    )
+
+    assert success
+    manager.tor_transport.send_message.assert_called_once()
+    manager.i2p_transport.send_message.assert_called_once()
+    manager.dual_path_transport.send_message.assert_called_once()


### PR DESCRIPTION
## Summary
- Generate per-hop keys and protocol hints when constructing privacy circuits
- Wrap federated messages in onion layers and forward according to hop protocol
- Add tests covering circuit key generation and Tor/I2P routing selection

## Implementation notes
- `_build_privacy_circuit` now returns hop descriptors with node id, random key, and chosen protocol
- `_send_via_privacy_circuit` builds nested encrypted layers and dispatches via `_send_via_protocol`
- `_send_via_protocol` selects between DualPath, Tor, or I2P transports

## Tradeoffs
- Encryption uses simple XOR for demonstration; not production-ready
- Protocol selection for relays is random rather than policy driven

## Tests added
- `tests/test_privacy_routing.py` verifies key generation and protocol routing

## Local run logs (lint/type/tests)
- `ruff check .` (errors in unrelated files)
- `ruff format --check .` (parse errors in unrelated files)
- `mypy .` (syntax error in unrelated file)
- `pytest -q`
- `pytest -q tests/p2p/test_dual_path.py -q` (file not found)
- `pytest -q tests/test_orchestrator_integration.py -q` (known failures)


------
https://chatgpt.com/codex/tasks/task_e_689f197b8660832c92a4f8978bace735