### PR TITLE
Register FL P2P handlers and add secure aggregation stub

### DIFF
--- a/src/production/federated_learning/secure_aggregation.py
+++ b/src/production/federated_learning/secure_aggregation.py
@@ -1,0 +1,44 @@
+"""Simplified secure aggregation utilities for federated learning."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import torch
+
+from src.production.communications.p2p.p2p_node import P2PNode
+
+
+@dataclass
+class PrivacyConfig:
+    """Privacy configuration for secure aggregation."""
+
+    threshold: int = 2
+    epsilon: float = 1.0
+    delta: float = 1e-5
+
+
+class SecureAggregationProtocol:
+    """Basic placeholder implementation of a secure aggregation protocol."""
+
+    def __init__(self, p2p_node: P2PNode, config: PrivacyConfig | None = None) -> None:
+        self.p2p_node = p2p_node
+        self.config = config or PrivacyConfig()
+        self.initialized = False
+
+    async def initialize(self) -> None:
+        """Initialize protocol resources."""
+        self.initialized = True
+
+    async def aggregate_gradients(
+        self, gradients: Iterable[dict[str, torch.Tensor]]
+    ) -> dict[str, torch.Tensor]:
+        """Aggregate gradients using simple averaging."""
+        gradients = list(gradients)
+        if not gradients:
+            return {}
+        aggregated: dict[str, torch.Tensor] = {}
+        for name in gradients[0]:
+            aggregated[name] = sum(g[name] for g in gradients) / len(gradients)
+        return aggregated


### PR DESCRIPTION
## Summary
- Hook federated learning message types into the P2P node and handle capability announcements and gradient exchange
- Provide a minimal `SecureAggregationProtocol` with basic configuration and averaging logic
- Skip secure aggregation gracefully when the module is missing

## Testing
- `pre-commit run --files src/production/federated_learning/federated_coordinator.py src/production/federated_learning/secure_aggregation.py` *(fails: ruff-format and black continually reformat this file)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f19808c48832ca799d5cf88a19b3d