### PR TITLE
Fix unified pipeline imports

### DIFF
--- a/src/agent_forge/unified_pipeline.py
+++ b/src/agent_forge/unified_pipeline.py
@@ -18,12 +18,18 @@ from pathlib import Path
 from typing import Any
 
 import click
-from compression_pipeline import CompressionConfig, CompressionPipeline
+from production.compression.compression_pipeline import (
+    CompressionConfig,
+    CompressionPipeline,
+)
 
 # Import pipeline components
-from evomerge_pipeline import EvolutionConfig, EvoMergePipeline
+from production.evolution.evomerge_pipeline import (
+    EvolutionConfig,
+    EvoMergePipeline,
+)
 from pydantic import BaseModel, Field
-from quietstar_baker import QuietSTaRBaker, QuietSTaRConfig
+from .quietstar_baker import QuietSTaRBaker, QuietSTaRConfig
 
 import wandb
 
@@ -245,7 +251,7 @@ class UnifiedPipeline:
         if self.config.evomerge_config:
             evomerge_config = EvolutionConfig(**self.config.evomerge_config)
         else:
-            from evomerge_pipeline import BaseModelConfig
+            from production.evolution.evomerge_pipeline import BaseModelConfig
 
             evomerge_config = EvolutionConfig(
                 base_models=[


### PR DESCRIPTION
## Summary
- use production package imports for compression and evolution modules
- switch quietstar baker import to package-relative
- adjust internal EvoMerge BaseModelConfig import

## Testing
- `WANDB_MODE=disabled python -m agent_forge.unified_pipeline run-pipeline --no-evomerge --no-quietstar --no-compression --generations 1 --output-dir ../tmp_unified_output --device cpu`
- `pytest tests/test_unified_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0973a1134832c97c02918c1e4d168