### PR TITLE
refactor: use model_post_init for unified pipeline

### DIFF
--- a/src/agent_forge/unified_pipeline.py
+++ b/src/agent_forge/unified_pipeline.py
@@ -11,9 +11,9 @@ ready for deployment.
 """
 
 import asyncio
+from datetime import datetime
 import json
 import logging
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -24,12 +24,9 @@ from compression_pipeline import CompressionConfig, CompressionPipeline
 from evomerge_pipeline import EvolutionConfig, EvoMergePipeline
 from pydantic import BaseModel, Field
 from quietstar_baker import QuietSTaRBaker, QuietSTaRConfig
-
 import wandb
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 # ============================================================================
@@ -42,9 +39,7 @@ class UnifiedPipelineConfig(BaseModel):
 
     # Pipeline control
     enable_evomerge: bool = Field(default=True, description="Run evolutionary merging")
-    enable_quietstar: bool = Field(
-        default=True, description="Run Quiet-STaR reasoning enhancement"
-    )
+    enable_quietstar: bool = Field(default=True, description="Run Quiet-STaR reasoning enhancement")
     enable_compression: bool = Field(default=True, description="Run BitNet compression")
 
     # Output configuration
@@ -81,13 +76,11 @@ class UnifiedPipelineConfig(BaseModel):
     wandb_tags: list[str] = Field(default_factory=lambda: ["unified", "end-to-end"])
 
     # Resume configuration
-    resume_from_phase: str | None = Field(
-        default=None, description="Resume from specific phase"
-    )
+    resume_from_phase: str | None = Field(default=None, description="Resume from specific phase")
     checkpoint_dir: Path = Field(default=Path("./unified_checkpoints"))
 
-    def __post_init__(self):
-        """Create output directories."""
+    def model_post_init(self, __context: Any) -> None:  # Pydantic v2 hook
+        """Create output directories after validation."""
         self.base_output_dir.mkdir(parents=True, exist_ok=True)
         self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
@@ -185,19 +178,13 @@ class UnifiedPipeline:
             self.initialize_wandb()
 
             # Phase 1: EvoMerge (if enabled)
-            if (
-                self.config.enable_evomerge
-                and "evomerge" not in self.state.completed_phases
-            ):
+            if self.config.enable_evomerge and "evomerge" not in self.state.completed_phases:
                 await self.run_evomerge_phase()
                 self.state.completed_phases.append("evomerge")
                 self.state.save_checkpoint(self.config.checkpoint_dir)
 
             # Phase 2: Quiet-STaR (if enabled)
-            if (
-                self.config.enable_quietstar
-                and "quietstar" not in self.state.completed_phases
-            ):
+            if self.config.enable_quietstar and "quietstar" not in self.state.completed_phases:
                 if not self.state.evomerge_model_path:
                     msg = "EvoMerge model path required for Quiet-STaR phase"
                     raise ValueError(msg)
@@ -207,13 +194,8 @@ class UnifiedPipeline:
                 self.state.save_checkpoint(self.config.checkpoint_dir)
 
             # Phase 3: Compression (if enabled)
-            if (
-                self.config.enable_compression
-                and "compression" not in self.state.completed_phases
-            ):
-                source_model = (
-                    self.state.quietstar_model_path or self.state.evomerge_model_path
-                )
+            if self.config.enable_compression and "compression" not in self.state.completed_phases:
+                source_model = self.state.quietstar_model_path or self.state.evomerge_model_path
                 if not source_model:
                     msg = "Source model path required for compression phase"
                     raise ValueError(msg)
@@ -245,19 +227,13 @@ class UnifiedPipeline:
         if self.config.evomerge_config:
             evomerge_config = EvolutionConfig(**self.config.evomerge_config)
         else:
-            from evomerge_pipeline import BaseModelConfig
+            from evomerge_pipeline import BaseModelConfig  # noqa: PLC0415
 
             evomerge_config = EvolutionConfig(
                 base_models=[
-                    BaseModelConfig(
-                        name="deepseek", path=self.config.evomerge_base_models[0]
-                    ),
-                    BaseModelConfig(
-                        name="nemotron", path=self.config.evomerge_base_models[1]
-                    ),
-                    BaseModelConfig(
-                        name="qwen2", path=self.config.evomerge_base_models[2]
-                    ),
+                    BaseModelConfig(name="deepseek", path=self.config.evomerge_base_models[0]),
+                    BaseModelConfig(name="nemotron", path=self.config.evomerge_base_models[1]),
+                    BaseModelConfig(name="qwen2", path=self.config.evomerge_base_models[2]),
                 ],
                 max_generations=self.config.evomerge_generations,
                 device=self.config.device,
@@ -284,18 +260,12 @@ class UnifiedPipeline:
                     {
                         "evomerge_best_fitness": best_candidate.overall_fitness,
                         "evomerge_generations": best_candidate.generation,
-                        "evomerge_code_score": best_candidate.fitness_scores.get(
-                            "code", 0
-                        ),
-                        "evomerge_math_score": best_candidate.fitness_scores.get(
-                            "math", 0
-                        ),
+                        "evomerge_code_score": best_candidate.fitness_scores.get("code", 0),
+                        "evomerge_math_score": best_candidate.fitness_scores.get("math", 0),
                     }
                 )
 
-            logger.info(
-                f"✅ EvoMerge completed - Best fitness: {best_candidate.overall_fitness:.3f}"
-            )
+            logger.info(f"✅ EvoMerge completed - Best fitness: {best_candidate.overall_fitness:.3f}")
         else:
             msg = "EvoMerge failed to produce a best candidate"
             raise RuntimeError(msg)
@@ -331,12 +301,8 @@ class UnifiedPipeline:
                 {
                     "quietstar_winner": results["winner"],
                     "quietstar_improvement": results["improvement"],
-                    "quietstar_baseline_accuracy": results["ab_test_results"][
-                        "baseline_accuracy"
-                    ],
-                    "quietstar_thoughts_accuracy": results["ab_test_results"][
-                        "thoughts_accuracy"
-                    ],
+                    "quietstar_baseline_accuracy": results["ab_test_results"]["baseline_accuracy"],
+                    "quietstar_thoughts_accuracy": results["ab_test_results"]["thoughts_accuracy"],
                 }
             )
 
@@ -379,9 +345,7 @@ class UnifiedPipeline:
                 }
             )
 
-        logger.info(
-            f"✅ Compression completed - Ratio: {results['compression_ratio']:.1f}x"
-        )
+        logger.info(f"✅ Compression completed - Ratio: {results['compression_ratio']:.1f}x")
 
     async def calculate_final_metrics(self) -> None:
         """Calculate final performance metrics."""
@@ -393,9 +357,7 @@ class UnifiedPipeline:
 
         # Apply EvoMerge improvement
         if self.state.evomerge_results:
-            evomerge_improvement = (
-                self.state.evomerge_results["best_fitness"] - base_performance
-            )
+            evomerge_improvement = self.state.evomerge_results["best_fitness"] - base_performance
             final_performance += evomerge_improvement
 
         # Apply Quiet-STaR improvement
@@ -403,9 +365,7 @@ class UnifiedPipeline:
             quietstar_improvement = self.state.quietstar_results["improvement"] / 100
             final_performance += quietstar_improvement
 
-        self.state.total_improvement = (
-            (final_performance - base_performance) / base_performance
-        ) * 100
+        self.state.total_improvement = ((final_performance - base_performance) / base_performance) * 100
 
         # Final performance breakdown
         self.state.final_performance = {
@@ -413,14 +373,10 @@ class UnifiedPipeline:
             "final_performance": final_performance,
             "total_improvement_percent": self.state.total_improvement,
             "evomerge_contribution": (
-                self.state.evomerge_results["best_fitness"]
-                if self.state.evomerge_results
-                else 0
+                self.state.evomerge_results["best_fitness"] if self.state.evomerge_results else 0
             ),
             "quietstar_contribution": (
-                self.state.quietstar_results["improvement"]
-                if self.state.quietstar_results
-                else 0
+                self.state.quietstar_results["improvement"] if self.state.quietstar_results else 0
             ),
             "compression_ratio": self.state.compression_ratio,
         }
@@ -452,19 +408,11 @@ class UnifiedPipeline:
             "performance_summary": {
                 "total_improvement": f"{self.state.total_improvement:.1f}%",
                 "compression_ratio": f"{self.state.compression_ratio:.1f}x",
-                "evomerge_fitness": (
-                    self.state.evomerge_results["best_fitness"]
-                    if self.state.evomerge_results
-                    else 0
-                ),
+                "evomerge_fitness": (self.state.evomerge_results["best_fitness"] if self.state.evomerge_results else 0),
                 "quietstar_improvement": (
-                    f"{self.state.quietstar_results['improvement']:.1f}%"
-                    if self.state.quietstar_results
-                    else "0%"
+                    f"{self.state.quietstar_results['improvement']:.1f}%" if self.state.quietstar_results else "0%"
                 ),
-                "final_model_size": (
-                    "Compressed" if self.state.compression_ratio > 1 else "Original"
-                ),
+                "final_model_size": ("Compressed" if self.state.compression_ratio > 1 else "Original"),
             },
             "phase_details": {
                 "evomerge": self.state.evomerge_results,
@@ -476,18 +424,13 @@ class UnifiedPipeline:
         }
 
         # Save report
-        report_path = (
-            self.config.base_output_dir
-            / f"unified_pipeline_report_{self.state.run_id}.json"
-        )
+        report_path = self.config.base_output_dir / f"unified_pipeline_report_{self.state.run_id}.json"
         with open(report_path, "w") as f:
             json.dump(report, f, indent=2, default=str)
 
         # Log to W&B as artifact
         if self.wandb_run:
-            artifact = wandb.Artifact(
-                f"unified_pipeline_report_{self.state.run_id}", type="report"
-            )
+            artifact = wandb.Artifact(f"unified_pipeline_report_{self.state.run_id}", type="report")
             artifact.add_file(str(report_path))
             self.wandb_run.log_artifact(artifact)
 
@@ -534,9 +477,7 @@ class UnifiedPipeline:
         print("\n🎯 NEXT STEPS:")
         if report["deployment_ready"]:
             print(f"  1. Load model from: {summary['final_model_path']}")
-            print(
-                f"  2. Deploy with {performance['compression_ratio']} memory efficiency"
-            )
+            print(f"  2. Deploy with {performance['compression_ratio']} memory efficiency")
             print(f"  3. Expect {performance['total_improvement']} better performance")
         else:
             print("  ❌ Pipeline incomplete - check logs for issues")
@@ -556,12 +497,8 @@ def forge() -> None:
 
 @forge.command()
 @click.option("--config", help="Configuration JSON file")
-@click.option(
-    "--evomerge/--no-evomerge", default=True, help="Enable/disable EvoMerge phase"
-)
-@click.option(
-    "--quietstar/--no-quietstar", default=True, help="Enable/disable Quiet-STaR phase"
-)
+@click.option("--evomerge/--no-evomerge", default=True, help="Enable/disable EvoMerge phase")
+@click.option("--quietstar/--no-quietstar", default=True, help="Enable/disable Quiet-STaR phase")
 @click.option(
     "--compression/--no-compression",
     default=True,
@@ -571,9 +508,7 @@ def forge() -> None:
 @click.option("--output-dir", default="./unified_output", help="Base output directory")
 @click.option("--device", default="auto", help="Device to use")
 @click.option("--resume", help="Resume from checkpoint file")
-def run_pipeline(
-    config, evomerge, quietstar, compression, generations, output_dir, device, resume
-) -> None:
+def run_pipeline(config, evomerge, quietstar, compression, generations, output_dir, device, resume) -> None:
     """Run complete Agent Forge pipeline: EvoMerge → Quiet-STaR → Compression."""
     try:
         # Load configuration
@@ -600,9 +535,7 @@ def run_pipeline(
         pipeline = UnifiedPipeline(pipeline_config)
 
         logger.info("🚀 Starting Agent Forge Unified Pipeline")
-        logger.info(
-            f"Phases enabled: EvoMerge={evomerge}, Quiet-STaR={quietstar}, Compression={compression}"
-        )
+        logger.info(f"Phases enabled: EvoMerge={evomerge}, Quiet-STaR={quietstar}, Compression={compression}")
 
         results = asyncio.run(pipeline.run_complete_pipeline())
 
@@ -611,7 +544,7 @@ def run_pipeline(
 
     except Exception as e:
         logger.exception(f"Unified pipeline failed: {e}")
-        raise click.ClickException(str(e))
+        raise click.ClickException(str(e)) from e
 
 
 if __name__ == "__main__":

--- a/src/software/agent_forge/legacy/unified_pipeline.py
+++ b/src/software/agent_forge/legacy/unified_pipeline.py
@@ -11,9 +11,9 @@ ready for deployment.
 """
 
 import asyncio
+from datetime import datetime
 import json
 import logging
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -24,12 +24,9 @@ from compression_pipeline import CompressionConfig, CompressionPipeline
 from evomerge_pipeline import EvolutionConfig, EvoMergePipeline
 from pydantic import BaseModel, Field
 from quietstar_baker import QuietSTaRBaker, QuietSTaRConfig
-
 import wandb
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 # ============================================================================
@@ -42,9 +39,7 @@ class UnifiedPipelineConfig(BaseModel):
 
     # Pipeline control
     enable_evomerge: bool = Field(default=True, description="Run evolutionary merging")
-    enable_quietstar: bool = Field(
-        default=True, description="Run Quiet-STaR reasoning enhancement"
-    )
+    enable_quietstar: bool = Field(default=True, description="Run Quiet-STaR reasoning enhancement")
     enable_compression: bool = Field(default=True, description="Run BitNet compression")
 
     # Output configuration
@@ -81,13 +76,11 @@ class UnifiedPipelineConfig(BaseModel):
     wandb_tags: list[str] = Field(default_factory=lambda: ["unified", "end-to-end"])
 
     # Resume configuration
-    resume_from_phase: str | None = Field(
-        default=None, description="Resume from specific phase"
-    )
+    resume_from_phase: str | None = Field(default=None, description="Resume from specific phase")
     checkpoint_dir: Path = Field(default=Path("./unified_checkpoints"))
 
-    def __post_init__(self):
-        """Create output directories."""
+    def model_post_init(self, __context: Any) -> None:  # Pydantic v2 hook
+        """Create output directories after validation."""
         self.base_output_dir.mkdir(parents=True, exist_ok=True)
         self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
@@ -185,19 +178,13 @@ class UnifiedPipeline:
             self.initialize_wandb()
 
             # Phase 1: EvoMerge (if enabled)
-            if (
-                self.config.enable_evomerge
-                and "evomerge" not in self.state.completed_phases
-            ):
+            if self.config.enable_evomerge and "evomerge" not in self.state.completed_phases:
                 await self.run_evomerge_phase()
                 self.state.completed_phases.append("evomerge")
                 self.state.save_checkpoint(self.config.checkpoint_dir)
 
             # Phase 2: Quiet-STaR (if enabled)
-            if (
-                self.config.enable_quietstar
-                and "quietstar" not in self.state.completed_phases
-            ):
+            if self.config.enable_quietstar and "quietstar" not in self.state.completed_phases:
                 if not self.state.evomerge_model_path:
                     msg = "EvoMerge model path required for Quiet-STaR phase"
                     raise ValueError(msg)
@@ -207,13 +194,8 @@ class UnifiedPipeline:
                 self.state.save_checkpoint(self.config.checkpoint_dir)
 
             # Phase 3: Compression (if enabled)
-            if (
-                self.config.enable_compression
-                and "compression" not in self.state.completed_phases
-            ):
-                source_model = (
-                    self.state.quietstar_model_path or self.state.evomerge_model_path
-                )
+            if self.config.enable_compression and "compression" not in self.state.completed_phases:
+                source_model = self.state.quietstar_model_path or self.state.evomerge_model_path
                 if not source_model:
                     msg = "Source model path required for compression phase"
                     raise ValueError(msg)
@@ -245,19 +227,13 @@ class UnifiedPipeline:
         if self.config.evomerge_config:
             evomerge_config = EvolutionConfig(**self.config.evomerge_config)
         else:
-            from evomerge_pipeline import BaseModelConfig
+            from evomerge_pipeline import BaseModelConfig  # noqa: PLC0415
 
             evomerge_config = EvolutionConfig(
                 base_models=[
-                    BaseModelConfig(
-                        name="deepseek", path=self.config.evomerge_base_models[0]
-                    ),
-                    BaseModelConfig(
-                        name="nemotron", path=self.config.evomerge_base_models[1]
-                    ),
-                    BaseModelConfig(
-                        name="qwen2", path=self.config.evomerge_base_models[2]
-                    ),
+                    BaseModelConfig(name="deepseek", path=self.config.evomerge_base_models[0]),
+                    BaseModelConfig(name="nemotron", path=self.config.evomerge_base_models[1]),
+                    BaseModelConfig(name="qwen2", path=self.config.evomerge_base_models[2]),
                 ],
                 max_generations=self.config.evomerge_generations,
                 device=self.config.device,
@@ -284,18 +260,12 @@ class UnifiedPipeline:
                     {
                         "evomerge_best_fitness": best_candidate.overall_fitness,
                         "evomerge_generations": best_candidate.generation,
-                        "evomerge_code_score": best_candidate.fitness_scores.get(
-                            "code", 0
-                        ),
-                        "evomerge_math_score": best_candidate.fitness_scores.get(
-                            "math", 0
-                        ),
+                        "evomerge_code_score": best_candidate.fitness_scores.get("code", 0),
+                        "evomerge_math_score": best_candidate.fitness_scores.get("math", 0),
                     }
                 )
 
-            logger.info(
-                f"✅ EvoMerge completed - Best fitness: {best_candidate.overall_fitness:.3f}"
-            )
+            logger.info(f"✅ EvoMerge completed - Best fitness: {best_candidate.overall_fitness:.3f}")
         else:
             msg = "EvoMerge failed to produce a best candidate"
             raise RuntimeError(msg)
@@ -331,12 +301,8 @@ class UnifiedPipeline:
                 {
                     "quietstar_winner": results["winner"],
                     "quietstar_improvement": results["improvement"],
-                    "quietstar_baseline_accuracy": results["ab_test_results"][
-                        "baseline_accuracy"
-                    ],
-                    "quietstar_thoughts_accuracy": results["ab_test_results"][
-                        "thoughts_accuracy"
-                    ],
+                    "quietstar_baseline_accuracy": results["ab_test_results"]["baseline_accuracy"],
+                    "quietstar_thoughts_accuracy": results["ab_test_results"]["thoughts_accuracy"],
                 }
             )
 
@@ -379,9 +345,7 @@ class UnifiedPipeline:
                 }
             )
 
-        logger.info(
-            f"✅ Compression completed - Ratio: {results['compression_ratio']:.1f}x"
-        )
+        logger.info(f"✅ Compression completed - Ratio: {results['compression_ratio']:.1f}x")
 
     async def calculate_final_metrics(self) -> None:
         """Calculate final performance metrics."""
@@ -393,9 +357,7 @@ class UnifiedPipeline:
 
         # Apply EvoMerge improvement
         if self.state.evomerge_results:
-            evomerge_improvement = (
-                self.state.evomerge_results["best_fitness"] - base_performance
-            )
+            evomerge_improvement = self.state.evomerge_results["best_fitness"] - base_performance
             final_performance += evomerge_improvement
 
         # Apply Quiet-STaR improvement
@@ -403,9 +365,7 @@ class UnifiedPipeline:
             quietstar_improvement = self.state.quietstar_results["improvement"] / 100
             final_performance += quietstar_improvement
 
-        self.state.total_improvement = (
-            (final_performance - base_performance) / base_performance
-        ) * 100
+        self.state.total_improvement = ((final_performance - base_performance) / base_performance) * 100
 
         # Final performance breakdown
         self.state.final_performance = {
@@ -413,14 +373,10 @@ class UnifiedPipeline:
             "final_performance": final_performance,
             "total_improvement_percent": self.state.total_improvement,
             "evomerge_contribution": (
-                self.state.evomerge_results["best_fitness"]
-                if self.state.evomerge_results
-                else 0
+                self.state.evomerge_results["best_fitness"] if self.state.evomerge_results else 0
             ),
             "quietstar_contribution": (
-                self.state.quietstar_results["improvement"]
-                if self.state.quietstar_results
-                else 0
+                self.state.quietstar_results["improvement"] if self.state.quietstar_results else 0
             ),
             "compression_ratio": self.state.compression_ratio,
         }
@@ -452,19 +408,11 @@ class UnifiedPipeline:
             "performance_summary": {
                 "total_improvement": f"{self.state.total_improvement:.1f}%",
                 "compression_ratio": f"{self.state.compression_ratio:.1f}x",
-                "evomerge_fitness": (
-                    self.state.evomerge_results["best_fitness"]
-                    if self.state.evomerge_results
-                    else 0
-                ),
+                "evomerge_fitness": (self.state.evomerge_results["best_fitness"] if self.state.evomerge_results else 0),
                 "quietstar_improvement": (
-                    f"{self.state.quietstar_results['improvement']:.1f}%"
-                    if self.state.quietstar_results
-                    else "0%"
+                    f"{self.state.quietstar_results['improvement']:.1f}%" if self.state.quietstar_results else "0%"
                 ),
-                "final_model_size": (
-                    "Compressed" if self.state.compression_ratio > 1 else "Original"
-                ),
+                "final_model_size": ("Compressed" if self.state.compression_ratio > 1 else "Original"),
             },
             "phase_details": {
                 "evomerge": self.state.evomerge_results,
@@ -476,18 +424,13 @@ class UnifiedPipeline:
         }
 
         # Save report
-        report_path = (
-            self.config.base_output_dir
-            / f"unified_pipeline_report_{self.state.run_id}.json"
-        )
+        report_path = self.config.base_output_dir / f"unified_pipeline_report_{self.state.run_id}.json"
         with open(report_path, "w") as f:
             json.dump(report, f, indent=2, default=str)
 
         # Log to W&B as artifact
         if self.wandb_run:
-            artifact = wandb.Artifact(
-                f"unified_pipeline_report_{self.state.run_id}", type="report"
-            )
+            artifact = wandb.Artifact(f"unified_pipeline_report_{self.state.run_id}", type="report")
             artifact.add_file(str(report_path))
             self.wandb_run.log_artifact(artifact)
 
@@ -534,9 +477,7 @@ class UnifiedPipeline:
         print("\n🎯 NEXT STEPS:")
         if report["deployment_ready"]:
             print(f"  1. Load model from: {summary['final_model_path']}")
-            print(
-                f"  2. Deploy with {performance['compression_ratio']} memory efficiency"
-            )
+            print(f"  2. Deploy with {performance['compression_ratio']} memory efficiency")
             print(f"  3. Expect {performance['total_improvement']} better performance")
         else:
             print("  ❌ Pipeline incomplete - check logs for issues")
@@ -556,12 +497,8 @@ def forge() -> None:
 
 @forge.command()
 @click.option("--config", help="Configuration JSON file")
-@click.option(
-    "--evomerge/--no-evomerge", default=True, help="Enable/disable EvoMerge phase"
-)
-@click.option(
-    "--quietstar/--no-quietstar", default=True, help="Enable/disable Quiet-STaR phase"
-)
+@click.option("--evomerge/--no-evomerge", default=True, help="Enable/disable EvoMerge phase")
+@click.option("--quietstar/--no-quietstar", default=True, help="Enable/disable Quiet-STaR phase")
 @click.option(
     "--compression/--no-compression",
     default=True,
@@ -571,9 +508,7 @@ def forge() -> None:
 @click.option("--output-dir", default="./unified_output", help="Base output directory")
 @click.option("--device", default="auto", help="Device to use")
 @click.option("--resume", help="Resume from checkpoint file")
-def run_pipeline(
-    config, evomerge, quietstar, compression, generations, output_dir, device, resume
-) -> None:
+def run_pipeline(config, evomerge, quietstar, compression, generations, output_dir, device, resume) -> None:
     """Run complete Agent Forge pipeline: EvoMerge → Quiet-STaR → Compression."""
     try:
         # Load configuration
@@ -600,9 +535,7 @@ def run_pipeline(
         pipeline = UnifiedPipeline(pipeline_config)
 
         logger.info("🚀 Starting Agent Forge Unified Pipeline")
-        logger.info(
-            f"Phases enabled: EvoMerge={evomerge}, Quiet-STaR={quietstar}, Compression={compression}"
-        )
+        logger.info(f"Phases enabled: EvoMerge={evomerge}, Quiet-STaR={quietstar}, Compression={compression}")
 
         results = asyncio.run(pipeline.run_complete_pipeline())
 
@@ -611,7 +544,7 @@ def run_pipeline(
 
     except Exception as e:
         logger.exception(f"Unified pipeline failed: {e}")
-        raise click.ClickException(str(e))
+        raise click.ClickException(str(e)) from e
 
 
 if __name__ == "__main__":

--- a/tests/test_unified_pipeline_dirs.py
+++ b/tests/test_unified_pipeline_dirs.py
@@ -1,0 +1,33 @@
+import sys
+import types
+
+compression_stub = types.ModuleType("compression_pipeline")
+compression_stub.CompressionConfig = object
+compression_stub.CompressionPipeline = object
+sys.modules["compression_pipeline"] = compression_stub
+
+evomerge_stub = types.ModuleType("evomerge_pipeline")
+evomerge_stub.EvolutionConfig = object
+evomerge_stub.EvoMergePipeline = object
+evomerge_stub.BaseModelConfig = object
+sys.modules["evomerge_pipeline"] = evomerge_stub
+
+quietstar_stub = types.ModuleType("quietstar_baker")
+quietstar_stub.QuietSTaRBaker = object
+quietstar_stub.QuietSTaRConfig = object
+sys.modules["quietstar_baker"] = quietstar_stub
+
+from agent_forge.unified_pipeline import UnifiedPipeline, UnifiedPipelineConfig  # noqa: E402
+
+
+def test_pipeline_creates_directories(tmp_path):
+    config = UnifiedPipelineConfig(
+        base_output_dir=tmp_path / "output",
+        checkpoint_dir=tmp_path / "checkpoints",
+        enable_evomerge=False,
+        enable_quietstar=False,
+        enable_compression=False,
+    )
+    UnifiedPipeline(config)
+    assert config.base_output_dir.is_dir()
+    assert config.checkpoint_dir.is_dir()


### PR DESCRIPTION
## Summary
- use Pydantic `model_post_init` to create pipeline output and checkpoint directories
- add regression test ensuring pipeline startup creates output directories

## Testing
- `SKIP=mypy pre-commit run --files src/agent_forge/unified_pipeline.py src/software/agent_forge/legacy/unified_pipeline.py tests/test_unified_pipeline_dirs.py`
- `pytest tests/test_unified_pipeline_dirs.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0973ae154832c81d11636608db3e7