### PR TITLE
Fix CLI imports for production pipelines

### DIFF
--- a/src/agent_forge/unified_pipeline.py
+++ b/src/agent_forge/unified_pipeline.py
@@ -18,10 +18,16 @@ from pathlib import Path
 from typing import Any
 
 import click
-from compression_pipeline import CompressionConfig, CompressionPipeline
+from production.compression.compression_pipeline import (
+    CompressionConfig,
+    CompressionPipeline,
+)
 
 # Import pipeline components
-from evomerge_pipeline import EvolutionConfig, EvoMergePipeline
+from production.evolution.evomerge_pipeline import (
+    EvolutionConfig,
+    EvoMergePipeline,
+)
 from pydantic import BaseModel, Field
 from quietstar_baker import QuietSTaRBaker, QuietSTaRConfig
 
@@ -245,7 +251,7 @@ class UnifiedPipeline:
         if self.config.evomerge_config:
             evomerge_config = EvolutionConfig(**self.config.evomerge_config)
         else:
-            from evomerge_pipeline import BaseModelConfig
+            from production.evolution.evomerge_pipeline import BaseModelConfig
 
             evomerge_config = EvolutionConfig(
                 base_models=[


### PR DESCRIPTION
## Summary
- Update Agent Forge CLI to import production pipeline modules directly and raise explicit ImportErrors when missing
- Register pipeline commands without silent fallbacks so users immediately see missing modules
- Point unified pipeline to production compression and evolution modules

## Testing
- `python -m agent_forge.cli --help`


------
https://chatgpt.com/codex/tasks/task_e_68a0973d2190832cbba5bfb8b8de1919