### PR TITLE
feat: enable unified pipeline resume

### DIFF
--- a/src/agent_forge/unified_pipeline.py
+++ b/src/agent_forge/unified_pipeline.py
@@ -592,16 +592,33 @@ def run_pipeline(
             )
 
         # Handle resume
+        resume_state = None
         if resume and Path(resume).exists():
             logger.info(f"Resuming from checkpoint: {resume}")
-            # Implementation would load state and continue
+            resume_path = Path(resume)
+            resume_state = PipelineState.load_checkpoint(resume_path)
+            completed = set(resume_state.completed_phases)
+
+            if "evomerge" in completed:
+                pipeline_config.enable_evomerge = False
+            if "quietstar" in completed:
+                pipeline_config.enable_quietstar = False
+            if "compression" in completed:
+                pipeline_config.enable_compression = False
+
+            pipeline_config.checkpoint_dir = resume_path.parent
 
         # Run unified pipeline
         pipeline = UnifiedPipeline(pipeline_config)
 
+        if resume_state:
+            pipeline.state = resume_state
+
         logger.info("🚀 Starting Agent Forge Unified Pipeline")
         logger.info(
-            f"Phases enabled: EvoMerge={evomerge}, Quiet-STaR={quietstar}, Compression={compression}"
+            f"Phases enabled: EvoMerge={pipeline.config.enable_evomerge}, "
+            f"Quiet-STaR={pipeline.config.enable_quietstar}, "
+            f"Compression={pipeline.config.enable_compression}"
         )
 
         results = asyncio.run(pipeline.run_complete_pipeline())

--- a/tests/test_unified_pipeline_resume.py
+++ b/tests/test_unified_pipeline_resume.py
@@ -1,0 +1,89 @@
+import asyncio
+
+import pytest
+import sys
+import types
+
+sys.modules.setdefault("compression_pipeline", types.ModuleType("compression_pipeline"))
+sys.modules["compression_pipeline"].CompressionConfig = object
+sys.modules["compression_pipeline"].CompressionPipeline = object
+
+sys.modules.setdefault("evomerge_pipeline", types.ModuleType("evomerge_pipeline"))
+sys.modules["evomerge_pipeline"].EvolutionConfig = object
+sys.modules["evomerge_pipeline"].EvoMergePipeline = object
+
+sys.modules.setdefault("quietstar_baker", types.ModuleType("quietstar_baker"))
+sys.modules["quietstar_baker"].QuietSTaRBaker = object
+sys.modules["quietstar_baker"].QuietSTaRConfig = object
+
+from agent_forge.unified_pipeline import (
+    PipelineState,
+    UnifiedPipeline,
+    UnifiedPipelineConfig,
+    run_pipeline,
+)
+
+
+async def _noop(*args, **kwargs):
+    return None
+
+
+async def _report(self):
+    return {"pipeline_summary": {"run_id": self.state.run_id}}
+
+
+def test_resume_from_checkpoint(tmp_path, monkeypatch):
+    async def fake_evomerge(self):
+        self.state.evomerge_model_path = "evomerge.model"
+
+    async def failing_quietstar(self):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(UnifiedPipeline, "run_evomerge_phase", fake_evomerge)
+    monkeypatch.setattr(UnifiedPipeline, "run_quietstar_phase", failing_quietstar)
+    monkeypatch.setattr(UnifiedPipeline, "run_compression_phase", _noop)
+    monkeypatch.setattr(UnifiedPipeline, "calculate_final_metrics", _noop)
+    monkeypatch.setattr(UnifiedPipeline, "generate_final_report", _report)
+
+    config = UnifiedPipelineConfig(base_output_dir=tmp_path, checkpoint_dir=tmp_path)
+    pipeline = UnifiedPipeline(config)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(pipeline.run_complete_pipeline())
+
+    checkpoint = next(tmp_path.glob("unified_pipeline_*.json"))
+    state = PipelineState.load_checkpoint(checkpoint)
+    assert state.completed_phases == ["evomerge"]
+
+    evomerge_called = False
+
+    async def mark_evomerge(self):
+        nonlocal evomerge_called
+        evomerge_called = True
+
+    async def fake_quietstar(self):
+        self.state.quietstar_model_path = "quietstar.model"
+
+    async def fake_compression(self, source_model):
+        self.state.final_model_path = "final.model"
+
+    monkeypatch.setattr(UnifiedPipeline, "run_evomerge_phase", mark_evomerge)
+    monkeypatch.setattr(UnifiedPipeline, "run_quietstar_phase", fake_quietstar)
+    monkeypatch.setattr(UnifiedPipeline, "run_compression_phase", fake_compression)
+    monkeypatch.setattr(UnifiedPipeline, "calculate_final_metrics", _noop)
+    monkeypatch.setattr(UnifiedPipeline, "generate_final_report", _report)
+
+    run_pipeline.callback(
+        config=None,
+        evomerge=True,
+        quietstar=True,
+        compression=True,
+        generations=1,
+        output_dir=str(tmp_path / "out"),
+        device="auto",
+        resume=str(checkpoint),
+    )
+
+    assert not evomerge_called
+    resumed = PipelineState.load_checkpoint(checkpoint)
+    assert resumed.completed_phases == ["evomerge", "quietstar", "compression"]


### PR DESCRIPTION
## Summary
- resume unified pipeline from a saved checkpoint
- skip completed phases and continue pending ones
- add regression test ensuring resume behaviour

## Testing
- `pytest tests/test_unified_pipeline_resume.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a097427dec832c845db994483c2cf7