### PR TITLE
Compute package hashes in SBOM

### DIFF
--- a/betanet-bounty/crates/betanet-linter/Cargo.toml
+++ b/betanet-bounty/crates/betanet-linter/Cargo.toml
@@ -26,6 +26,7 @@ walkdir = "2.5"
 cargo_metadata = "0.18"
 uuid = { version = "1.10", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
## Summary
- Compute SHA256 over package source files for SPDX `packageVerificationCode`
- Replace placeholder values with real hashes in SBOM output
- Test that package hashing is deterministic across runs

## Testing
- `cargo test -p betanet-linter` *(fails: checks::bootstrap::tests::test_bootstrap_negotiation_rule, checks::bootstrap::tests::test_abuse_tracking_rule, checks::frame_format::tests::test_frame_buffer_rule, checks::bootstrap::tests::test_cpu_pow_fallback_rule, checks::frame_format::tests::test_frame_validation_rule, checks::bootstrap::tests::test_argon2id_parameter_rule, checks::noise_xk::tests::test_key_rotation_rule, checks::noise_xk::tests::test_security_rule, checks::noise_xk::tests::test_transport_rule, checks::scion_bridge::tests::test_scion_deployment_rule, checks::scion_bridge::tests::test_scion_gateway_rule, checks::scion_bridge::tests::test_scion_security_rule, checks::tls_mirror::tests::test_anti_fingerprint_rule, checks::tls_mirror::tests::test_template_cache_rule)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b1756628832c8eadbed38bb93449