### PR TITLE
Parse and validate ECH configs for QUIC

### DIFF
--- a/betanet-bounty/README.md
+++ b/betanet-bounty/README.md
@@ -70,11 +70,17 @@ HTX (Hybrid Transport eXtension) protocol implementation.
 - Frame-based message protocol
 - Async/await throughout
 - Integration with AI Village transport layer
+- Encrypted Client Hello (ECH) support via DNS or file configuration
 
 ```rust
 use betanet_htx::{HtxClient, HtxConfig};
+use betanet_htx::quic::EchConfig;
 
-let config = HtxConfig::default();
+let mut config = HtxConfig::default();
+config.enable_tls_camouflage = true;
+config.camouflage_domain = Some("cloudflare.com".to_string());
+// Load ECH configuration from DNS
+let _ech = EchConfig::from_dns("cloudflare.com").await?;
 let mut client = HtxClient::new(config);
 client.connect("127.0.0.1:9000".parse()?).await?;
 client.send(b"Hello, Betanet!").await?;

--- a/betanet-bounty/crates/betanet-htx/Cargo.toml
+++ b/betanet-bounty/crates/betanet-htx/Cargo.toml
@@ -41,6 +41,7 @@ parking_lot = { workspace = true }
 webpki-roots = { workspace = true }
 base64 = "0.21"
 urlencoding = "2.1"
+trust-dns-resolver = { version = "0.23", features = ["tokio-runtime"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }


### PR DESCRIPTION
## Summary
- parse ECH configs from file or DNS and validate them
- surface configuration errors when ECH is enabled without a valid config
- document ECH setup and show usage in the QUIC example

## Testing
- `pre-commit run --files betanet-bounty/README.md betanet-bounty/crates/betanet-htx/Cargo.toml betanet-bounty/crates/betanet-htx/src/lib.rs betanet-bounty/crates/betanet-htx/src/quic.rs betanet-bounty/examples/htx_quic_datagram_demo.rs`
- `cargo test -p betanet-htx --features quic`

------
https://chatgpt.com/codex/tasks/task_e_68a0b1786260832c81e544e3e6ace54a