### PR TITLE
Handle mixnode bench errors without unwrap

### DIFF
--- a/betanet-bounty/crates/betanet-mixnode/benches/README.md
+++ b/betanet-bounty/crates/betanet-mixnode/benches/README.md
@@ -1,0 +1,14 @@
+# Mixnode Benchmarks
+
+Run the benchmarks with:
+
+```
+cargo bench --bench mixnode_bench
+```
+
+The benchmark prints detailed throughput statistics. If an error occurs the
+program exits with a message such as `Benchmark failed: ...` instead of
+panicking. This typically means the mixnode pipeline could not start or
+finish the throughput test. Inspect the logs and configuration to diagnose
+issues. Migrating this suite to the [`criterion`](https://crates.io/crates/criterion)
+crate would provide structured benchmarking and clearer failure reporting.

--- a/betanet-bounty/crates/betanet-mixnode/benches/mixnode_bench.rs
+++ b/betanet-bounty/crates/betanet-mixnode/benches/mixnode_bench.rs
@@ -1,20 +1,27 @@
 //! Mixnode performance benchmarks
 //!
 //! Target: 25,000 packets/second sustained throughput
+//!
+//! The benchmark reports errors instead of panicking so failures can be
+//! interpreted by CI or developers. Consider migrating to the `criterion`
+//! crate for statistically sound benchmarking and richer error reporting.
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
-use betanet_mixnode::pipeline::{PacketPipeline, PipelinePacket, PipelineBenchmark};
+use betanet_mixnode::{
+    pipeline::PipelineBenchmark,
+    Result,
+};
 
 /// Custom benchmark for mixnode-specific performance testing
-async fn custom_mixnode_benchmark() {
+async fn custom_mixnode_benchmark() -> Result<()> {
     println!("🚀 Custom Mixnode Performance Test");
     println!("==================================");
 
     // Test 1: Quick throughput check
     println!("\n📊 Test 1: Quick Throughput Check (5 seconds)");
     let mut benchmark = PipelineBenchmark::new(4, 5000);
-    let results = benchmark.run_throughput_test(5).await.unwrap();
+    let results = benchmark.run_throughput_test(5).await?;
     results.print_results();
 
     let meets_target = results.meets_target(25000.0);
@@ -23,7 +30,7 @@ async fn custom_mixnode_benchmark() {
     // Test 2: Longer sustained test
     println!("\n📊 Test 2: Sustained Throughput (15 seconds)");
     let mut benchmark = PipelineBenchmark::new(4, 10000);
-    let results = benchmark.run_throughput_test(15).await.unwrap();
+    let results = benchmark.run_throughput_test(15).await?;
     results.print_results();
 
     let meets_target = results.meets_target(25000.0);
@@ -33,7 +40,7 @@ async fn custom_mixnode_benchmark() {
     println!("\n📊 Test 3: Worker Scaling Analysis");
     for workers in [1, 2, 4, 6, 8] {
         let mut benchmark = PipelineBenchmark::new(workers, 2000);
-        let results = benchmark.run_throughput_test(3).await.unwrap();
+        let results = benchmark.run_throughput_test(3).await?;
         println!("  {} workers: {:.0} pkt/s", workers, results.throughput_pps);
     }
 
@@ -56,10 +63,18 @@ async fn custom_mixnode_benchmark() {
     println!("  Allocated: {}, Reused: {}", allocated, reused);
 
     println!("\n🏁 Performance Testing Complete!");
+    Ok(())
 }
 
 /// Run the benchmark
 #[tokio::main]
 async fn main() {
-    custom_mixnode_benchmark().await;
+    // Propagate errors without panicking so that failures can be
+    // interpreted and reported by the caller. A failure typically
+    // indicates the pipeline could not start or complete the test.
+    if let Err(e) = custom_mixnode_benchmark().await {
+        eprintln!("❌ Benchmark failed: {e}");
+        eprintln!("Check mixnode logs and configuration. Consider using the \"criterion\" crate for more structured benchmarks.");
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
## Summary
- Replace unwrap() calls in mixnode_bench with `?` and report failures gracefully
- Add README describing how to run the benchmark and interpret failures
- Suggest migrating to the criterion crate for richer benchmarking

## Testing
- `cargo check --bench mixnode_bench`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd4ad7c0832cb4871ed4553a5a01