### PR TITLE
Return BetanetResult from feature support API

### DIFF
--- a/betanet-bounty/crates/betanet-ffi/Cargo.toml
+++ b/betanet-bounty/crates/betanet-ffi/Cargo.toml
@@ -10,7 +10,7 @@ description = "C FFI bindings for Betanet core components"
 
 [lib]
 name = "betanet_ffi"
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 # Minimal dependencies for Day 8-9 deliverable
 [dependencies]

--- a/betanet-bounty/crates/betanet-ffi/examples/htx_example.c
+++ b/betanet-bounty/crates/betanet-ffi/examples/htx_example.c
@@ -19,7 +19,7 @@ int main() {
     }
 
     printf("Library version: %s\n", betanet_version());
-    printf("HTX support: %s\n", betanet_feature_supported("htx") ? "Yes" : "No");
+    printf("HTX support: %s\n", betanet_feature_supported("htx") == BETANET_SUCCESS ? "Yes" : "No");
     printf("\n");
 
     // Create a DATA frame

--- a/betanet-bounty/crates/betanet-ffi/examples/linter_example.c
+++ b/betanet-bounty/crates/betanet-ffi/examples/linter_example.c
@@ -19,7 +19,7 @@ int main() {
     }
 
     printf("Library version: %s\n", betanet_version());
-    printf("Linter support: %s\n", betanet_feature_supported("linter") ? "Yes" : "No");
+    printf("Linter support: %s\n", betanet_feature_supported("linter") == BETANET_SUCCESS ? "Yes" : "No");
     printf("\n");
 
     // Configure linter

--- a/betanet-bounty/crates/betanet-ffi/examples/minimal_example.c
+++ b/betanet-bounty/crates/betanet-ffi/examples/minimal_example.c
@@ -19,10 +19,10 @@ int main() {
     }
 
     printf("Library version: %s\n", betanet_version());
-    printf("FFI demo support: %s\n", betanet_feature_supported("ffi_demo") ? "Yes" : "No");
-    printf("Buffer management: %s\n", betanet_feature_supported("buffer_management") ? "Yes" : "No");
-    printf("Version info: %s\n", betanet_feature_supported("version_info") ? "Yes" : "No");
-    printf("Unknown feature: %s\n", betanet_feature_supported("unknown") ? "Yes" : "No");
+    printf("FFI demo support: %s\n", betanet_feature_supported("ffi_demo") == BETANET_SUCCESS ? "Yes" : "No");
+    printf("Buffer management: %s\n", betanet_feature_supported("buffer_management") == BETANET_SUCCESS ? "Yes" : "No");
+    printf("Version info: %s\n", betanet_feature_supported("version_info") == BETANET_SUCCESS ? "Yes" : "No");
+    printf("Unknown feature: %s\n", betanet_feature_supported("unknown") == BETANET_SUCCESS ? "Yes" : "No");
     printf("\n");
 
     // Test echo function

--- a/betanet-bounty/crates/betanet-ffi/examples/mixnode_example.c
+++ b/betanet-bounty/crates/betanet-ffi/examples/mixnode_example.c
@@ -19,8 +19,8 @@ int main() {
     }
 
     printf("Library version: %s\n", betanet_version());
-    printf("Mixnode support: %s\n", betanet_feature_supported("mixnode") ? "Yes" : "No");
-    printf("Sphinx support: %s\n", betanet_feature_supported("sphinx") ? "Yes" : "No");
+    printf("Mixnode support: %s\n", betanet_feature_supported("mixnode") == BETANET_SUCCESS ? "Yes" : "No");
+    printf("Sphinx support: %s\n", betanet_feature_supported("sphinx") == BETANET_SUCCESS ? "Yes" : "No");
     printf("\n");
 
     // Configure mixnode

--- a/betanet-bounty/crates/betanet-ffi/examples/utls_example.c
+++ b/betanet-bounty/crates/betanet-ffi/examples/utls_example.c
@@ -25,9 +25,9 @@ int main() {
     }
 
     printf("Library version: %s\n", betanet_version());
-    printf("uTLS support: %s\n", betanet_feature_supported("utls") ? "Yes" : "No");
-    printf("JA3 support: %s\n", betanet_feature_supported("ja3") ? "Yes" : "No");
-    printf("JA4 support: %s\n", betanet_feature_supported("ja4") ? "Yes" : "No");
+    printf("uTLS support: %s\n", betanet_feature_supported("utls") == BETANET_SUCCESS ? "Yes" : "No");
+    printf("JA3 support: %s\n", betanet_feature_supported("ja3") == BETANET_SUCCESS ? "Yes" : "No");
+    printf("JA4 support: %s\n", betanet_feature_supported("ja4") == BETANET_SUCCESS ? "Yes" : "No");
     printf("\n");
 
     // Run self-test first

--- a/betanet-bounty/crates/betanet-ffi/include/betanet.h
+++ b/betanet-bounty/crates/betanet-ffi/include/betanet.h
@@ -75,11 +75,11 @@ const char* betanet_version(void);
  * @param feature - Feature name to check (null-terminated string)
  *
  * Returns:
- * - 1 if feature is supported
- * - 0 if feature is not supported
- * - -1 if feature name is invalid
+ * - BETANET_SUCCESS if feature is supported
+ * - BETANET_NOT_SUPPORTED if feature is not supported
+ * - BETANET_INVALID_ARGUMENT if feature name is invalid
  */
-int betanet_feature_supported(const char* feature);
+BetanetResult betanet_feature_supported(const char* feature);
 
 /**
  * Free a buffer allocated by Betanet

--- a/betanet-bounty/crates/betanet-ffi/src/common.rs
+++ b/betanet-bounty/crates/betanet-ffi/src/common.rs
@@ -4,8 +4,8 @@ use std::os::raw::{c_char, c_int, c_uint, c_void};
 use std::ptr;
 
 /// Result codes for Betanet FFI functions
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BetanetResult {
     /// Operation completed successfully
     Success = 0,

--- a/betanet-bounty/crates/betanet-ffi/tests/feature_supported.rs
+++ b/betanet-bounty/crates/betanet-ffi/tests/feature_supported.rs
@@ -1,0 +1,29 @@
+use betanet_ffi::{betanet_feature_supported, BetanetResult};
+use std::ffi::CString;
+
+#[test]
+fn feature_supported_known_feature() {
+    let feature = CString::new("ffi_demo").unwrap();
+    let result = betanet_feature_supported(feature.as_ptr());
+    assert_eq!(result, BetanetResult::Success);
+}
+
+#[test]
+fn feature_supported_unknown_feature() {
+    let feature = CString::new("unknown").unwrap();
+    let result = betanet_feature_supported(feature.as_ptr());
+    assert_eq!(result, BetanetResult::NotSupported);
+}
+
+#[test]
+fn feature_supported_null_pointer() {
+    let result = betanet_feature_supported(std::ptr::null());
+    assert_eq!(result, BetanetResult::InvalidArgument);
+}
+
+#[test]
+fn result_code_mapping() {
+    assert_eq!(BetanetResult::Success as i32, 0);
+    assert_eq!(BetanetResult::InvalidArgument as i32, -1);
+    assert_eq!(BetanetResult::NotSupported as i32, -7);
+}


### PR DESCRIPTION
## Summary
- make BetanetResult use `#[repr(i32)]` for stable cross-platform layout
- expose `betanet_feature_supported` as returning `BetanetResult` and document mapping
- verify result code mapping through new tests

## Implementation Notes
- updated C header and examples for `betanet_feature_supported`
- enabled `rlib` crate type for `betanet-ffi` to allow Rust tests

## Tradeoffs
- adding `rlib` output slightly increases build artifacts but is required for testing

## Tests Added
- `feature_supported.rs` verifies supported, unsupported and invalid feature mappings and enum code values

## Local Run Logs
- `cargo fmt --manifest-path betanet-bounty/Cargo.toml --package betanet-ffi`
- `cargo test --manifest-path betanet-bounty/Cargo.toml -p betanet-ffi`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd4c6510832c92954532ed081e27