### PR TITLE
Expose mixnode statistics handle

### DIFF
--- a/betanet-bounty/crates/betanet-mixnode/src/lib.rs
+++ b/betanet-bounty/crates/betanet-mixnode/src/lib.rs
@@ -9,6 +9,9 @@
 
 use std::net::SocketAddr;
 use std::time::Duration;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
 
 use thiserror::Error;
 
@@ -135,8 +138,8 @@ pub trait Mixnode: Send + Sync {
     /// Process a packet
     async fn process_packet(&self, packet: &[u8]) -> Result<Option<Vec<u8>>>;
 
-    /// Get node statistics
-    fn stats(&self) -> &MixnodeStats;
+    /// Get node statistics handle
+    fn stats(&self) -> Arc<RwLock<MixnodeStats>>;
 
     /// Get node address
     fn address(&self) -> SocketAddr;

--- a/betanet-bounty/crates/betanet-mixnode/src/mixnode.rs
+++ b/betanet-bounty/crates/betanet-mixnode/src/mixnode.rs
@@ -272,10 +272,8 @@ impl Mixnode for StandardMixnode {
         Ok(Some(packet.to_vec()))
     }
 
-    fn stats(&self) -> &MixnodeStats {
-        // This is a placeholder - in a real implementation, we'd need to
-        // handle the async nature of the stats access differently
-        unimplemented!("Use async stats access instead")
+    fn stats(&self) -> Arc<RwLock<MixnodeStats>> {
+        Arc::clone(&self.stats)
     }
 
     fn address(&self) -> SocketAddr {
@@ -302,5 +300,15 @@ mod tests {
         let delay = mixnode.calculate_delay().await;
         assert!(delay >= mixnode.config.min_delay);
         assert!(delay <= mixnode.config.max_delay);
+    }
+
+    #[tokio::test]
+    async fn test_stats_access() {
+        let config = MixnodeConfig::default();
+        let mixnode = StandardMixnode::new(config).unwrap();
+
+        let stats_handle = mixnode.stats();
+        let stats = stats_handle.read().await;
+        assert_eq!(stats.packets_processed, 0);
     }
 }


### PR DESCRIPTION
## Summary
- expose stats handle by returning an `Arc<RwLock<MixnodeStats>>` from `stats`
- update Mixnode trait and tests to use the async stats handle
- add unit test exercising the new accessor

## Testing
- `cargo test -p betanet-mixnode`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd51d560832c8803d23d49c22389