### PR TITLE
Expand Betanet FFI modules and headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,16 @@
 [workspace]
-members = ["betanet-mixnode"]
+members = [
+    "crates/betanet-ffi",
+    "crates/betanet-htx",
+    "crates/betanet-mixnode",
+    "crates/betanet-utls",
+    "crates/betanet-linter"
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+rust-version = "1.70"
+authors = ["AI Village"]
+repository = "https://example.com"

--- a/crates/betanet-ffi/Cargo.toml
+++ b/crates/betanet-ffi/Cargo.toml
@@ -1,11 +1,8 @@
 [package]
 name = "betanet-ffi"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-repository.workspace = true
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
 description = "C FFI bindings for Betanet core components"
 
 [lib]
@@ -14,19 +11,13 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 # Minimal dependencies for Day 8-9 deliverable
 [dependencies]
-# Full dependencies commented out due to OpenSSL issues on Windows
-# betanet-htx = { path = "../betanet-htx" }
-# betanet-mixnode = { path = "../betanet-mixnode" }
-# betanet-utls = { path = "../betanet-utls" }
-# betanet-linter = { path = "../betanet-linter" }
+betanet-htx = { path = "../betanet-htx" }
+betanet-mixnode = { path = "../betanet-mixnode" }
+betanet-utls = { path = "../betanet-utls" }
+betanet-linter = { path = "../betanet-linter" }
 
-# FFI dependencies
 libc = "0.2"
-# serde = { workspace = true }
-# serde_json = { workspace = true }
-# tokio = { workspace = true, features = ["rt", "macros"] }
-# anyhow = { workspace = true }
-# futures = { workspace = true }
+futures = "0.3"
 
 [features]
 default = []

--- a/crates/betanet-ffi/src/lib.rs
+++ b/crates/betanet-ffi/src/lib.rs
@@ -3,13 +3,23 @@
 //! This library provides C-compatible FFI bindings for core Betanet functionality
 //! For Day 8-9 deliverable, using minimal implementation to avoid OpenSSL issues on Windows
 
-// Use minimal implementation for now to avoid OpenSSL build issues
+// Core shared types and utilities
+mod common;
+pub use common::*;
+
+// Base library functions (initialization, buffers, etc.)
 mod lib_minimal;
 pub use lib_minimal::*;
 
-// Full implementation (commented out due to OpenSSL dependency issues)
-// mod htx;
-// mod mixnode;
-// mod utls;
-// mod linter;
-// mod common;
+// Protocol modules
+mod htx;
+pub use htx::*;
+
+mod mixnode;
+pub use mixnode::*;
+
+mod utls;
+pub use utls::*;
+
+mod linter;
+pub use linter::*;

--- a/crates/betanet-ffi/src/lib_minimal.rs
+++ b/crates/betanet-ffi/src/lib_minimal.rs
@@ -1,121 +1,26 @@
-//! Betanet FFI - Minimal C bindings for Day 8-9 deliverable
+//! Betanet FFI - Core library functions
 //!
-//! This is a minimal version for demonstrating FFI capabilities without OpenSSL dependencies
+//! Provides basic initialization and demo packet utilities using
+//! shared types from [`common`].
 
 use std::ffi::CStr;
-use std::os::raw::{c_char, c_int, c_uint};
-use std::ptr;
+use std::os::raw::{c_char, c_int};
 
-/// Result codes for Betanet FFI functions
-#[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum BetanetResult {
-    /// Operation completed successfully
-    Success = 0,
-    /// Invalid argument provided
-    InvalidArgument = -1,
-    /// Out of memory
-    OutOfMemory = -2,
-    /// Network error
-    NetworkError = -3,
-    /// Parsing error
-    ParseError = -4,
-    /// Cryptographic error
-    CryptoError = -5,
-    /// Internal error
-    InternalError = -6,
-    /// Feature not supported
-    NotSupported = -7,
-    /// Operation timed out
-    Timeout = -8,
-}
-
-/// Buffer structure for passing data between C and Rust
-#[repr(C)]
-pub struct BetanetBuffer {
-    /// Pointer to data
-    pub data: *mut u8,
-    /// Length of data in bytes
-    pub len: c_uint,
-    /// Capacity of buffer (for owned buffers)
-    pub capacity: c_uint,
-}
-
-impl BetanetBuffer {
-    /// Create a new empty buffer
-    pub fn new() -> Self {
-        Self {
-            data: ptr::null_mut(),
-            len: 0,
-            capacity: 0,
-        }
-    }
-
-    /// Create buffer from Vec<u8>
-    pub fn from_vec(mut vec: Vec<u8>) -> Self {
-        let data = vec.as_mut_ptr();
-        let len = vec.len() as c_uint;
-        let capacity = vec.capacity() as c_uint;
-        std::mem::forget(vec); // Transfer ownership to C
-
-        Self {
-            data,
-            len,
-            capacity,
-        }
-    }
-
-    /// Create buffer from slice (read-only)
-    pub fn from_slice(slice: &[u8]) -> Self {
-        Self {
-            data: slice.as_ptr() as *mut u8,
-            len: slice.len() as c_uint,
-            capacity: 0, // Indicates read-only
-        }
-    }
-
-    /// Convert back to Vec<u8> (takes ownership)
-    ///
-    /// # Safety
-    /// Buffer must have been created from a Vec with from_vec()
-    pub unsafe fn into_vec(self) -> Vec<u8> {
-        if self.capacity == 0 || self.data.is_null() {
-            return Vec::new();
-        }
-
-        Vec::from_raw_parts(self.data, self.len as usize, self.capacity as usize)
-    }
-
-    /// Get slice view of buffer data
-    ///
-    /// # Safety
-    /// Buffer data pointer must be valid
-    pub unsafe fn as_slice(&self) -> &[u8] {
-        if self.data.is_null() || self.len == 0 {
-            &[]
-        } else {
-            std::slice::from_raw_parts(self.data, self.len as usize)
-        }
-    }
-}
+use crate::common::{BetanetBuffer, BetanetResult};
 
 /// Initialize the Betanet library
 ///
 /// Must be called before using any other functions.
-/// Returns 0 on success, negative error code on failure.
 #[no_mangle]
 pub extern "C" fn betanet_init() -> c_int {
-    // Initialize logging if needed
-    // Initialize any global state
+    // Initialize logging or global state here if necessary
     0
 }
 
 /// Cleanup and shutdown the Betanet library
-///
-/// Should be called when finished using the library.
 #[no_mangle]
 pub extern "C" fn betanet_cleanup() {
-    // Cleanup any global state
+    // Cleanup any global state here if necessary
 }
 
 /// Get library version string
@@ -124,19 +29,17 @@ pub extern "C" fn betanet_cleanup() {
 /// The caller must not free the returned pointer.
 #[no_mangle]
 pub extern "C" fn betanet_version() -> *const c_char {
-    static VERSION: &[u8] = b"0.1.0-minimal\0";
+    static VERSION: &[u8] = b"0.1.0\0";
     VERSION.as_ptr() as *const c_char
 }
 
 /// Check if a feature is supported
 ///
-/// # Arguments
 /// * `feature` - Feature name to check (null-terminated string)
 ///
-/// # Returns
-/// * `BetanetResult::Success` if feature is supported
-/// * `BetanetResult::NotSupported` if feature is not supported
-/// * `BetanetResult::InvalidArgument` if feature name is invalid
+/// Returns [`BetanetResult::Success`] if supported,
+/// [`BetanetResult::NotSupported`] if not, or
+/// [`BetanetResult::InvalidArgument`] on error.
 #[no_mangle]
 pub extern "C" fn betanet_feature_supported(feature: *const c_char) -> BetanetResult {
     if feature.is_null() {
@@ -150,77 +53,13 @@ pub extern "C" fn betanet_feature_supported(feature: *const c_char) -> BetanetRe
     };
 
     match feature_str {
-        "ffi_demo" | "buffer_management" | "version_info" => BetanetResult::Success,
+        "ffi_demo" | "buffer_management" | "version_info" |
+        "htx" | "mixnode" | "sphinx" | "utls" | "ja3" | "ja4" | "linter" => BetanetResult::Success,
         _ => BetanetResult::NotSupported,
     }
 }
 
-/// Free a buffer allocated by Betanet
-///
-/// # Arguments
-/// * `buffer` - Buffer to free
-///
-/// # Safety
-/// Buffer must have been allocated by Betanet library
-#[no_mangle]
-pub unsafe extern "C" fn betanet_buffer_free(buffer: BetanetBuffer) {
-    if buffer.capacity > 0 && !buffer.data.is_null() {
-        // This was an owned buffer, convert back to Vec to drop
-        let _vec = buffer.into_vec();
-    }
-}
-
-/// Allocate a new buffer
-///
-/// # Arguments
-/// * `size` - Size in bytes to allocate
-///
-/// # Returns
-/// * New buffer on success
-/// * Empty buffer on failure
-#[no_mangle]
-pub extern "C" fn betanet_buffer_alloc(size: c_uint) -> BetanetBuffer {
-    if size == 0 {
-        return BetanetBuffer::new();
-    }
-
-    let vec = vec![0u8; size as usize];
-    BetanetBuffer::from_vec(vec)
-}
-
-/// Get error message for result code
-///
-/// # Arguments
-/// * `result` - Result code
-///
-/// # Returns
-/// * Null-terminated error message string
-/// * The caller must not free the returned pointer
-#[no_mangle]
-pub extern "C" fn betanet_error_message(result: BetanetResult) -> *const c_char {
-    let msg = match result {
-        BetanetResult::Success => "Success\0",
-        BetanetResult::InvalidArgument => "Invalid argument\0",
-        BetanetResult::OutOfMemory => "Out of memory\0",
-        BetanetResult::NetworkError => "Network error\0",
-        BetanetResult::ParseError => "Parse error\0",
-        BetanetResult::CryptoError => "Cryptographic error\0",
-        BetanetResult::InternalError => "Internal error\0",
-        BetanetResult::NotSupported => "Feature not supported\0",
-        BetanetResult::Timeout => "Operation timed out\0",
-    };
-
-    msg.as_ptr() as *const c_char
-}
-
-/// Simple packet encoder/decoder demo
-///
-/// # Arguments
-/// * `input` - Input data
-/// * `output` - Output buffer (will be allocated)
-///
-/// # Returns
-/// * Result code
+/// Simple packet encoder demo
 #[no_mangle]
 pub extern "C" fn betanet_packet_encode(
     input: BetanetBuffer,
@@ -238,7 +77,6 @@ pub extern "C" fn betanet_packet_encode(
         }
     };
 
-    // Simple demo encoding: add length prefix
     let mut encoded = Vec::with_capacity(4 + input_data.len());
     encoded.extend_from_slice(&(input_data.len() as u32).to_be_bytes());
     encoded.extend_from_slice(input_data);
@@ -251,13 +89,6 @@ pub extern "C" fn betanet_packet_encode(
 }
 
 /// Simple packet decoder demo
-///
-/// # Arguments
-/// * `input` - Input encoded data
-/// * `output` - Output buffer (will be allocated)
-///
-/// # Returns
-/// * Result code
 #[no_mangle]
 pub extern "C" fn betanet_packet_decode(
     input: BetanetBuffer,
@@ -278,9 +109,12 @@ pub extern "C" fn betanet_packet_decode(
         return BetanetResult::ParseError;
     }
 
-    // Decode length prefix
-    let length =
-        u32::from_be_bytes([input_data[0], input_data[1], input_data[2], input_data[3]]) as usize;
+    let length = u32::from_be_bytes([
+        input_data[0],
+        input_data[1],
+        input_data[2],
+        input_data[3],
+    ]) as usize;
 
     if input_data.len() < 4 + length {
         return BetanetResult::ParseError;
@@ -296,15 +130,11 @@ pub extern "C" fn betanet_packet_decode(
 }
 
 /// Echo function for testing
-///
-/// # Arguments
-/// * `input` - Input string (null-terminated)
-/// * `output` - Output buffer (will be allocated)
-///
-/// # Returns
-/// * Result code
 #[no_mangle]
-pub extern "C" fn betanet_echo(input: *const c_char, output: *mut BetanetBuffer) -> BetanetResult {
+pub extern "C" fn betanet_echo(
+    input: *const c_char,
+    output: *mut BetanetBuffer,
+) -> BetanetResult {
     if input.is_null() || output.is_null() {
         return BetanetResult::InvalidArgument;
     }


### PR DESCRIPTION
## Summary
- Expose full Betanet modules (HTX, mixnode, uTLS, linter) from the FFI crate
- Rework core library to use shared types and support additional feature flags
- Provide comprehensive C header with bindings for new modules

## Testing
- `cargo test --manifest-path crates/betanet-ffi/Cargo.toml` *(fails: failed to parse manifest for dependency `betanet-htx`)*


------
https://chatgpt.com/codex/tasks/task_e_68a37d2b3c9c832c8f2d842714837a5f