### PR TITLE
feat(htx): add ECH DNS resolution

### DIFF
--- a/crates/betanet-htx/Cargo.toml
+++ b/crates/betanet-htx/Cargo.toml
@@ -44,8 +44,8 @@ webpki-roots = { workspace = true }
 base64 = "0.21"
 urlencoding = "2.1"
 hex = "0.4"
-# Optional QUIC DNS resolver (disabled)
-# trust-dns-resolver = { version = "0.23", optional = true }
+trust-dns-resolver = { version = "0.23", optional = true, default-features = false, features = ["tokio-runtime", "system-config"] }
+once_cell = "1.19"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
@@ -58,7 +58,7 @@ rand_distr = "0.4"
 [features]
 default = ["tcp", "noise-xk"]
 tcp = []
-quic = ["dep:quinn", "dep:rcgen"]
+quic = ["dep:quinn", "dep:rcgen", "dep:trust-dns-resolver"]
 noise-xk = []
 hybrid-kem-stub = []
 tls-fingerprint = []


### PR DESCRIPTION
## Summary
- add trust-dns based ECH TXT lookup with caching and validation
- enable trust-dns-resolver and once_cell dependencies for QUIC

## Testing
- `cargo check -p betanet-htx --features quic` *(fails: `workspace.dependencies` was not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a380697f88832ca4d6142bd7ee0351