### PR TITLE
Use syn AST parsing for unsafe code rule

### DIFF
--- a/clients/rust/betanet-linter/Cargo.toml
+++ b/clients/rust/betanet-linter/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 regex = "1.10"
 async-trait = "0.1"
 once_cell = { workspace = true }
+syn = { version = "2", features = ["full", "visit"] }
 
 # For SBOM generation
 toml = "0.8"


### PR DESCRIPTION
## Summary
- use `syn` to parse files and detect `unsafe` blocks or functions
- add tests for unsafe detection and ignore false positives
- include `syn` crate dependency

## Testing
- `cargo test -p betanet-linter --lib` *(fails: failed to load manifest due to missing workspace member)*


------
https://chatgpt.com/codex/tasks/task_e_68a38a2695b0832cae3eab85e0a6015f