### PR TITLE
feat: parallel sbom hashing

### DIFF
--- a/clients/rust/betanet-linter/Cargo.toml
+++ b/clients/rust/betanet-linter/Cargo.toml
@@ -28,6 +28,7 @@ cargo_metadata = "0.18"
 uuid = { version = "1.10", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = { workspace = true }
+rayon = "1.10"
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
## Summary
- hash SBOM files in parallel using rayon and stable ordering
- add performance stress test for large directory trees

## Testing
- `cargo test -p betanet-linter` *(fails: failed to load manifest for workspace member `/workspace/AIVillage/crates/betanet-ffi`)*
- `cargo test` in crate *(fails: error inheriting `anyhow` from workspace root manifest's `workspace.dependencies.anyhow`)*

------
https://chatgpt.com/codex/tasks/task_e_68a38a2f8df4832ca41f542c77fe67ba