### PR TITLE
Use trusted roots for QUIC client

### DIFF
--- a/clients/rust/betanet-htx/src/client.rs
+++ b/clients/rust/betanet-htx/src/client.rs
@@ -36,7 +36,7 @@ impl HtxClient {
 
         #[cfg(feature = "quic")]
         if self.config.enable_quic {
-            let conn = crate::quic::QuicTransport::connect(addr, &self.config).await?;
+            let conn = crate::quic::QuicTransport::connect(addr, &self.config, None).await?;
             self.connection = Some(Arc::new(RwLock::new(Box::new(conn))));
             return Ok(());
         }

--- a/clients/rust/betanet-htx/tests/quic_invalid_cert.rs
+++ b/clients/rust/betanet-htx/tests/quic_invalid_cert.rs
@@ -1,0 +1,29 @@
+#![cfg(feature = "quic")]
+use betanet_htx::quic::QuicTransport;
+use betanet_htx::HtxConfig;
+use std::net::SocketAddr;
+use tokio::time::{sleep, Duration};
+
+#[tokio::test]
+async fn rejects_untrusted_certificate() {
+    let addr: SocketAddr = "127.0.0.1:14444".parse().unwrap();
+
+    let mut server_cfg = HtxConfig::default();
+    server_cfg.listen_addr = addr;
+    server_cfg.enable_quic = true;
+
+    let handle = tokio::spawn(async move {
+        let _ = QuicTransport::listen(server_cfg, |_| {}).await;
+    });
+
+    sleep(Duration::from_millis(100)).await;
+
+    let client_cfg = HtxConfig::default();
+    let res = QuicTransport::connect(addr, &client_cfg, None).await;
+    assert!(
+        res.is_err(),
+        "connection with invalid certificate succeeded"
+    );
+
+    handle.abort();
+}


### PR DESCRIPTION
## Summary
- remove insecure certificate verifier from QUIC transport
- load webpki root certificates and allow custom verifier when connecting
- add test to ensure connections fail with invalid certificates

## Testing
- `cargo test --manifest-path clients/rust/betanet-htx/Cargo.toml --features quic` *(fails: `error inheriting bincode from workspace root manifest's workspace.dependencies.bincode`)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1d289fc832c97bb79b1984be8d2