### PR TITLE
use size_t for FFI buffer lengths

### DIFF
--- a/clients/rust/betanet-ffi/examples/htx_example.c
+++ b/clients/rust/betanet-ffi/examples/htx_example.c
@@ -50,7 +50,7 @@ int main() {
         return 1;
     }
 
-    printf("Frame encoded: %u bytes\n", encoded_frame.len);
+    printf("Frame encoded: %zu bytes\n", encoded_frame.len);
 
     // Decode frame back
     printf("\nDecoding frame...\n");
@@ -72,7 +72,7 @@ int main() {
     result = htx_frame_payload(decoded_frame, &decoded_payload);
     if (result == betanet_Success) {
         printf("  Payload: ");
-        for (unsigned int i = 0; i < decoded_payload.len; i++) {
+        for (size_t i = 0; i < decoded_payload.len; i++) {
             printf("%c", decoded_payload.data[i]);
         }
         printf("\n");

--- a/clients/rust/betanet-ffi/examples/linter_example.c
+++ b/clients/rust/betanet-ffi/examples/linter_example.c
@@ -96,11 +96,11 @@ int main() {
 
     if (result == betanet_Success) {
         printf("SBOM generated successfully!\n");
-        printf("SBOM size: %u bytes\n", sbom_json.len);
+        printf("SBOM size: %zu bytes\n", sbom_json.len);
 
         // Show first 200 characters of SBOM
         printf("SBOM preview:\n");
-        for (unsigned int i = 0; i < 200 && i < sbom_json.len; i++) {
+        for (size_t i = 0; i < 200 && i < sbom_json.len; i++) {
             printf("%c", sbom_json.data[i]);
         }
         if (sbom_json.len > 200) {
@@ -121,7 +121,7 @@ int main() {
 
     if (result == betanet_Success) {
         printf("CycloneDX SBOM generated successfully!\n");
-        printf("SBOM size: %u bytes\n", sbom_json.len);
+        printf("SBOM size: %zu bytes\n", sbom_json.len);
         betanet_buffer_free(sbom_json);
     } else {
         printf("Failed to generate CycloneDX SBOM: %s\n", betanet_error_message(result));

--- a/clients/rust/betanet-ffi/examples/minimal_example.c
+++ b/clients/rust/betanet-ffi/examples/minimal_example.c
@@ -31,7 +31,7 @@ int main() {
     BetanetResult result = betanet_echo("Hello from C!", &echo_output);
     if (result == BETANET_SUCCESS) {
         printf("Echo result: ");
-        for (uint32_t i = 0; i < echo_output.len; i++) {
+        for (size_t i = 0; i < echo_output.len; i++) {
             printf("%c", echo_output.data[i]);
         }
         printf("\n");
@@ -45,10 +45,10 @@ int main() {
     printf("Testing buffer allocation...\n");
     BetanetBuffer test_buffer = betanet_buffer_alloc(100);
     if (test_buffer.data != NULL && test_buffer.len == 100) {
-        printf("Buffer allocated successfully: %u bytes\n", test_buffer.len);
+        printf("Buffer allocated successfully: %zu bytes\n", test_buffer.len);
 
         // Fill buffer with test data
-        for (uint32_t i = 0; i < test_buffer.len; i++) {
+        for (size_t i = 0; i < test_buffer.len; i++) {
             test_buffer.data[i] = (uint8_t)(i % 256);
         }
 
@@ -71,15 +71,15 @@ int main() {
     BetanetBuffer encoded_packet;
     result = betanet_packet_encode(input_buffer, &encoded_packet);
     if (result == BETANET_SUCCESS) {
-        printf("Packet encoded: %u bytes\n", encoded_packet.len);
+        printf("Packet encoded: %zu bytes\n", encoded_packet.len);
 
         // Decode packet
         BetanetBuffer decoded_packet;
         result = betanet_packet_decode(encoded_packet, &decoded_packet);
         if (result == BETANET_SUCCESS) {
-            printf("Packet decoded: %u bytes\n", decoded_packet.len);
+            printf("Packet decoded: %zu bytes\n", decoded_packet.len);
             printf("Decoded content: ");
-            for (uint32_t i = 0; i < decoded_packet.len; i++) {
+            for (size_t i = 0; i < decoded_packet.len; i++) {
                 printf("%c", decoded_packet.data[i]);
             }
             printf("\n");

--- a/clients/rust/betanet-ffi/examples/mixnode_example.c
+++ b/clients/rust/betanet-ffi/examples/mixnode_example.c
@@ -94,7 +94,7 @@ int main() {
         return 1;
     }
 
-    printf("Packet encoded: %u bytes\n", encoded_packet.len);
+    printf("Packet encoded: %zu bytes\n", encoded_packet.len);
 
     // Process packet through mixnode
     printf("\nProcessing packet through mixnode...\n");
@@ -104,7 +104,7 @@ int main() {
         fprintf(stderr, "Failed to process packet: %s\n", betanet_error_message(result));
     } else {
         if (output_packet.len > 0) {
-            printf("Packet forwarded: %u bytes\n", output_packet.len);
+            printf("Packet forwarded: %zu bytes\n", output_packet.len);
             betanet_buffer_free(output_packet);
         } else {
             printf("Packet consumed (final destination or dropped)\n");

--- a/clients/rust/betanet-ffi/examples/utls_example.c
+++ b/clients/rust/betanet-ffi/examples/utls_example.c
@@ -57,7 +57,7 @@ int main() {
     betanet_Result result = utls_ja3_generate(ja3_gen, client_hello, &ja3_fingerprint);
     if (result == betanet_Success) {
         printf("JA3 fingerprint: ");
-        for (unsigned int i = 0; i < ja3_fingerprint.len; i++) {
+        for (size_t i = 0; i < ja3_fingerprint.len; i++) {
             printf("%c", ja3_fingerprint.data[i]);
         }
         printf("\n");
@@ -81,7 +81,7 @@ int main() {
     result = utls_ja4_generate(ja4_gen, client_hello, 0, &ja4_fingerprint); // 0 = TCP
     if (result == betanet_Success) {
         printf("JA4 fingerprint (TCP): ");
-        for (unsigned int i = 0; i < ja4_fingerprint.len; i++) {
+        for (size_t i = 0; i < ja4_fingerprint.len; i++) {
             printf("%c", ja4_fingerprint.data[i]);
         }
         printf("\n");
@@ -94,7 +94,7 @@ int main() {
     result = utls_ja4_generate(ja4_gen, client_hello, 1, &ja4_fingerprint); // 1 = QUIC
     if (result == betanet_Success) {
         printf("JA4 fingerprint (QUIC): ");
-        for (unsigned int i = 0; i < ja4_fingerprint.len; i++) {
+        for (size_t i = 0; i < ja4_fingerprint.len; i++) {
             printf("%c", ja4_fingerprint.data[i]);
         }
         printf("\n");
@@ -115,7 +115,7 @@ int main() {
         betanet_Buffer generated_client_hello;
         result = utls_template_generate_client_hello(template, "example.com", &generated_client_hello);
         if (result == betanet_Success) {
-            printf("Generated ClientHello: %u bytes\n", generated_client_hello.len);
+            printf("Generated ClientHello: %zu bytes\n", generated_client_hello.len);
             betanet_buffer_free(generated_client_hello);
         } else {
             printf("Failed to generate ClientHello: %s\n", betanet_error_message(result));

--- a/clients/rust/betanet-ffi/include/betanet.h
+++ b/clients/rust/betanet-ffi/include/betanet.h
@@ -38,8 +38,8 @@ typedef BetanetResult betanet_Result;
 /* Buffer structure for passing data between C and Rust */
 typedef struct {
     uint8_t *data;
-    uint32_t len;
-    uint32_t capacity;
+    size_t len;
+    size_t capacity;
 } BetanetBuffer;
 
 typedef BetanetBuffer betanet_Buffer;
@@ -99,7 +99,7 @@ void betanet_cleanup(void);
 const char* betanet_version(void);
 BetanetResult betanet_feature_supported(const char* feature);
 void betanet_buffer_free(BetanetBuffer buffer);
-BetanetBuffer betanet_buffer_alloc(uint32_t size);
+BetanetBuffer betanet_buffer_alloc(size_t size);
 const char* betanet_error_message(BetanetResult result);
 BetanetResult betanet_packet_encode(BetanetBuffer input, BetanetBuffer* output);
 BetanetResult betanet_packet_decode(BetanetBuffer input, BetanetBuffer* output);


### PR DESCRIPTION
## Summary
- use `size_t` for buffer lengths and capacity in C header
- switch Rust FFI buffer fields and allocation to `usize`
- adjust C examples to print and iterate with `size_t`

## Testing
- `make test` *(fails: failed to load manifest for workspace member `/workspace/AIVillage/crates/betanet-ffi`)*
- `make examples` *(fails: `/usr/bin/ld: cannot find -lbetanet_ffi`)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1ecc084832c948964ec4b0e4f8b