### PR TITLE
Use monotonic clock for transport activity

### DIFF
--- a/packages/p2p/core/transport_manager.py
+++ b/packages/p2p/core/transport_manager.py
@@ -11,11 +11,11 @@ transport systems, unified into a single coherent interface.
 
 import asyncio
 import logging
-import time
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
+from time import monotonic
 from typing import Any
 
 from .message_types import MessagePriority, UnifiedMessage
@@ -150,7 +150,7 @@ class TransportManager:
             "transport_failures": defaultdict(int),
             "routing_decisions": defaultdict(int),
             "chunk_reassemblies": 0,
-            "last_activity": time.time(),
+            "last_activity": monotonic(),
         }
 
         # Configuration
@@ -327,7 +327,7 @@ class TransportManager:
         if success:
             self.stats["messages_sent"] += 1
             self.stats["bytes_sent"] += message.size_bytes
-            self.stats["last_activity"] = time.time()
+            self.stats["last_activity"] = monotonic()
             return True
 
         # Try fallback transports
@@ -337,7 +337,7 @@ class TransportManager:
             if success:
                 self.stats["messages_sent"] += 1
                 self.stats["bytes_sent"] += message.size_bytes
-                self.stats["last_activity"] = time.time()
+                self.stats["last_activity"] = monotonic()
                 return True
 
         logger.error("Failed to send message via all available transports")
@@ -414,7 +414,7 @@ class TransportManager:
 
         self.stats["messages_received"] += 1
         self.stats["bytes_received"] += message.size_bytes
-        self.stats["last_activity"] = time.time()
+        self.stats["last_activity"] = monotonic()
 
         # Handle chunked messages
         if message.is_chunked:

--- a/tests/htx/test_transport.py
+++ b/tests/htx/test_transport.py
@@ -66,8 +66,9 @@ class TestHTXStream:
         assert stream.flow_control_window == 65536  # Default 64KB
         assert stream.data_received == b""
         assert stream.data_to_send == b""
-        assert stream.created_at <= time.time()
-        assert stream.last_activity <= time.time()
+        now = time.monotonic()
+        assert stream.created_at <= now
+        assert stream.last_activity <= now
 
     def test_stream_with_custom_values(self):
         """Test stream with custom values."""

--- a/tests/integration/test_real_agent_communication.py
+++ b/tests/integration/test_real_agent_communication.py
@@ -320,7 +320,7 @@ class TestRealAgentCommunication:
                     self.metrics["average_response_time"] = (
                         self.metrics["total_processing_time"] / self.metrics["tasks_completed"]
                     )
-                    self.metrics["last_activity"] = time.time()
+                    self.metrics["last_activity"] = time.monotonic()
 
                     # Calculate success rate
                     total_attempts = self.metrics["tasks_completed"] + self.metrics["errors_count"]
@@ -337,7 +337,7 @@ class TestRealAgentCommunication:
                     self.metrics["errors_count"] += 1
                     total_attempts = self.metrics["tasks_completed"] + self.metrics["errors_count"]
                     self.metrics["success_rate"] = self.metrics["tasks_completed"] / total_attempts
-                    self.metrics["last_activity"] = time.time()
+                    self.metrics["last_activity"] = time.monotonic()
 
                     return {
                         "status": "error",


### PR DESCRIPTION
## Summary
- track transport manager last activity using `time.monotonic()`
- adjust tests to accommodate monotonic-based activity timing

## Testing
- `pre-commit run --files packages/p2p/core/transport_manager.py tests/htx/test_transport.py tests/integration/test_real_agent_communication.py`
- `pytest tests/integration/test_real_agent_communication.py -q`
- `pytest tests/htx/test_transport.py -q` *(fails: ModuleNotFoundError: No module named 'core.p2p')*

------
https://chatgpt.com/codex/tasks/task_e_68a656d8c4fc832ca3567b0bf186ebff