### PR TITLE
feat(p2p): base64 encode unified message payloads

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@
 - EvoMerge integration for 30× faster iteration with pre-optimized seed models
 - Added `digital_twin` module, increasing core module count to 17.
 
+### Changed
+- P2P UnifiedMessage payloads now use base64 encoding instead of hex for interoperability with existing transports.
+
 ## [1.0.0] - 2025-07-27
 ### Added
 - **Sprint 2 Complete**: Production/experimental separation with quality gates

--- a/packages/p2p/core/message_types.py
+++ b/packages/p2p/core/message_types.py
@@ -2,9 +2,11 @@
 Unified message types and formats for P2P communication.
 
 Provides standardized message formats that work across all transport types
-including BitChat, BetaNet, and direct QUIC connections.
+including BitChat, BetaNet, and direct QUIC connections. Payloads are
+base64-encoded to maintain interoperability across different transports.
 """
 
+import base64
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -119,7 +121,7 @@ class UnifiedMessage:
         """Convert message to dictionary for serialization."""
         return {
             "message_type": self.message_type.value,
-            "payload": self.payload.hex(),  # Hex encode for JSON safety
+            "payload": base64.b64encode(self.payload).decode("utf-8"),  # Base64 encode for transport interoperability
             "metadata": {
                 "message_id": self.metadata.message_id,
                 "correlation_id": self.metadata.correlation_id,
@@ -173,7 +175,7 @@ class UnifiedMessage:
 
         return cls(
             message_type=MessageType(data["message_type"]),
-            payload=bytes.fromhex(data["payload"]),
+            payload=base64.b64decode(data["payload"]),
             metadata=metadata,
             chunk_index=data["chunk_index"],
             total_chunks=data["total_chunks"],


### PR DESCRIPTION
## Summary
- encode UnifiedMessage payloads using base64 instead of hex
- decode base64 payloads when rebuilding messages
- document base64 encoding in changelog for transport interoperability

## Implementation Notes
- import `base64` and swap hex helpers for base64 equivalents
- update module docstring to highlight interoperability

## Tradeoffs
- base64 is slightly less compact than binary but avoids hex overhead and matches transport expectations

## Tests Added
- none

## Local Run Logs (optional)
- `ruff check . --no-fix | head -n 20`
- `ruff format --check . | head -n 20`
- `mypy .`
- `pytest -q` *(fails: No module named 'pytest_asyncio')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: No module named 'pytest_asyncio')*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68a656ed9fcc832c9350ccee9fdd7538