### PR TITLE
Use env vars for credentials and add missing checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Sample environment variables for AIVillage
+OPENAI_API_KEY=
+NEO4J_URI=
+NEO4J_USER=
+NEO4J_PASSWORD=
+DATABASE_URL=
+MCP_SERVER_SECRET=
+

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -6,8 +6,13 @@ before starting the services.
 
 Required variables:
 
-- `POSTGRES_PASSWORD` – password for the PostgreSQL credits database
+- `OPENAI_API_KEY` – API key for OpenAI access
+- `NEO4J_URI` – connection URI for the Neo4j graph database
+- `NEO4J_USER` – username for the Neo4j graph database
 - `NEO4J_PASSWORD` – password for the Neo4j graph database
+- `DATABASE_URL` – connection string for the credits ledger database
+- `MCP_SERVER_SECRET` – secret used to secure MCP server tokens
+- `POSTGRES_PASSWORD` – password for the PostgreSQL credits database
 - `REDIS_PASSWORD` – password for the Redis instance
 - `GRAFANA_PASSWORD` – admin password for Grafana
 - `HYPERAG_JWT_SECRET` – secret used to sign HyperRAG JWT tokens
@@ -15,8 +20,13 @@ Required variables:
 Example `.env` file:
 
 ```dotenv
-POSTGRES_PASSWORD=change-me
+OPENAI_API_KEY=change-me
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
 NEO4J_PASSWORD=change-me
+DATABASE_URL=postgresql://user:password@localhost/aivillage
+MCP_SERVER_SECRET=change-me-change-me-change-me-change-me
+POSTGRES_PASSWORD=change-me
 REDIS_PASSWORD=change-me
 GRAFANA_PASSWORD=change-me
 HYPERAG_JWT_SECRET=change-me

--- a/packages/core/experimental/agents/agents/utils/configuration.py
+++ b/packages/core/experimental/agents/agents/utils/configuration.py
@@ -1,5 +1,3 @@
-# agents/langroid/utils/configuration.py
-
 """Utility classes for handling application configuration."""
 
 from __future__ import annotations
@@ -8,17 +6,17 @@ import json
 from pathlib import Path
 from typing import Any
 
+from pydantic import BaseSettings, Field
 import yaml
-from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables or a file."""
 
-    openai_api_key: str = ""
-    neo4j_uri: str = "bolt://localhost:7687"
-    neo4j_user: str = "neo4j"
-    neo4j_password: str = "password"
+    openai_api_key: str = Field(..., env="OPENAI_API_KEY")
+    neo4j_uri: str = Field(..., env="NEO4J_URI")
+    neo4j_user: str = Field(..., env="NEO4J_USER")
+    neo4j_password: str = Field(..., env="NEO4J_PASSWORD")
 
     class Config:
         env_prefix = ""

--- a/packages/p2p/communications/credits_ledger.py
+++ b/packages/p2p/communications/credits_ledger.py
@@ -1,9 +1,9 @@
 """Credits Ledger MVP - Fixed-supply shell currency with Prometheus-based earning."""
 
-import logging
-import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
+import logging
+import os
 
 from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint, create_engine
 from sqlalchemy.exc import IntegrityError
@@ -146,8 +146,11 @@ class EarningResponse:
 
 
 class CreditsConfig:
-    def __init__(self) -> None:
-        self.database_url = os.getenv("DATABASE_URL", "postgresql://user:password@localhost/aivillage")
+    def __init__(self, database_url: str | None = None) -> None:
+        self.database_url = database_url or os.getenv("DATABASE_URL")
+        if not self.database_url:
+            msg = "DATABASE_URL environment variable is required"
+            raise RuntimeError(msg)
         self.burn_rate = 0.01  # 1% burn on spend
         self.fixed_supply = 1_000_000_000  # 1 billion credits max supply
         self.earning_rate_flops = 1000  # credits per GFLOP

--- a/packages/rag/mcp_servers/hyperag/mcp_server.py
+++ b/packages/rag/mcp_servers/hyperag/mcp_server.py
@@ -46,9 +46,12 @@ class HypeRAGMCPServer:
             import os
 
             jwt_secret = os.getenv("MCP_SERVER_SECRET")
-            if not jwt_secret or len(jwt_secret) < 32:
-                logger.warning("Using default MCP secret - CHANGE IN PRODUCTION!")
-                jwt_secret = "INSECURE_DEFAULT_MCP_SECRET_CHANGE_IMMEDIATELY_IN_PRODUCTION"
+            if not jwt_secret:
+                msg = "MCP_SERVER_SECRET environment variable is required"
+                raise RuntimeError(msg)
+            if len(jwt_secret) < 32:
+                msg = "MCP_SERVER_SECRET must be at least 32 characters"
+                raise RuntimeError(msg)
 
             self.permission_manager = PermissionManager(jwt_secret=jwt_secret, enable_audit=False)
 

--- a/tests/test_credits_api.py
+++ b/tests/test_credits_api.py
@@ -1,13 +1,14 @@
 """Unit tests for credits API endpoints."""
 
+from datetime import UTC, datetime
 import os
 import tempfile
-from datetime import UTC, datetime
 
+from fastapi.testclient import TestClient
 import pytest
+
 from communications.credits_api import app, get_ledger
 from communications.credits_ledger import CreditsConfig, CreditsLedger
-from fastapi.testclient import TestClient
 
 
 @pytest.fixture
@@ -25,8 +26,7 @@ def temp_db():
 @pytest.fixture
 def test_config(temp_db):
     """Create test configuration."""
-    config = CreditsConfig()
-    config.database_url = temp_db
+    config = CreditsConfig(database_url=temp_db)
     config.burn_rate = 0.01
     config.fixed_supply = 1000000
     return config

--- a/tests/test_credits_ledger.py
+++ b/tests/test_credits_ledger.py
@@ -1,10 +1,11 @@
 """Unit tests for credits ledger functionality."""
 
+from datetime import UTC, datetime
 import os
 import tempfile
-from datetime import UTC, datetime
 
 import pytest
+
 from communications.credits_ledger import CreditsConfig, CreditsLedger, Wallet
 
 
@@ -23,8 +24,7 @@ def temp_db():
 @pytest.fixture
 def test_config(temp_db):
     """Create test configuration."""
-    config = CreditsConfig()
-    config.database_url = temp_db
+    config = CreditsConfig(database_url=temp_db)
     config.burn_rate = 0.01
     config.fixed_supply = 1000000
     config.earning_rate_flops = 1000

--- a/tests/test_missing_credentials.py
+++ b/tests/test_missing_credentials.py
@@ -1,0 +1,56 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+from pydantic import ValidationError
+import pytest
+
+
+def _load_module(relative_path: str, name: str):
+    path = pathlib.Path(__file__).resolve().parent.parent / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_settings_missing_env(monkeypatch):
+    for var in ["OPENAI_API_KEY", "NEO4J_URI", "NEO4J_USER", "NEO4J_PASSWORD"]:
+        monkeypatch.delenv(var, raising=False)
+    module = _load_module("packages/core/experimental/agents/agents/utils/configuration.py", "configuration")
+    Settings = module.Settings
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_credits_config_missing_env(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    module = _load_module("packages/p2p/communications/credits_ledger.py", "credits_ledger")
+    CreditsConfig = module.CreditsConfig
+    with pytest.raises(RuntimeError):
+        CreditsConfig()
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_missing_secret(monkeypatch):
+    monkeypatch.delenv("MCP_SERVER_SECRET", raising=False)
+
+    software = types.ModuleType("software")
+    hyper_rag = types.ModuleType("software.hyper_rag")
+    hyper_pipeline = types.ModuleType("software.hyper_rag.hyper_rag_pipeline")
+
+    class HyperRAGPipeline:  # pragma: no cover - simple stub
+        pass
+
+    hyper_pipeline.HyperRAGPipeline = HyperRAGPipeline
+    sys.modules["software"] = software
+    sys.modules["software.hyper_rag"] = hyper_rag
+    sys.modules["software.hyper_rag.hyper_rag_pipeline"] = hyper_pipeline
+
+    module = _load_module("packages/rag/mcp_servers/hyperag/mcp_server.py", "mcp_server")
+    HypeRAGMCPServer = module.HypeRAGMCPServer
+    server = HypeRAGMCPServer()
+    with pytest.raises(RuntimeError):
+        await server.initialize()

--- a/tests/unit/test_credits_api.py
+++ b/tests/unit/test_credits_api.py
@@ -1,13 +1,14 @@
 """Unit tests for credits API endpoints."""
 
+from datetime import UTC, datetime
 import os
 import tempfile
-from datetime import UTC, datetime
 
+from fastapi.testclient import TestClient
 import pytest
+
 from communications.credits_api import app, get_ledger
 from communications.credits_ledger import CreditsConfig, CreditsLedger
-from fastapi.testclient import TestClient
 
 
 @pytest.fixture
@@ -25,8 +26,7 @@ def temp_db():
 @pytest.fixture
 def test_config(temp_db):
     """Create test configuration."""
-    config = CreditsConfig()
-    config.database_url = temp_db
+    config = CreditsConfig(database_url=temp_db)
     config.burn_rate = 0.01
     config.fixed_supply = 1000000
     return config

--- a/tests/unit/test_credits_ledger.py
+++ b/tests/unit/test_credits_ledger.py
@@ -1,10 +1,11 @@
 """Unit tests for credits ledger functionality."""
 
+from datetime import UTC, datetime
 import os
 import tempfile
-from datetime import UTC, datetime
 
 import pytest
+
 from communications.credits_ledger import CreditsConfig, CreditsLedger, Wallet
 
 
@@ -23,8 +24,7 @@ def temp_db():
 @pytest.fixture
 def test_config(temp_db):
     """Create test configuration."""
-    config = CreditsConfig()
-    config.database_url = temp_db
+    config = CreditsConfig(database_url=temp_db)
     config.burn_rate = 0.01
     config.fixed_supply = 1000000
     config.earning_rate_flops = 1000


### PR DESCRIPTION
## Summary
- enforce environment-based configuration for OpenAI, Neo4j, credits DB, and MCP server
- document required environment variables
- add tests confirming failures when credentials are absent

## Implementation Notes
- replaced hardcoded secrets with `Field(..., env=...)` and explicit runtime checks
- added `.env.example` and updated deployment docs
- created `test_missing_credentials.py` to verify fail-fast behavior

## Tradeoffs
- full linting and formatting checks fail due to numerous pre-existing issues
- pytest suite cannot run without `pytest_asyncio` plugin

## Tests Added
- tests for missing OpenAI/Neo4j/DATABASE_URL/MCP_SERVER_SECRET variables

## Local Run Logs
- `ruff check .` *(fails: undefined names in unrelated tests)*
- `ruff format --check .` *(fails: many files would be reformatted)*
- `mypy .` *(fails: aivillage-module is not a valid Python package name)*
- `pytest -q` *(fails: No module named 'pytest_asyncio')*
- `pytest -q tests/p2p/test_dual_path.py -q` *(fails: No module named 'pytest_asyncio')*
- `pytest -q tests/test_orchestrator_integration.py -q` *(fails: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68a66ce8afb4832cb2651fd1ca1579f5