### PR TITLE
Secure JWT verification for fog jobs

### DIFF
--- a/tests/unit/test_jobs_jwt.py
+++ b/tests/unit/test_jobs_jwt.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timedelta
+import os
+import sys
+import types
+
+import jwt
+import pytest
+from fastapi import HTTPException
+
+from packages.fog.gateway.api.jobs import JobsAPI
+
+
+@pytest.fixture
+def jobs_api(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "testsecret")
+    dummy_module = types.ModuleType("packages.core.security.rbac_system")
+
+    class DummyPermission:
+        FOG_JOB_SUBMIT = "fog.job.submit"
+
+    class DummyRBACSystem:
+        async def check_permission(self, user_id, permission):
+            return True
+
+    dummy_module.Permission = DummyPermission
+    dummy_module.RBACSystem = DummyRBACSystem
+    monkeypatch.setitem(sys.modules, "packages.core.security.rbac_system", dummy_module)
+    return JobsAPI()
+
+
+@pytest.mark.asyncio
+async def test_validate_job_permissions_valid_token(jobs_api):
+    token = jwt.encode(
+        {"user_id": "user1", "exp": datetime.utcnow() + timedelta(minutes=5)},
+        os.getenv("JWT_SECRET"),
+        algorithm="HS256",
+    )
+    await jobs_api._validate_job_permissions("user1", f"Bearer {token}", "org/team")
+
+
+@pytest.mark.asyncio
+async def test_validate_job_permissions_expired_token(jobs_api):
+    token = jwt.encode(
+        {"user_id": "user1", "exp": datetime.utcnow() - timedelta(minutes=5)},
+        os.getenv("JWT_SECRET"),
+        algorithm="HS256",
+    )
+    with pytest.raises(HTTPException) as exc:
+        await jobs_api._validate_job_permissions("user1", f"Bearer {token}", "org/team")
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_validate_job_permissions_tampered_token(jobs_api):
+    token = jwt.encode(
+        {"user_id": "user1", "exp": datetime.utcnow() + timedelta(minutes=5)},
+        os.getenv("JWT_SECRET"),
+        algorithm="HS256",
+    )
+    tampered = token + "a"
+    with pytest.raises(HTTPException) as exc:
+        await jobs_api._validate_job_permissions("user1", f"Bearer {tampered}", "org/team")
+    assert exc.value.status_code == 403


### PR DESCRIPTION
## Summary
- require JWT signature verification using secret from configuration
- add tests for valid, expired, and tampered tokens

## Testing
- `pytest tests/unit/test_jobs_jwt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66ce9f2d8832ca88cab4b232d05be