### PR TITLE
Safely evaluate calculator expressions

### DIFF
--- a/tests/unit/test_calculator_tool.py
+++ b/tests/unit/test_calculator_tool.py
@@ -1,0 +1,16 @@
+from packages.agent_forge.phases.tool_persona_baking import ToolIntegrationSystem
+
+
+def test_calculator_tool_valid_expression():
+    system = ToolIntegrationSystem(None)
+    result = system._calculator_tool("2 + 3 * 4")
+    assert result["success"] is True
+    assert result["result"] == "14"
+
+
+def test_calculator_tool_malicious_expression():
+    system = ToolIntegrationSystem(None)
+    expr = "2 + __import__('os').system('echo hacked')"
+    result = system._calculator_tool(expr)
+    assert result["success"] is True
+    assert result["result"] == f"Mathematical expression: {expr}"


### PR DESCRIPTION
## Summary
- Replace `eval` with an AST-based safe evaluator and strict input validation for calculator tool
- Define allowed math operators and validate expressions before execution
- Add unit tests covering valid math and malicious payloads

## Testing
- `pytest tests/unit/test_calculator_tool.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a66ceb2058832ca7c20d6cce34bb82