### PR TITLE
refactor serializer to use whitelist mapping

### DIFF
--- a/tests/security/test_secure_serializer_types.py
+++ b/tests/security/test_secure_serializer_types.py
@@ -1,0 +1,25 @@
+import pytest
+
+from packages.core.legacy.security.secure_serializer import SecureSerializer
+
+
+@pytest.mark.parametrize(
+    "type_name,value",
+    [
+        ("str", "hello"),
+        ("int", 1),
+        ("float", 1.5),
+        ("bool", True),
+    ],
+)
+def test_restore_data_allowed_types(type_name, value):
+    serializer = SecureSerializer()
+    data = {"__type__": type_name, "__value__": value}
+    assert serializer._restore_data(data) == value
+
+
+def test_restore_data_disallowed_type():
+    serializer = SecureSerializer()
+    data = {"__type__": "complex", "__value__": "1+2j"}
+    with pytest.raises(ValueError):
+        serializer._restore_data(data)


### PR DESCRIPTION
## Summary
- replace `eval` in `SecureSerializer` with a whitelist mapping for primitive types
- raise `ValueError` on unknown serialized types
- add tests for allowed and disallowed types in `_restore_data`

## Testing
- `pre-commit run --files packages/core/legacy/security/secure_serializer.py tests/security/test_secure_serializer_types.py`
- `pytest tests/security/test_secure_serializer_types.py`


------
https://chatgpt.com/codex/tasks/task_e_68a66cec3924832c81c614ce096366bb