### PR TITLE
Add creative search context to rag CLI

### DIFF
--- a/scripts/rag_cli.py
+++ b/scripts/rag_cli.py
@@ -79,6 +79,7 @@ async def query_system(text: str, mode: str) -> None:
     }
     retrieval_mode = mode_map.get(mode, RetrievalMode.BALANCED)
     query_type = query_type_map.get(mode, QueryType.FACTUAL)
+    context = QueryContext(enable_creative_search=(mode == "creative"))
 
     retrieve = getattr(system, "retrieve", system.query)
     try:
@@ -86,7 +87,7 @@ async def query_system(text: str, mode: str) -> None:
             text,
             query_type=query_type,
             retrieval_mode=retrieval_mode,
-            context=QueryContext(),
+            context=context,
         )
     except Exception as exc:  # pragma: no cover
         print(f"Query failed: {exc}")
@@ -132,7 +133,7 @@ def main() -> None:
         "--mode",
         choices=["creative", "balanced", "analytical"],
         default="balanced",
-        help="Retrieval mode to use",
+        help="Retrieval mode to use; 'creative' activates graph-based brainstorming",
     )
 
     sub.add_parser("detect-gaps", help="Detect missing knowledge graph nodes")


### PR DESCRIPTION
## Summary
- Enable creative search context in rag_cli's query mode, tying it to `--mode creative`
- Clarify CLI help that creative mode uses graph-based brainstorming

## Testing
- `python -m py_compile scripts/rag_cli.py`
- `pytest tests -k rag_cli -q` *(fails: No module named 'infrastructure.distributed_inference.federated_inference_coordinator')*

------
https://chatgpt.com/codex/tasks/task_e_68b86d025338832cbb9807a66de3d155