### PR TITLE
docs: add creative search and gap detection guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ AIVillage is a sophisticated multi-agent AI system with self-evolution capabilit
 ### Core Functionality
 - 🟡 **Agent Communication**: Protocol defined but end-to-end workflow needs validation
 - 🟡 **Unified Compression System**: Consolidated from 28+ fragmented implementations into a pipeline targeting 4×–100× compression ([documentation](src/production/compression/README.md))
-- 🟡 **RAG System**: Structure implemented; small benchmark of 5 queries averaged **1.509 ms** with 100% accuracy ([results](docs/benchmarks/rag_latency_results.json))
+- 🟡 **RAG System**: Structure implemented; small benchmark of 5 queries averaged **1.509 ms** with 100% accuracy ([results](docs/benchmarks/rag_latency_results.json)). See [creative search and gap detection guide](rag/creative_search_and_gap_detection.md).
 - 🟡 **Evolution System**: Simulation logic complete but real agent evolution needs testing
 - 🟡 **P2P Networking**: Basic implementation; 5-message localhost benchmark averaged **0.748 ms** round trip with 100% success ([results](docs/benchmarks/p2p_network_results.json))
 

--- a/docs/rag/creative_search_and_gap_detection.md
+++ b/docs/rag/creative_search_and_gap_detection.md
@@ -1,0 +1,56 @@
+# Creative Search and Gap Detection
+
+This guide shows how to explore knowledge graphs creatively and how to detect missing nodes or connections. It complements the [Unified RAG Module Structure](../unified_rag_module_structure.md).
+
+## CreativeGraphSearch patterns
+`CreativeGraphSearch` supports multiple patterns of divergent thinking:
+- **Analogical** – find analogies between distant concepts
+- **Combinatorial** – combine unrelated concepts
+- **Divergent** – explore multiple directions
+- **Associative** – follow loose associations
+- **Metaphorical** – create metaphorical connections
+- **Contrarian** – explore contrasting ideas
+
+### Example
+```python
+import networkx as nx
+from unified_rag.graph import CreativeGraphSearch, CreativityPattern
+
+G = nx.Graph()
+search = CreativeGraphSearch(G)
+session = await search.creative_brainstorm(
+    "sustainable energy",
+    creativity_patterns=[
+        CreativityPattern.ANALOGICAL,
+        CreativityPattern.COMBINATORIAL,
+    ],
+    num_insights=3,
+)
+for insight in session.generated_insights:
+    print(insight.insight_text)
+```
+
+Query the system in creative mode via CLI:
+```bash
+python scripts/rag_cli.py query "How does photosynthesis relate to solar panels?" --mode creative
+```
+
+## MissingNodeDetector
+`MissingNodeDetector` analyzes a graph and reports gaps such as missing concepts, missing connections, structural gaps and more. Typical output is a `GapAnalysis` with a `coverage_score`, recommendations and a list of `KnowledgeGap` entries containing gap type, description and suggested concepts or connections.
+
+### Example
+```python
+import networkx as nx
+from unified_rag.graph import MissingNodeDetector
+
+G = nx.Graph()
+detector = MissingNodeDetector(G)
+analysis = await detector.detect_missing_nodes()
+for gap in analysis.detected_gaps:
+    print(gap.gap_type, gap.description)
+```
+
+Run gap detection from the command line:
+```bash
+python scripts/rag_cli.py detect-gaps
+```

--- a/docs/unified_rag_module_structure.md
+++ b/docs/unified_rag_module_structure.md
@@ -14,3 +14,7 @@ This document summarizes the consolidation of legacy `core/rag` modules into the
 
 The legacy files in `core/rag` have been removed or reduced to thin wrappers that import from `unified_rag`.  New development should target the `unified_rag` package exclusively.
 
+
+## Related Documentation
+
+- [Creative Search and Gap Detection](rag/creative_search_and_gap_detection.md)


### PR DESCRIPTION
## Summary
- document CreativeGraphSearch patterns and MissingNodeDetector outputs
- show CLI usage for creative queries and gap detection
- link new guide from unified RAG docs and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'packages.agents.core.agent_interface')*


------
https://chatgpt.com/codex/tasks/task_e_68b86d0dcf1c832cb70b0c52a01a223c