### PR TITLE
docs: add hippo cache guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ AIVillage is a sophisticated multi-agent AI system with self-evolution capabilit
 ### Core Functionality
 - 🟡 **Agent Communication**: Protocol defined but end-to-end workflow needs validation
 - 🟡 **Unified Compression System**: Consolidated from 28+ fragmented implementations into a pipeline targeting 4×–100× compression ([documentation](src/production/compression/README.md))
-- 🟡 **RAG System**: Structure implemented; small benchmark of 5 queries averaged **1.509 ms** with 100% accuracy ([results](docs/benchmarks/rag_latency_results.json)). See [creative search and gap detection guide](rag/creative_search_and_gap_detection.md).
+  - 🟡 **RAG System**: Structure implemented; small benchmark of 5 queries averaged **1.509 ms** with 100% accuracy ([results](docs/benchmarks/rag_latency_results.json)). See [creative search and gap detection guide](rag/creative_search_and_gap_detection.md) and [HippoCache usage guide](rag/hippo_cache.md).
 - 🟡 **Evolution System**: Simulation logic complete but real agent evolution needs testing
 - 🟡 **P2P Networking**: Basic implementation; 5-message localhost benchmark averaged **0.748 ms** round trip with 100% success ([results](docs/benchmarks/p2p_network_results.json))
 

--- a/docs/rag/hippo_cache.md
+++ b/docs/rag/hippo_cache.md
@@ -1,0 +1,66 @@
+# HippoCache Usage Guide
+
+The `HippoCache` provides a high‑performance semantic cache for the unified RAG
+stack.  It stores embeddings and retrieved documents, evicting entries with an
+LRU policy and optional time‑to‑live.
+
+This guide complements the
+[Unified RAG Module Structure](../unified_rag_module_structure.md).
+
+## Configuration
+
+`HippoCache` can be tuned through its constructor:
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `max_size` | Maximum number of cached entries | `10_000` |
+| `ttl_hours` | Hours before an entry expires | `24` |
+| `similarity_threshold` | Minimum cosine similarity for a hit | `0.95` |
+
+## Cache API
+
+### `get(query_embedding)`
+Returns a `CacheEntry` whose embedding is above the similarity threshold or
+`None` if no suitable entry exists.
+
+### `set(key, entry)`
+Inserts or updates an entry keyed by `key`.  Embeddings are normalized and the
+cache respects the configured size limit.
+
+### `get_or_retrieve(key, query_embedding, retrieval_fn)`
+Attempts `get`; on a miss, `retrieval_fn` is invoked to fetch documents and
+scores, which are then cached under `key`.
+
+### `metrics()`
+Exposes basic performance metrics:
+
+```python
+{
+    "hit_rate": float,       # cache hits / total lookups
+    "avg_latency_ms": float, # mean lookup latency
+    "size": int,             # live entry count
+}
+```
+
+## Example Integration with `UnifiedRAGSystem`
+
+```python
+from datetime import datetime
+import numpy as np
+
+from unified_rag.core.unified_rag_system import UnifiedRAGSystem
+from integrations.clients.py_aivillage.rag.hippo_cache import CacheEntry
+
+rag = UnifiedRAGSystem()
+await rag.initialize()
+
+embedding = np.random.rand(768)
+
+def retrieve_docs():
+    # Domain‑specific retrieval logic
+    return ["doc"], [1.0], {"source": "demo"}
+
+entry = rag.cache.get_or_retrieve("demo", embedding, retrieve_docs)
+print(rag.cache.metrics())
+```
+

--- a/docs/unified_rag_module_structure.md
+++ b/docs/unified_rag_module_structure.md
@@ -18,3 +18,4 @@ The legacy files in `core/rag` have been removed or reduced to thin wrappers tha
 ## Related Documentation
 
 - [Creative Search and Gap Detection](rag/creative_search_and_gap_detection.md)
+- [HippoCache Usage Guide](rag/hippo_cache.md)


### PR DESCRIPTION
## Summary
- document HippoCache configuration and cache API
- link HippoCache guide from unified RAG docs and general README

## Testing
- `pre-commit run --files docs/rag/hippo_cache.md docs/unified_rag_module_structure.md docs/README.md --config config/enhanced-pre-commit-config.yaml` *(fails: pathspec 'v2.8.4' did not match)*
- `PYTHONPATH=integrations/clients/py-aivillage pytest tests/hyperrag/test_hippo_cache.py` *(fails: No module named 'hyperrag.hippo_cache')*


------
https://chatgpt.com/codex/tasks/task_e_68b8702eee7c832ca82db6573f7f6b43