### PR TITLE
fix: correct detect-secrets line continuations

### DIFF
--- a/.github/workflows/scion_production.yml
+++ b/.github/workflows/scion_production.yml
@@ -73,34 +73,34 @@ jobs:
             echo "Starting detect-secrets at: $(date)"
             if [ -f ".secrets.baseline" ]; then
               echo "Using secrets baseline file"
-              timeout 240 detect-secrets scan --baseline .secrets.baseline \\
-                --exclude-files 'tests/.*\.py$' \\
-                --exclude-files 'examples/.*\.py$' \\
-                --exclude-files '.*/analytics\.py$' \\
-                --exclude-files '.*/profiler\.py$' \\
-                --exclude-files '.*/optimization/.*\.py$' \\
-                --exclude-files '.*/experiments/.*\.py$' \\
-                --exclude-files '.*/integration/.*\.py$' \\
-                --exclude-files '.*/__pycache__/.*' \\
-                --exclude-files '.*/node_modules/.*' \\
-                --exclude-files '.*/\.git/.*' \\
-                --exclude-files '.*/target/.*' \\
-                --exclude-files '.*/build/.*' \\
-                --exclude-files '.*/dist/.*'
+                timeout 240 detect-secrets scan --baseline .secrets.baseline \
+                  --exclude-files 'tests/.*\.py$' \
+                  --exclude-files 'examples/.*\.py$' \
+                  --exclude-files '.*/analytics\.py$' \
+                  --exclude-files '.*/profiler\.py$' \
+                  --exclude-files '.*/optimization/.*\.py$' \
+                  --exclude-files '.*/experiments/.*\.py$' \
+                  --exclude-files '.*/integration/.*\.py$' \
+                  --exclude-files '.*/__pycache__/.*' \
+                  --exclude-files '.*/node_modules/.*' \
+                  --exclude-files '.*/\.git/.*' \
+                  --exclude-files '.*/target/.*' \
+                  --exclude-files '.*/build/.*' \
+                  --exclude-files '.*/dist/.*'
             else
               echo "No secrets baseline found, creating one and scanning"
-              timeout 240 detect-secrets scan \\
-                --exclude-files 'tests/.*\.py$' \\
-                --exclude-files 'examples/.*\.py$' \\
-                --exclude-files '.*/analytics\.py$' \\
-                --exclude-files '.*/profiler\.py$' \\
-                --exclude-files '.*/optimization/.*\.py$' \\
-                --exclude-files '.*/__pycache__/.*' \\
-                --exclude-files '.*/node_modules/.*' \\
-                --exclude-files '.*/\.git/.*' \\
-                --exclude-files '.*/target/.*' \\
-                --exclude-files '.*/build/.*' \\
-                --exclude-files '.*/dist/.*' \\
+              timeout 240 detect-secrets scan \
+                --exclude-files 'tests/.*\.py$' \
+                --exclude-files 'examples/.*\.py$' \
+                --exclude-files '.*/analytics\.py$' \
+                --exclude-files '.*/profiler\.py$' \
+                --exclude-files '.*/optimization/.*\.py$' \
+                --exclude-files '.*/__pycache__/.*' \
+                --exclude-files '.*/node_modules/.*' \
+                --exclude-files '.*/\.git/.*' \
+                --exclude-files '.*/target/.*' \
+                --exclude-files '.*/build/.*' \
+                --exclude-files '.*/dist/.*' \
                 --baseline .secrets.baseline
             fi
             exit_code=$?


### PR DESCRIPTION
## Summary
- fix detect-secrets step in Scion Production workflow to correctly pass exclude patterns

## Testing
- `pre-commit run --files .github/workflows/scion_production.yml` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `yamllint .github/workflows/scion_production.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b87588e99c832c971cfced1184d960