### PR TITLE
Increase detect-secrets scan timeout

### DIFF
--- a/.github/workflows/scion_production.yml
+++ b/.github/workflows/scion_production.yml
@@ -73,7 +73,7 @@ jobs:
             echo "Starting detect-secrets at: $(date)"
             if [ -f ".secrets.baseline" ]; then
               echo "Using secrets baseline file"
-                timeout 240 detect-secrets scan --baseline .secrets.baseline \
+                timeout 600 detect-secrets scan --baseline .secrets.baseline \
                   --exclude-files 'tests/.*\.py$' \
                   --exclude-files 'examples/.*\.py$' \
                   --exclude-files '.*/analytics\.py$' \
@@ -89,7 +89,7 @@ jobs:
                   --exclude-files '.*/dist/.*'
             else
               echo "No secrets baseline found, creating one and scanning"
-              timeout 240 detect-secrets scan \
+              timeout 600 detect-secrets scan \
                 --exclude-files 'tests/.*\.py$' \
                 --exclude-files 'examples/.*\.py$' \
                 --exclude-files '.*/analytics\.py$' \

--- a/scripts/security/adjust_workflow_timeouts.py
+++ b/scripts/security/adjust_workflow_timeouts.py
@@ -3,7 +3,7 @@
 Workflow Timeout Adjustment Script
 
 Adjusts the timeout values in the SCION production security workflow based on monitoring findings.
-Increases detect-secrets timeout from 300s to 600s to prevent timeout failures.
+Increases detect-secrets timeout from 240s to 600s to prevent timeout failures.
 
 Usage:
     python scripts/security/adjust_workflow_timeouts.py [--dry-run]
@@ -29,10 +29,10 @@ class WorkflowTimeoutAdjuster:
         # Timeout adjustments based on monitoring findings
         self.timeout_adjustments = [
             {
-                "description": "Increase detect-secrets timeout from 300s to 600s",
-                "pattern": r"timeout 300 detect-secrets scan",
+                "description": "Increase detect-secrets timeout from 240s to 600s",
+                "pattern": r"timeout 240 detect-secrets scan",
                 "replacement": r"timeout 600 detect-secrets scan",
-                "reason": "detect-secrets consistently timing out after 5 minutes"
+                "reason": "detect-secrets consistently timing out after 4 minutes"
             }
         ]
 


### PR DESCRIPTION
## Summary
- extend detect-secrets scan timeout to 10 minutes to avoid premature termination
- align timeout adjustment script with new detect-secrets threshold

## Testing
- `python -m py_compile scripts/security/adjust_workflow_timeouts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b87cea0d2c832c8f98a6e746632e35