### PR TITLE
chore: update secret detection timeout message

### DIFF
--- a/.github/workflows/scion_production.yml
+++ b/.github/workflows/scion_production.yml
@@ -106,7 +106,7 @@ jobs:
             exit_code=$?
             echo "Detect-secrets completed at: $(date)"
             if [ $exit_code -eq 124 ]; then
-              echo "[FAIL] Secret detection timed out after 4 minutes"
+              echo "[FAIL] Secret detection timed out after 10 minutes"
               exit 1
             elif [ $exit_code -eq 0 ]; then
               echo "[PASS] Secret detection passed"


### PR DESCRIPTION
## Summary
- update scion production workflow to reflect 10 minute secret detection timeout

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'packages.agents.core.agent_interface')*


------
https://chatgpt.com/codex/tasks/task_e_68b886de10e8832c9cd2e2faa0bdd6ad