### PR TITLE
Upgrade detect-secrets to 1.5.0 and refresh baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,8 +91,8 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
@@ -123,5 +123,5 @@
     }
   ],
   "results": {},
-  "generated_at": "2025-09-03T15:44:48Z"
+  "generated_at": "2025-09-03T18:25:07Z"
 }

--- a/config/constraints.txt
+++ b/config/constraints.txt
@@ -61,7 +61,7 @@ bandit==1.7.5                           # Security linter
 safety==2.3.4                           # Vulnerability scanner
 pip-audit==2.6.1                        # Audit pip packages
 semgrep==1.45.0                         # SAST analysis
-detect-secrets==1.4.0                   # Secret detection
+detect-secrets==1.5.0                   # Secret detection
 
 # ==============================================================================
 # DEVELOPMENT TOOLING (Dev experience critical)


### PR DESCRIPTION
## Summary
- pin `detect-secrets` to version 1.5.0 in constraints
- regenerate `.secrets.baseline`

## Testing
- `pip install -r requirements.txt -c config/constraints.txt` *(fails: dependency resolution conflict)*
- `pip install detect-secrets==1.5.0 -c config/constraints.txt`
- `detect-secrets --version`
- `detect-secrets audit .secrets.baseline`
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'packages.agents.navigation')*

------
https://chatgpt.com/codex/tasks/task_e_68b886855e78832cbd6182f7afe6c25a