### PR TITLE
Implement basic fingerprint calibration in Rust tool

### DIFF
--- a/infrastructure/shared/tools/betanet/calibrate_fingerprint.rs
+++ b/infrastructure/shared/tools/betanet/calibrate_fingerprint.rs
@@ -1,3 +1,35 @@
+use std::env;
+use std::process;
+
+/// Simple fingerprint calibration utility.
+///
+/// Accepts numeric readings on the command line and outputs the
+/// average value which can serve as a basic calibration constant.
 fn main() {
-    println!("Calibration stub not implemented");
+    // Skip program name and collect provided values
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    if args.is_empty() {
+        eprintln!("Usage: calibrate_fingerprint <values...>");
+        process::exit(1);
+    }
+
+    // Parse command line arguments into floating point numbers
+    let mut values: Vec<f64> = Vec::new();
+    for arg in args {
+        match arg.parse::<f64>() {
+            Ok(v) => values.push(v),
+            Err(_) => {
+                eprintln!("Invalid numeric value: {arg}");
+                process::exit(1);
+            }
+        }
+    }
+
+    // Calculate average (our calibration result)
+    let sum: f64 = values.iter().sum();
+    let avg = sum / values.len() as f64;
+
+    // Output the result for downstream tools
+    println!("Calibrated fingerprint: {:.2}", avg);
 }

--- a/tests/test_calibrate_fingerprint_rs.py
+++ b/tests/test_calibrate_fingerprint_rs.py
@@ -1,0 +1,19 @@
+import subprocess
+from pathlib import Path
+
+
+def test_calibration_average(tmp_path):
+    """Compile and run the calibrate_fingerprint Rust tool."""
+    src = (
+        Path(__file__).resolve().parent.parent
+        / "infrastructure"
+        / "shared"
+        / "tools"
+        / "betanet"
+        / "calibrate_fingerprint.rs"
+    )
+    binary = tmp_path / "calibrate_fingerprint"
+    subprocess.run(["rustc", src, "-O", "-o", binary], check=True)
+    result = subprocess.run([binary, "10", "20", "30"], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "Calibrated fingerprint: 20.00"
+


### PR DESCRIPTION
## Summary
- replace calibration stub with argument parsing, average computation, and result output
- add integration test compiling and running the tool

## Testing
- `pytest tests/test_calibrate_fingerprint_rs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a15e5bd0832ca8167d4f45456675