### PR TITLE
feat: add mls group support with persistence

### DIFF
--- a/integrations/bounties/betanet/crates/agent-fabric/Cargo.toml
+++ b/integrations/bounties/betanet/crates/agent-fabric/Cargo.toml
@@ -25,9 +25,10 @@ betanet-htx = { path = "../betanet-htx" }
 betanet-dtn = { path = "../betanet-dtn" }
 
 # MLS group messaging
-openmls = { version = "0.5", optional = true }
+openmls = { version = "0.5", optional = true, features = ["test-utils"] }
 openmls_traits = { version = "0.2", optional = true }
 openmls_rust_crypto = { version = "0.2", optional = true }
+openmls_basic_credential = { version = "0.2", optional = true }
 
 # Serialization for RPC
 protobuf = "3.0"
@@ -49,7 +50,7 @@ proptest = { workspace = true }
 default = ["rpc", "dtn"]
 rpc = []
 dtn = []
-mls = ["openmls", "openmls_traits", "openmls_rust_crypto"]
+mls = ["openmls", "openmls_traits", "openmls_rust_crypto", "openmls_basic_credential"]
 unstable = []
 
 [[test]]

--- a/integrations/bounties/betanet/crates/agent-fabric/src/groups.rs
+++ b/integrations/bounties/betanet/crates/agent-fabric/src/groups.rs
@@ -4,24 +4,26 @@
 //! training sessions, alerts, and voting protocols.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use tokio::fs;
 use tokio::sync::{mpsc, Mutex, RwLock};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 #[cfg(feature = "mls")]
 use openmls::group::MlsGroup as MlsGroup_;
-#[cfg(feature = "mls")]
-use openmls::messages::processed_message::ProcessedMessageContent;
 #[cfg(feature = "mls")]
 use openmls::prelude::*;
 #[cfg(feature = "mls")]
 use openmls_rust_crypto::OpenMlsRustCrypto;
 #[cfg(feature = "mls")]
-use openmls_traits::{OpenMlsCryptoProvider, OpenMlsProvider};
+use openmls_basic_credential::SignatureKeyPair;
+#[cfg(feature = "mls")]
+use std::io::Cursor;
 
 use crate::{AgentFabricError, AgentId, Result};
 
@@ -119,6 +121,8 @@ pub struct GroupMember {
     pub joined_at: u64,
     pub last_active: u64,
     pub vote_weight: u32,
+    #[cfg(feature = "mls")]
+    pub leaf_index: Option<u32>,
 }
 
 /// Voting proposal
@@ -133,6 +137,19 @@ pub struct VoteProposal {
     pub total_weight: u32,
     pub deadline: u64,
     pub executed: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistentState {
+    members: Vec<GroupMember>,
+    proposals: Vec<VoteProposal>,
+}
+
+#[async_trait]
+pub trait GroupCallback: Send + Sync {
+    async fn member_added(&self, _member: &GroupMember) {}
+    async fn member_removed(&self, _agent: &AgentId) {}
+    async fn vote_executed(&self, _proposal: &VoteProposal) {}
 }
 
 /// Group statistics
@@ -168,12 +185,19 @@ pub struct MlsGroup {
     key_store: Arc<RwLock<HashMap<Vec<u8>, KeyPackage>>>,
     #[cfg(not(feature = "mls"))]
     key_store: (), // Placeholder
+    state_path: Arc<RwLock<Option<PathBuf>>>,
+    callbacks: Arc<RwLock<Vec<Arc<dyn GroupCallback>>>>,
+    #[cfg(feature = "mls")]
+    signer: Arc<SignatureKeyPair>,
 }
 
 impl MlsGroup {
     /// Create a new MLS group
     pub async fn new(group_id: String, config: GroupConfig) -> Result<Self> {
         let (sender, _receiver) = mpsc::channel(1000);
+        #[cfg(feature = "mls")]
+        let signer = SignatureKeyPair::new(SignatureScheme::ED25519)
+            .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
 
         let group = Self {
             group_id: group_id.clone(),
@@ -191,143 +215,294 @@ impl MlsGroup {
             key_store: Arc::new(RwLock::new(HashMap::new())),
             #[cfg(not(feature = "mls"))]
             key_store: (),
+            state_path: Arc::new(RwLock::new(None)),
+            callbacks: Arc::new(RwLock::new(Vec::new())),
+            #[cfg(feature = "mls")]
+            signer: Arc::new(signer),
         };
 
         info!("Created MLS group: {}", group_id);
         Ok(group)
     }
 
-    /// Initialize group as creator (admin)
-    pub async fn initialize_as_creator(&self, creator: AgentId) -> Result<()> {
-        // Simplified implementation for demo purposes
-        // In a real implementation, this would use MLS protocol
-        info!("Group initialization (simulated): {}", creator);
-
-        // Add creator as admin member
-        let member_id = creator.to_string().into_bytes();
-        let member = GroupMember {
-            agent_id: creator,
-            member_id: member_id.clone(),
-            is_admin: true,
-            joined_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
-            last_active: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
-            vote_weight: 1,
-        };
-
+    pub async fn set_state_path(&self, path: PathBuf) -> Result<()> {
         {
-            let mut members = self.members.write().await;
-            members.insert(member_id, member);
+            let mut guard = self.state_path.write().await;
+            *guard = Some(path);
         }
+        self.load_state().await
+    }
 
-        info!("Initialized MLS group {} as creator", self.group_id);
+    pub async fn register_callback(&self, cb: Arc<dyn GroupCallback>) {
+        let mut callbacks = self.callbacks.write().await;
+        callbacks.push(cb);
+    }
+
+    async fn load_state(&self) -> Result<()> {
+        let path = { self.state_path.read().await.clone() };
+        if let Some(path) = path {
+            if let Ok(data) = fs::read(&path).await {
+                if let Ok(state) = serde_json::from_slice::<PersistentState>(&data) {
+                    let mut members = self.members.write().await;
+                    members.clear();
+                    for m in state.members {
+                        members.insert(m.member_id.clone(), m);
+                    }
+                    let mut proposals = self.proposals.write().await;
+                    proposals.clear();
+                    for p in state.proposals {
+                        proposals.insert(p.proposal_id.clone(), p);
+                    }
+                }
+            }
+        }
         Ok(())
     }
 
-    /// Send message to group
-    pub async fn send_message(&self, message: GroupMessage) -> Result<()> {
-        // Simplified implementation for demo purposes
-        // In a real implementation, this would use MLS encryption
-
-        // Serialize message
-        let _message_bytes = serde_json::to_vec(&message)
-            .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
-
-        // In a real implementation, this would be sent to all group members
-        // via the underlying transport (RPC or DTN) with MLS encryption
-        debug!("Group message sent (simulated) for group {}", self.group_id);
-
-        // Update stats
-        {
-            let mut stats = self.stats.write().await;
-            stats.messages_sent += 1;
-
-            match &message.message_type {
-                GroupMessageType::Training { .. } => {
-                    // Training session tracking handled separately
-                }
-                GroupMessageType::Alert { .. } => {
-                    stats.alerts_sent += 1;
-                }
-                GroupMessageType::Vote { .. } => {
-                    // Vote tracking handled in vote processing
-                }
-                GroupMessageType::Broadcast { .. } => {
-                    // General broadcast
-                }
-            }
+    async fn save_state(&self) -> Result<()> {
+        let path = { self.state_path.read().await.clone() };
+        if let Some(path) = path {
+            let state = PersistentState {
+                members: self.members.read().await.values().cloned().collect(),
+                proposals: self.proposals.read().await.values().cloned().collect(),
+            };
+            let data = serde_json::to_vec(&state)
+                .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+            fs::write(path, data)
+                .await
+                .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
         }
-
-        // Queue message for local processing
-        {
-            let sender = self.message_queue.lock().await;
-            if sender.send(message).await.is_err() {
-                warn!("Failed to queue message locally");
-            }
-        }
-
         Ok(())
+    }
+
+    /// Initialize group as creator (admin)
+    pub async fn initialize_as_creator(&self, creator: AgentId) -> Result<()> {
+        #[cfg(feature = "mls")]
+        {
+            let backend = self.crypto_provider.as_ref();
+            let credential = Credential::new(
+                creator.to_string().into_bytes(),
+                CredentialType::Basic,
+            )
+            .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
+            let credential_with_key = CredentialWithKey {
+                credential,
+                signature_key: self.signer.public().into(),
+            };
+            let group_id = GroupId::from_slice(self.group_id.as_bytes());
+            let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+            let mls_group_config = MlsGroupConfig::builder()
+                .crypto_config(CryptoConfig::with_default_version(ciphersuite))
+                .build();
+            let mls_group = MlsGroup_::new_with_group_id(
+                backend,
+                self.signer.as_ref(),
+                &mls_group_config,
+                group_id,
+                credential_with_key,
+            )
+            .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+            {
+                let mut g = self.mls_group.lock().await;
+                *g = Some(mls_group);
+            }
+            let member_id = creator.to_string().into_bytes();
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let member = GroupMember {
+                agent_id: creator,
+                member_id: member_id.clone(),
+                is_admin: true,
+                joined_at: now,
+                last_active: now,
+                vote_weight: 1,
+                leaf_index: Some(0),
+            };
+            {
+                let mut members = self.members.write().await;
+                members.insert(member_id, member);
+            }
+            self.save_state().await?;
+            info!("Initialized MLS group {} as creator", self.group_id);
+            Ok(())
+        }
+        #[cfg(not(feature = "mls"))]
+        {
+            info!("Group initialization (simulated): {}", creator);
+            let member_id = creator.to_string().into_bytes();
+            let member = GroupMember {
+                agent_id: creator,
+                member_id: member_id.clone(),
+                is_admin: true,
+                joined_at: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                last_active: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                vote_weight: 1,
+            };
+            {
+                let mut members = self.members.write().await;
+                members.insert(member_id, member);
+            }
+            Ok(())
+        }
+    }
+
+    /// Send message to group
+    pub async fn send_message(&self, message: GroupMessage) -> Result<Vec<u8>> {
+        let payload = serde_json::to_vec(&message)
+            .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+        #[cfg(feature = "mls")]
+        {
+            let mut group_lock = self.mls_group.lock().await;
+            let group = group_lock.as_mut().ok_or_else(|| {
+                AgentFabricError::MlsError("Group not initialized".to_string())
+            })?;
+            let msg_out = group
+                .create_message(
+                    self.crypto_provider.as_ref(),
+                    self.signer.as_ref(),
+                    &payload,
+                )
+                .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+            let bytes = msg_out
+                .tls_serialize_detached()
+                .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+            {
+                let mut stats = self.stats.write().await;
+                stats.messages_sent += 1;
+                match &message.message_type {
+                    GroupMessageType::Alert { .. } => stats.alerts_sent += 1,
+                    _ => {}
+                }
+            }
+            {
+                let sender = self.message_queue.lock().await;
+                if sender.send(message).await.is_err() {
+                    warn!("Failed to queue message locally");
+                }
+            }
+            Ok(bytes)
+        }
+        #[cfg(not(feature = "mls"))]
+        {
+            debug!("Group message sent (simulated) for group {}", self.group_id);
+            {
+                let mut stats = self.stats.write().await;
+                stats.messages_sent += 1;
+            }
+            {
+                let sender = self.message_queue.lock().await;
+                if sender.send(message).await.is_err() {
+                    warn!("Failed to queue message locally");
+                }
+            }
+            Ok(payload)
+        }
     }
 
     /// Process received MLS message
     pub async fn process_message(&self, mls_message: &[u8]) -> Result<Option<GroupMessage>> {
-        // Simplified implementation for demo purposes
-        // In a real implementation, this would decrypt using MLS
-
-        // For demo, assume the message is JSON-encoded GroupMessage
-        let message: GroupMessage = serde_json::from_slice(mls_message)
-            .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
-
-        // Update stats
+        #[cfg(feature = "mls")]
         {
-            let mut stats = self.stats.write().await;
-            stats.messages_received += 1;
+            let mut group_lock = self.mls_group.lock().await;
+            let group = group_lock.as_mut().ok_or_else(|| {
+                AgentFabricError::MlsError("Group not initialized".to_string())
+            })?;
+            let mut cursor = Cursor::new(mls_message);
+            let msg_in = MlsMessageIn::tls_deserialize(&mut cursor)
+                .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
+            let protocol = msg_in
+                .into_protocol_message()
+                .ok_or_else(|| AgentFabricError::MlsError("Invalid message".to_string()))?;
+            let processed = group
+                .process_message(self.crypto_provider.as_ref(), protocol)
+                .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
+            if let ProcessedMessageContent::ApplicationMessage(app) = processed.into_content() {
+                let payload = app.into_bytes();
+                let message: GroupMessage = serde_json::from_slice(&payload)
+                    .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+                {
+                    let mut stats = self.stats.write().await;
+                    stats.messages_received += 1;
+                }
+                self.handle_group_message(&message).await?;
+                return Ok(Some(message));
+            }
+            Ok(None)
         }
-
-        // Process specific message types
-        self.handle_group_message(&message).await?;
-
-        Ok(Some(message))
+        #[cfg(not(feature = "mls"))]
+        {
+            let message: GroupMessage = serde_json::from_slice(mls_message)
+                .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+            {
+                let mut stats = self.stats.write().await;
+                stats.messages_received += 1;
+            }
+            self.handle_group_message(&message).await?;
+            Ok(Some(message))
+        }
     }
 
     /// Add member to group
     #[cfg(feature = "mls")]
-    pub async fn add_member(&self, agent_id: AgentId, _key_package: KeyPackage) -> Result<()> {
-        // Simplified implementation for demo purposes
-        // In a real implementation, this would use MLS key packages and proposals
-
-        // For now, directly add the member
+    pub async fn add_member(&self, agent_id: AgentId, key_package: KeyPackage) -> Result<()> {
+        let mut group_lock = self.mls_group.lock().await;
+        let group = group_lock.as_mut().ok_or_else(|| {
+            AgentFabricError::MlsError("Group not initialized".to_string())
+        })?;
+        group
+            .add_members(
+                self.crypto_provider.as_ref(),
+                self.signer.as_ref(),
+                &[key_package.clone()],
+            )
+            .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+        group
+            .merge_pending_commit(self.crypto_provider.as_ref())
+            .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
         let member_id = agent_id.to_string().into_bytes();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let leaf_index = group
+            .members()
+            .find(|m| m.credential.identity() == agent_id.id.as_bytes())
+            .map(|m| m.index.u32())
+            .unwrap_or(0);
         let member = GroupMember {
             agent_id: agent_id.clone(),
             member_id: member_id.clone(),
             is_admin: false,
-            joined_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
-            last_active: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
+            joined_at: now,
+            last_active: now,
             vote_weight: 1,
+            leaf_index: Some(leaf_index),
         };
-
         {
             let mut members = self.members.write().await;
-            members.insert(member_id, member);
+            members.insert(member_id.clone(), member.clone());
         }
-
         {
             let mut stats = self.stats.write().await;
             stats.members_added += 1;
         }
-
+        {
+            let mut store = self.key_store.write().await;
+            store.insert(member_id, key_package);
+        }
+        self.save_state().await?;
+        let callbacks = self.callbacks.read().await.clone();
+        for cb in callbacks {
+            cb.member_added(&member).await;
+        }
         info!("Added member {} to group {}", agent_id, self.group_id);
         Ok(())
     }
@@ -372,18 +547,44 @@ impl MlsGroup {
     /// Remove member from group
     pub async fn remove_member(&self, agent_id: &AgentId) -> Result<()> {
         let member_id = agent_id.to_string().into_bytes();
+        #[cfg(feature = "mls")]
+        {
+            let mut group_lock = self.mls_group.lock().await;
+            let group = group_lock.as_mut().ok_or_else(|| {
+                AgentFabricError::MlsError("Group not initialized".to_string())
+            })?;
+            let index = {
+                let members = self.members.read().await;
+                members
+                    .get(&member_id)
+                    .and_then(|m| m.leaf_index)
+                    .unwrap_or(0)
+            };
+            group
+                .remove_members(
+                    self.crypto_provider.as_ref(),
+                    self.signer.as_ref(),
+                    &[LeafNodeIndex::new(index)],
+                )
+                .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+            group
+                .merge_pending_commit(self.crypto_provider.as_ref())
+                .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+        }
 
-        // Remove from members
         {
             let mut members = self.members.write().await;
             members.remove(&member_id);
         }
-
         {
             let mut stats = self.stats.write().await;
             stats.members_removed += 1;
         }
-
+        self.save_state().await?;
+        let callbacks = self.callbacks.read().await.clone();
+        for cb in callbacks {
+            cb.member_removed(agent_id).await;
+        }
         info!("Removed member {} from group {}", agent_id, self.group_id);
         Ok(())
     }
@@ -419,6 +620,7 @@ impl MlsGroup {
             let mut proposals = self.proposals.write().await;
             proposals.insert(proposal_id.clone(), proposal);
         }
+        self.save_state().await?;
 
         // Send vote proposal message
         let vote_message = GroupMessage {
@@ -435,7 +637,7 @@ impl MlsGroup {
                 .as_secs(),
         };
 
-        self.send_message(vote_message).await?;
+        let _ = self.send_message(vote_message).await?;
 
         {
             let mut stats = self.stats.write().await;
@@ -474,6 +676,7 @@ impl MlsGroup {
                 return Err(AgentFabricError::MlsError("Proposal not found".to_string()));
             }
         }
+        self.save_state().await?;
 
         // Send vote message
         let vote_message = GroupMessage {
@@ -490,7 +693,7 @@ impl MlsGroup {
                 .as_secs(),
         };
 
-        self.send_message(vote_message).await?;
+        let _ = self.send_message(vote_message).await?;
 
         debug!(
             "Vote cast for proposal {} by {}: {}",
@@ -627,6 +830,10 @@ impl MlsGroup {
                     "Vote {} PASSED ({} for, {} against)",
                     proposal_id, proposal.votes_for, proposal.votes_against
                 );
+                let callbacks = self.callbacks.read().await.clone();
+                for cb in callbacks {
+                    cb.vote_executed(proposal).await;
+                }
             } else {
                 info!(
                     "Vote {} FAILED ({} for, {} against)",
@@ -637,7 +844,7 @@ impl MlsGroup {
             let mut stats = self.stats.write().await;
             stats.votes_completed += 1;
         }
-
+        self.save_state().await?;
         Ok(())
     }
 
@@ -656,6 +863,22 @@ impl MlsGroup {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "mls")]
+    fn make_key_package(identity: &str, backend: &OpenMlsRustCrypto) -> KeyPackage {
+        let credential = Credential::new(identity.as_bytes().to_vec(), CredentialType::Basic).unwrap();
+        let signer = SignatureKeyPair::new(SignatureScheme::ED25519).unwrap();
+        signer.store(backend.key_store()).unwrap();
+        let cred_with_key = CredentialWithKey { credential, signature_key: signer.public().into() };
+        KeyPackage::builder()
+            .build(
+                CryptoConfig::with_default_version(Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519),
+                backend,
+                &signer,
+                cred_with_key,
+            )
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn test_group_creation() {
@@ -715,5 +938,64 @@ mod tests {
         assert_eq!(proposal.proposal_id, "prop-1");
         assert_eq!(proposal.total_weight, 10);
         assert!(!proposal.executed);
+    }
+
+    #[cfg(feature = "mls")]
+    #[tokio::test]
+    async fn test_member_add_remove() {
+        let config = GroupConfig::default();
+        let group = MlsGroup::new("g1".to_string(), config).await.unwrap();
+        let creator = AgentId::new("creator", "n1");
+        group.initialize_as_creator(creator.clone()).await.unwrap();
+        let backend = group.crypto_provider.clone();
+        let kp = make_key_package("bob", &backend);
+        let bob = AgentId::new("bob", "n1");
+        group.add_member(bob.clone(), kp).await.unwrap();
+        assert_eq!(group.get_members().await.len(), 2);
+        group.remove_member(&bob).await.unwrap();
+        assert_eq!(group.get_members().await.len(), 1);
+    }
+
+    #[cfg(feature = "mls")]
+    #[tokio::test]
+    async fn test_vote_tally() {
+        let config = GroupConfig::default();
+        let group = MlsGroup::new("g2".to_string(), config).await.unwrap();
+        let creator = AgentId::new("creator", "n1");
+        group.initialize_as_creator(creator.clone()).await.unwrap();
+        let proposal_id = group
+            .start_vote(
+                creator.clone(),
+                "title".into(),
+                "desc".into(),
+                60,
+            )
+            .await
+            .unwrap();
+        group
+            .cast_vote(proposal_id.clone(), creator.clone(), true)
+            .await
+            .unwrap();
+        group.tally_vote(&proposal_id).await.unwrap();
+        let proposals = group.proposals.read().await;
+        assert!(proposals.get(&proposal_id).unwrap().executed);
+    }
+
+    #[cfg(feature = "mls")]
+    #[tokio::test]
+    async fn test_encrypted_roundtrip() {
+        let config = GroupConfig::default();
+        let group = MlsGroup::new("g3".to_string(), config).await.unwrap();
+        let creator = AgentId::new("creator", "n1");
+        group.initialize_as_creator(creator.clone()).await.unwrap();
+        let message = GroupMessage {
+            message_id: "m1".to_string(),
+            from: creator.clone(),
+            message_type: GroupMessageType::Broadcast { category: "test".into() },
+            payload: Bytes::from("hello"),
+            timestamp: 1,
+        };
+        let bytes = group.send_message(message.clone()).await.unwrap();
+        assert!(!bytes.is_empty());
     }
 }

--- a/integrations/bounties/betanet/crates/agent-fabric/src/lib.rs
+++ b/integrations/bounties/betanet/crates/agent-fabric/src/lib.rs
@@ -195,7 +195,7 @@ impl AgentFabric {
     pub async fn send_to_group(&self, group_id: String, message: GroupMessage) -> Result<()> {
         let groups = self.mls_groups.read().await;
         if let Some(group) = groups.get(&group_id) {
-            group.send_message(message).await?;
+            let _ = group.send_message(message).await?;
             Ok(())
         } else {
             Err(AgentFabricError::GroupNotFound(group_id))

--- a/integrations/bounties/betanet/crates/agent-fabric/tests/integration_tests.rs
+++ b/integrations/bounties/betanet/crates/agent-fabric/tests/integration_tests.rs
@@ -213,7 +213,7 @@ async fn test_group_messaging() {
         timestamp: 1234567890,
     };
 
-    group.send_message(training_message).await.unwrap();
+    let _ = group.send_message(training_message).await.unwrap();
 
     // Test alert message
     let alert_message = GroupMessage {
@@ -227,7 +227,7 @@ async fn test_group_messaging() {
         timestamp: 1234567891,
     };
 
-    group.send_message(alert_message).await.unwrap();
+    let _ = group.send_message(alert_message).await.unwrap();
 
     let stats = group.get_stats().await;
     assert_eq!(stats.messages_sent, 2);

--- a/integrations/clients/rust/agent-fabric/Cargo.toml
+++ b/integrations/clients/rust/agent-fabric/Cargo.toml
@@ -25,9 +25,10 @@ betanet-htx = { path = "../betanet-htx" }
 betanet-dtn = { path = "../betanet-dtn" }
 
 # MLS group messaging
-openmls = { version = "0.5", optional = true }
+openmls = { version = "0.5", optional = true, features = ["test-utils"] }
 openmls_traits = { version = "0.2", optional = true }
 openmls_rust_crypto = { version = "0.2", optional = true }
+openmls_basic_credential = { version = "0.2", optional = true }
 
 # Serialization for RPC
 protobuf = "3.0"
@@ -49,4 +50,4 @@ proptest = { workspace = true }
 default = ["rpc", "dtn"]
 rpc = []
 dtn = []
-mls = ["openmls", "openmls_traits", "openmls_rust_crypto"]
+mls = ["openmls", "openmls_traits", "openmls_rust_crypto", "openmls_basic_credential"]

--- a/integrations/clients/rust/agent-fabric/src/groups.rs
+++ b/integrations/clients/rust/agent-fabric/src/groups.rs
@@ -4,24 +4,26 @@
 //! training sessions, alerts, and voting protocols.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use tokio::fs;
 use tokio::sync::{mpsc, Mutex, RwLock};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 #[cfg(feature = "mls")]
 use openmls::group::MlsGroup as MlsGroup_;
-#[cfg(feature = "mls")]
-use openmls::messages::processed_message::ProcessedMessageContent;
 #[cfg(feature = "mls")]
 use openmls::prelude::*;
 #[cfg(feature = "mls")]
 use openmls_rust_crypto::OpenMlsRustCrypto;
 #[cfg(feature = "mls")]
-use openmls_traits::{OpenMlsCryptoProvider, OpenMlsProvider};
+use openmls_basic_credential::SignatureKeyPair;
+#[cfg(feature = "mls")]
+use std::io::Cursor;
 
 use crate::{AgentFabricError, AgentId, Result};
 
@@ -119,6 +121,8 @@ pub struct GroupMember {
     pub joined_at: u64,
     pub last_active: u64,
     pub vote_weight: u32,
+    #[cfg(feature = "mls")]
+    pub leaf_index: Option<u32>,
 }
 
 /// Voting proposal
@@ -133,6 +137,19 @@ pub struct VoteProposal {
     pub total_weight: u32,
     pub deadline: u64,
     pub executed: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistentState {
+    members: Vec<GroupMember>,
+    proposals: Vec<VoteProposal>,
+}
+
+#[async_trait]
+pub trait GroupCallback: Send + Sync {
+    async fn member_added(&self, _member: &GroupMember) {}
+    async fn member_removed(&self, _agent: &AgentId) {}
+    async fn vote_executed(&self, _proposal: &VoteProposal) {}
 }
 
 /// Group statistics
@@ -168,12 +185,19 @@ pub struct MlsGroup {
     key_store: Arc<RwLock<HashMap<Vec<u8>, KeyPackage>>>,
     #[cfg(not(feature = "mls"))]
     key_store: (), // Placeholder
+    state_path: Arc<RwLock<Option<PathBuf>>>,
+    callbacks: Arc<RwLock<Vec<Arc<dyn GroupCallback>>>>,
+    #[cfg(feature = "mls")]
+    signer: Arc<SignatureKeyPair>,
 }
 
 impl MlsGroup {
     /// Create a new MLS group
     pub async fn new(group_id: String, config: GroupConfig) -> Result<Self> {
         let (sender, _receiver) = mpsc::channel(1000);
+        #[cfg(feature = "mls")]
+        let signer = SignatureKeyPair::new(SignatureScheme::ED25519)
+            .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
 
         let group = Self {
             group_id: group_id.clone(),
@@ -191,143 +215,294 @@ impl MlsGroup {
             key_store: Arc::new(RwLock::new(HashMap::new())),
             #[cfg(not(feature = "mls"))]
             key_store: (),
+            state_path: Arc::new(RwLock::new(None)),
+            callbacks: Arc::new(RwLock::new(Vec::new())),
+            #[cfg(feature = "mls")]
+            signer: Arc::new(signer),
         };
 
         info!("Created MLS group: {}", group_id);
         Ok(group)
     }
 
-    /// Initialize group as creator (admin)
-    pub async fn initialize_as_creator(&self, creator: AgentId) -> Result<()> {
-        // Simplified implementation for demo purposes
-        // In a real implementation, this would use MLS protocol
-        info!("Group initialization (simulated): {}", creator);
-
-        // Add creator as admin member
-        let member_id = creator.to_string().into_bytes();
-        let member = GroupMember {
-            agent_id: creator,
-            member_id: member_id.clone(),
-            is_admin: true,
-            joined_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
-            last_active: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
-            vote_weight: 1,
-        };
-
+    pub async fn set_state_path(&self, path: PathBuf) -> Result<()> {
         {
-            let mut members = self.members.write().await;
-            members.insert(member_id, member);
+            let mut guard = self.state_path.write().await;
+            *guard = Some(path);
         }
+        self.load_state().await
+    }
 
-        info!("Initialized MLS group {} as creator", self.group_id);
+    pub async fn register_callback(&self, cb: Arc<dyn GroupCallback>) {
+        let mut callbacks = self.callbacks.write().await;
+        callbacks.push(cb);
+    }
+
+    async fn load_state(&self) -> Result<()> {
+        let path = { self.state_path.read().await.clone() };
+        if let Some(path) = path {
+            if let Ok(data) = fs::read(&path).await {
+                if let Ok(state) = serde_json::from_slice::<PersistentState>(&data) {
+                    let mut members = self.members.write().await;
+                    members.clear();
+                    for m in state.members {
+                        members.insert(m.member_id.clone(), m);
+                    }
+                    let mut proposals = self.proposals.write().await;
+                    proposals.clear();
+                    for p in state.proposals {
+                        proposals.insert(p.proposal_id.clone(), p);
+                    }
+                }
+            }
+        }
         Ok(())
     }
 
-    /// Send message to group
-    pub async fn send_message(&self, message: GroupMessage) -> Result<()> {
-        // Simplified implementation for demo purposes
-        // In a real implementation, this would use MLS encryption
-
-        // Serialize message
-        let _message_bytes = serde_json::to_vec(&message)
-            .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
-
-        // In a real implementation, this would be sent to all group members
-        // via the underlying transport (RPC or DTN) with MLS encryption
-        debug!("Group message sent (simulated) for group {}", self.group_id);
-
-        // Update stats
-        {
-            let mut stats = self.stats.write().await;
-            stats.messages_sent += 1;
-
-            match &message.message_type {
-                GroupMessageType::Training { .. } => {
-                    // Training session tracking handled separately
-                }
-                GroupMessageType::Alert { .. } => {
-                    stats.alerts_sent += 1;
-                }
-                GroupMessageType::Vote { .. } => {
-                    // Vote tracking handled in vote processing
-                }
-                GroupMessageType::Broadcast { .. } => {
-                    // General broadcast
-                }
-            }
+    async fn save_state(&self) -> Result<()> {
+        let path = { self.state_path.read().await.clone() };
+        if let Some(path) = path {
+            let state = PersistentState {
+                members: self.members.read().await.values().cloned().collect(),
+                proposals: self.proposals.read().await.values().cloned().collect(),
+            };
+            let data = serde_json::to_vec(&state)
+                .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+            fs::write(path, data)
+                .await
+                .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
         }
-
-        // Queue message for local processing
-        {
-            let sender = self.message_queue.lock().await;
-            if sender.send(message).await.is_err() {
-                warn!("Failed to queue message locally");
-            }
-        }
-
         Ok(())
+    }
+
+    /// Initialize group as creator (admin)
+    pub async fn initialize_as_creator(&self, creator: AgentId) -> Result<()> {
+        #[cfg(feature = "mls")]
+        {
+            let backend = self.crypto_provider.as_ref();
+            let credential = Credential::new(
+                creator.to_string().into_bytes(),
+                CredentialType::Basic,
+            )
+            .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
+            let credential_with_key = CredentialWithKey {
+                credential,
+                signature_key: self.signer.public().into(),
+            };
+            let group_id = GroupId::from_slice(self.group_id.as_bytes());
+            let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+            let mls_group_config = MlsGroupConfig::builder()
+                .crypto_config(CryptoConfig::with_default_version(ciphersuite))
+                .build();
+            let mls_group = MlsGroup_::new_with_group_id(
+                backend,
+                self.signer.as_ref(),
+                &mls_group_config,
+                group_id,
+                credential_with_key,
+            )
+            .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+            {
+                let mut g = self.mls_group.lock().await;
+                *g = Some(mls_group);
+            }
+            let member_id = creator.to_string().into_bytes();
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let member = GroupMember {
+                agent_id: creator,
+                member_id: member_id.clone(),
+                is_admin: true,
+                joined_at: now,
+                last_active: now,
+                vote_weight: 1,
+                leaf_index: Some(0),
+            };
+            {
+                let mut members = self.members.write().await;
+                members.insert(member_id, member);
+            }
+            self.save_state().await?;
+            info!("Initialized MLS group {} as creator", self.group_id);
+            Ok(())
+        }
+        #[cfg(not(feature = "mls"))]
+        {
+            info!("Group initialization (simulated): {}", creator);
+            let member_id = creator.to_string().into_bytes();
+            let member = GroupMember {
+                agent_id: creator,
+                member_id: member_id.clone(),
+                is_admin: true,
+                joined_at: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                last_active: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                vote_weight: 1,
+            };
+            {
+                let mut members = self.members.write().await;
+                members.insert(member_id, member);
+            }
+            Ok(())
+        }
+    }
+
+    /// Send message to group
+    pub async fn send_message(&self, message: GroupMessage) -> Result<Vec<u8>> {
+        let payload = serde_json::to_vec(&message)
+            .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+        #[cfg(feature = "mls")]
+        {
+            let mut group_lock = self.mls_group.lock().await;
+            let group = group_lock.as_mut().ok_or_else(|| {
+                AgentFabricError::MlsError("Group not initialized".to_string())
+            })?;
+            let msg_out = group
+                .create_message(
+                    self.crypto_provider.as_ref(),
+                    self.signer.as_ref(),
+                    &payload,
+                )
+                .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+            let bytes = msg_out
+                .tls_serialize_detached()
+                .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+            {
+                let mut stats = self.stats.write().await;
+                stats.messages_sent += 1;
+                match &message.message_type {
+                    GroupMessageType::Alert { .. } => stats.alerts_sent += 1,
+                    _ => {}
+                }
+            }
+            {
+                let sender = self.message_queue.lock().await;
+                if sender.send(message).await.is_err() {
+                    warn!("Failed to queue message locally");
+                }
+            }
+            Ok(bytes)
+        }
+        #[cfg(not(feature = "mls"))]
+        {
+            debug!("Group message sent (simulated) for group {}", self.group_id);
+            {
+                let mut stats = self.stats.write().await;
+                stats.messages_sent += 1;
+            }
+            {
+                let sender = self.message_queue.lock().await;
+                if sender.send(message).await.is_err() {
+                    warn!("Failed to queue message locally");
+                }
+            }
+            Ok(payload)
+        }
     }
 
     /// Process received MLS message
     pub async fn process_message(&self, mls_message: &[u8]) -> Result<Option<GroupMessage>> {
-        // Simplified implementation for demo purposes
-        // In a real implementation, this would decrypt using MLS
-
-        // For demo, assume the message is JSON-encoded GroupMessage
-        let message: GroupMessage = serde_json::from_slice(mls_message)
-            .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
-
-        // Update stats
+        #[cfg(feature = "mls")]
         {
-            let mut stats = self.stats.write().await;
-            stats.messages_received += 1;
+            let mut group_lock = self.mls_group.lock().await;
+            let group = group_lock.as_mut().ok_or_else(|| {
+                AgentFabricError::MlsError("Group not initialized".to_string())
+            })?;
+            let mut cursor = Cursor::new(mls_message);
+            let msg_in = MlsMessageIn::tls_deserialize(&mut cursor)
+                .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
+            let protocol = msg_in
+                .into_protocol_message()
+                .ok_or_else(|| AgentFabricError::MlsError("Invalid message".to_string()))?;
+            let processed = group
+                .process_message(self.crypto_provider.as_ref(), protocol)
+                .map_err(|e| AgentFabricError::MlsError(e.to_string()))?;
+            if let ProcessedMessageContent::ApplicationMessage(app) = processed.into_content() {
+                let payload = app.into_bytes();
+                let message: GroupMessage = serde_json::from_slice(&payload)
+                    .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+                {
+                    let mut stats = self.stats.write().await;
+                    stats.messages_received += 1;
+                }
+                self.handle_group_message(&message).await?;
+                return Ok(Some(message));
+            }
+            Ok(None)
         }
-
-        // Process specific message types
-        self.handle_group_message(&message).await?;
-
-        Ok(Some(message))
+        #[cfg(not(feature = "mls"))]
+        {
+            let message: GroupMessage = serde_json::from_slice(mls_message)
+                .map_err(|e| AgentFabricError::SerializationError(e.to_string()))?;
+            {
+                let mut stats = self.stats.write().await;
+                stats.messages_received += 1;
+            }
+            self.handle_group_message(&message).await?;
+            Ok(Some(message))
+        }
     }
 
     /// Add member to group
     #[cfg(feature = "mls")]
-    pub async fn add_member(&self, agent_id: AgentId, _key_package: KeyPackage) -> Result<()> {
-        // Simplified implementation for demo purposes
-        // In a real implementation, this would use MLS key packages and proposals
-
-        // For now, directly add the member
+    pub async fn add_member(&self, agent_id: AgentId, key_package: KeyPackage) -> Result<()> {
+        let mut group_lock = self.mls_group.lock().await;
+        let group = group_lock.as_mut().ok_or_else(|| {
+            AgentFabricError::MlsError("Group not initialized".to_string())
+        })?;
+        group
+            .add_members(
+                self.crypto_provider.as_ref(),
+                self.signer.as_ref(),
+                &[key_package.clone()],
+            )
+            .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+        group
+            .merge_pending_commit(self.crypto_provider.as_ref())
+            .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
         let member_id = agent_id.to_string().into_bytes();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let leaf_index = group
+            .members()
+            .find(|m| m.credential.identity() == agent_id.id.as_bytes())
+            .map(|m| m.index.u32())
+            .unwrap_or(0);
         let member = GroupMember {
             agent_id: agent_id.clone(),
             member_id: member_id.clone(),
             is_admin: false,
-            joined_at: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
-            last_active: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
+            joined_at: now,
+            last_active: now,
             vote_weight: 1,
+            leaf_index: Some(leaf_index),
         };
-
         {
             let mut members = self.members.write().await;
-            members.insert(member_id, member);
+            members.insert(member_id.clone(), member.clone());
         }
-
         {
             let mut stats = self.stats.write().await;
             stats.members_added += 1;
         }
-
+        {
+            let mut store = self.key_store.write().await;
+            store.insert(member_id, key_package);
+        }
+        self.save_state().await?;
+        let callbacks = self.callbacks.read().await.clone();
+        for cb in callbacks {
+            cb.member_added(&member).await;
+        }
         info!("Added member {} to group {}", agent_id, self.group_id);
         Ok(())
     }
@@ -372,18 +547,44 @@ impl MlsGroup {
     /// Remove member from group
     pub async fn remove_member(&self, agent_id: &AgentId) -> Result<()> {
         let member_id = agent_id.to_string().into_bytes();
+        #[cfg(feature = "mls")]
+        {
+            let mut group_lock = self.mls_group.lock().await;
+            let group = group_lock.as_mut().ok_or_else(|| {
+                AgentFabricError::MlsError("Group not initialized".to_string())
+            })?;
+            let index = {
+                let members = self.members.read().await;
+                members
+                    .get(&member_id)
+                    .and_then(|m| m.leaf_index)
+                    .unwrap_or(0)
+            };
+            group
+                .remove_members(
+                    self.crypto_provider.as_ref(),
+                    self.signer.as_ref(),
+                    &[LeafNodeIndex::new(index)],
+                )
+                .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+            group
+                .merge_pending_commit(self.crypto_provider.as_ref())
+                .map_err(|e| AgentFabricError::MlsError(format!("{e:?}")))?;
+        }
 
-        // Remove from members
         {
             let mut members = self.members.write().await;
             members.remove(&member_id);
         }
-
         {
             let mut stats = self.stats.write().await;
             stats.members_removed += 1;
         }
-
+        self.save_state().await?;
+        let callbacks = self.callbacks.read().await.clone();
+        for cb in callbacks {
+            cb.member_removed(agent_id).await;
+        }
         info!("Removed member {} from group {}", agent_id, self.group_id);
         Ok(())
     }
@@ -419,6 +620,7 @@ impl MlsGroup {
             let mut proposals = self.proposals.write().await;
             proposals.insert(proposal_id.clone(), proposal);
         }
+        self.save_state().await?;
 
         // Send vote proposal message
         let vote_message = GroupMessage {
@@ -435,7 +637,7 @@ impl MlsGroup {
                 .as_secs(),
         };
 
-        self.send_message(vote_message).await?;
+        let _ = self.send_message(vote_message).await?;
 
         {
             let mut stats = self.stats.write().await;
@@ -474,6 +676,7 @@ impl MlsGroup {
                 return Err(AgentFabricError::MlsError("Proposal not found".to_string()));
             }
         }
+        self.save_state().await?;
 
         // Send vote message
         let vote_message = GroupMessage {
@@ -490,7 +693,7 @@ impl MlsGroup {
                 .as_secs(),
         };
 
-        self.send_message(vote_message).await?;
+        let _ = self.send_message(vote_message).await?;
 
         debug!(
             "Vote cast for proposal {} by {}: {}",
@@ -627,6 +830,10 @@ impl MlsGroup {
                     "Vote {} PASSED ({} for, {} against)",
                     proposal_id, proposal.votes_for, proposal.votes_against
                 );
+                let callbacks = self.callbacks.read().await.clone();
+                for cb in callbacks {
+                    cb.vote_executed(proposal).await;
+                }
             } else {
                 info!(
                     "Vote {} FAILED ({} for, {} against)",
@@ -637,7 +844,7 @@ impl MlsGroup {
             let mut stats = self.stats.write().await;
             stats.votes_completed += 1;
         }
-
+        self.save_state().await?;
         Ok(())
     }
 
@@ -656,6 +863,22 @@ impl MlsGroup {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "mls")]
+    fn make_key_package(identity: &str, backend: &OpenMlsRustCrypto) -> KeyPackage {
+        let credential = Credential::new(identity.as_bytes().to_vec(), CredentialType::Basic).unwrap();
+        let signer = SignatureKeyPair::new(SignatureScheme::ED25519).unwrap();
+        signer.store(backend.key_store()).unwrap();
+        let cred_with_key = CredentialWithKey { credential, signature_key: signer.public().into() };
+        KeyPackage::builder()
+            .build(
+                CryptoConfig::with_default_version(Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519),
+                backend,
+                &signer,
+                cred_with_key,
+            )
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn test_group_creation() {
@@ -715,5 +938,64 @@ mod tests {
         assert_eq!(proposal.proposal_id, "prop-1");
         assert_eq!(proposal.total_weight, 10);
         assert!(!proposal.executed);
+    }
+
+    #[cfg(feature = "mls")]
+    #[tokio::test]
+    async fn test_member_add_remove() {
+        let config = GroupConfig::default();
+        let group = MlsGroup::new("g1".to_string(), config).await.unwrap();
+        let creator = AgentId::new("creator", "n1");
+        group.initialize_as_creator(creator.clone()).await.unwrap();
+        let backend = group.crypto_provider.clone();
+        let kp = make_key_package("bob", &backend);
+        let bob = AgentId::new("bob", "n1");
+        group.add_member(bob.clone(), kp).await.unwrap();
+        assert_eq!(group.get_members().await.len(), 2);
+        group.remove_member(&bob).await.unwrap();
+        assert_eq!(group.get_members().await.len(), 1);
+    }
+
+    #[cfg(feature = "mls")]
+    #[tokio::test]
+    async fn test_vote_tally() {
+        let config = GroupConfig::default();
+        let group = MlsGroup::new("g2".to_string(), config).await.unwrap();
+        let creator = AgentId::new("creator", "n1");
+        group.initialize_as_creator(creator.clone()).await.unwrap();
+        let proposal_id = group
+            .start_vote(
+                creator.clone(),
+                "title".into(),
+                "desc".into(),
+                60,
+            )
+            .await
+            .unwrap();
+        group
+            .cast_vote(proposal_id.clone(), creator.clone(), true)
+            .await
+            .unwrap();
+        group.tally_vote(&proposal_id).await.unwrap();
+        let proposals = group.proposals.read().await;
+        assert!(proposals.get(&proposal_id).unwrap().executed);
+    }
+
+    #[cfg(feature = "mls")]
+    #[tokio::test]
+    async fn test_encrypted_roundtrip() {
+        let config = GroupConfig::default();
+        let group = MlsGroup::new("g3".to_string(), config).await.unwrap();
+        let creator = AgentId::new("creator", "n1");
+        group.initialize_as_creator(creator.clone()).await.unwrap();
+        let message = GroupMessage {
+            message_id: "m1".to_string(),
+            from: creator.clone(),
+            message_type: GroupMessageType::Broadcast { category: "test".into() },
+            payload: Bytes::from("hello"),
+            timestamp: 1,
+        };
+        let bytes = group.send_message(message.clone()).await.unwrap();
+        assert!(!bytes.is_empty());
     }
 }

--- a/integrations/clients/rust/agent-fabric/src/lib.rs
+++ b/integrations/clients/rust/agent-fabric/src/lib.rs
@@ -195,7 +195,7 @@ impl AgentFabric {
     pub async fn send_to_group(&self, group_id: String, message: GroupMessage) -> Result<()> {
         let groups = self.mls_groups.read().await;
         if let Some(group) = groups.get(&group_id) {
-            group.send_message(message).await?;
+            let _ = group.send_message(message).await?;
             Ok(())
         } else {
             Err(AgentFabricError::GroupNotFound(group_id))

--- a/integrations/clients/rust/agent-fabric/tests/integration_tests.rs
+++ b/integrations/clients/rust/agent-fabric/tests/integration_tests.rs
@@ -213,7 +213,7 @@ async fn test_group_messaging() {
         timestamp: 1234567890,
     };
 
-    group.send_message(training_message).await.unwrap();
+    let _ = group.send_message(training_message).await.unwrap();
 
     // Test alert message
     let alert_message = GroupMessage {
@@ -227,7 +227,7 @@ async fn test_group_messaging() {
         timestamp: 1234567891,
     };
 
-    group.send_message(alert_message).await.unwrap();
+    let _ = group.send_message(alert_message).await.unwrap();
 
     let stats = group.get_stats().await;
     assert_eq!(stats.messages_sent, 2);


### PR DESCRIPTION
## Summary
- replace placeholder groups with OpenMLS-backed implementation
- persist member and proposal state with JSON storage and callbacks
- test member management, voting, and encrypted messaging

## Testing
- `cargo test --features mls` *(passed)*
- `cargo test --features mls` (clients) *(failed: failed to parse manifest)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cff67ec4832cbb2390004d6b5fcc