### PR TITLE
Expose runtime and improve FFI safety

### DIFF
--- a/integrations/clients/rust/betanet-ffi/Cargo.toml
+++ b/integrations/clients/rust/betanet-ffi/Cargo.toml
@@ -18,10 +18,12 @@ betanet-linter = { path = "../betanet-linter" }
 
 libc = "0.2"
 futures = "0.3"
+once_cell = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [features]
 default = []
 static = []
 
-# [build-dependencies]
-# cbindgen = "0.26"
+[build-dependencies]
+cbindgen = "0.26"

--- a/integrations/clients/rust/betanet-ffi/build.rs
+++ b/integrations/clients/rust/betanet-ffi/build.rs
@@ -1,7 +1,14 @@
 fn main() {
-    // For now, just create the include directory
-    // Header file will be manually created
+    // Ensure include directory exists
     std::fs::create_dir_all("include").unwrap_or(());
+
+    // Generate C header using cbindgen
+    let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file("include/betanet.h");
 
     println!("cargo:rerun-if-changed=src/");
     println!("cargo:rerun-if-changed=build.rs");

--- a/integrations/clients/rust/betanet-ffi/examples/error_example.c
+++ b/integrations/clients/rust/betanet-ffi/examples/error_example.c
@@ -1,0 +1,31 @@
+/**
+ * Error Handling Example
+ *
+ * Demonstrates using betanet_error_message when API calls fail.
+ */
+
+#include <stdio.h>
+#include "../include/betanet.h"
+
+int main() {
+    if (betanet_init() != 0) {
+        fprintf(stderr, "Failed to initialize Betanet library\n");
+        return 1;
+    }
+
+    BetanetResult rt = betanet_init_runtime();
+    if (rt != betanet_Success) {
+        fprintf(stderr, "Runtime init failed: %s\n", betanet_error_message(rt));
+        return 1;
+    }
+
+    // Intentionally call with a NULL frame to trigger an error
+    BetanetBuffer buffer;
+    BetanetResult result = htx_frame_encode(NULL, &buffer);
+    if (result != betanet_Success) {
+        printf("htx_frame_encode failed: %s\n", betanet_error_message(result));
+    }
+
+    betanet_cleanup();
+    return 0;
+}

--- a/integrations/clients/rust/betanet-ffi/include/betanet.h
+++ b/integrations/clients/rust/betanet-ffi/include/betanet.h
@@ -95,6 +95,7 @@ typedef LinterResultsFFI betanet_LinterResultsFFI;
  * Base library functions
  */
 int betanet_init(void);
+BetanetResult betanet_init_runtime(void);
 void betanet_cleanup(void);
 const char* betanet_version(void);
 BetanetResult betanet_feature_supported(const char* feature);

--- a/integrations/clients/rust/betanet-ffi/src/htx.rs
+++ b/integrations/clients/rust/betanet-ffi/src/htx.rs
@@ -58,7 +58,8 @@ pub extern "C" fn htx_frame_create(
 ///
 /// # Arguments
 /// * `frame` - Frame handle
-/// * `buffer` - Output buffer (will be allocated)
+/// * `buffer` - Output buffer. Memory will be allocated by the library and must
+///   be released with `betanet_buffer_free` by the caller.
 ///
 /// # Returns
 /// * Result code
@@ -152,7 +153,8 @@ pub extern "C" fn htx_frame_type(frame: *const HTXFrame) -> c_uint {
 ///
 /// # Arguments
 /// * `frame` - Frame handle
-/// * `buffer` - Output buffer (will reference frame data)
+/// * `buffer` - Output buffer referencing frame payload. The returned buffer
+///   borrows memory from the frame and **must not** be freed by the caller.
 ///
 /// # Returns
 /// * Result code


### PR DESCRIPTION
## Summary
- export a shared Tokio runtime and document buffer ownership semantics
- replace direct `block_on` calls with the shared runtime
- generate C headers and add an error-handling example

## Testing
- `cargo build -p betanet-ffi` *(fails: failed to parse manifest: failed to find a workspace root)*
- `gcc -I../include -c error_example.c`


------
https://chatgpt.com/codex/tasks/task_e_68b8d0021b04832c9d6be7a1049f9b2f