### PR TITLE
Enable real QUIC MASQUE demo and TLS camouflage

### DIFF
--- a/integrations/bounties/betanet/crates/betanet-htx/examples/echo_client.rs
+++ b/integrations/bounties/betanet/crates/betanet-htx/examples/echo_client.rs
@@ -7,10 +7,7 @@
 //! - Noise XK handshake
 //! - Stream multiplexing
 
-use betanet_htx::{
-    dial_tcp, HtxConfig, HtxError, Result, StreamMux,
-    TlsCamouflageBuilder, create_tls_connector,
-};
+use betanet_htx::{dial_tcp, HtxConfig, HtxError, Result, StreamMux, TlsCamouflageBuilder};
 use clap::Parser;
 use std::net::SocketAddr;
 use tokio::sync::mpsc;
@@ -33,9 +30,9 @@ struct Args {
     #[arg(long)]
     quic: bool,
 
-    /// Enable ECH stub
+    /// Enable Encrypted Client Hello
     #[arg(long)]
-    ech_stub: bool,
+    enable_ech: bool,
 
     /// JA3 template to use
     #[arg(long)]
@@ -89,23 +86,25 @@ async fn main() -> Result<()> {
         enable_tcp: args.tcp || (!args.tcp && !args.quic), // Default to TCP
         enable_quic: args.quic,
         enable_noise_xk: true,
-        enable_tls_camouflage: args.ech_stub,
+        enable_tls_camouflage: args.enable_ech || args.ja3_template.is_some(),
         camouflage_domain: args.camouflage_domain.clone(),
         ech_config_path: args.ech_config_path.clone().map(Into::into),
         alpn_protocols: vec!["htx/1.1".to_string(), "h2".to_string()],
         ..Default::default()
     };
 
-    if args.ech_stub {
-        info!("ECH stub enabled for TLS camouflage");
+    if args.enable_ech {
+        info!("ECH enabled for TLS camouflage");
     }
 
-    if let Some(template) = &args.ja3_template {
-        info!("Using JA3 template: {}", template);
-        // Apply JA3 template (stub implementation)
-        if let Err(e) = betanet_htx::tls::apply_ja3_template(template) {
-            warn!("Failed to apply JA3 template: {}", e);
+    if args.enable_ech || args.ja3_template.is_some() {
+        let mut builder = TlsCamouflageBuilder::new().with_ech(args.enable_ech);
+        if let Some(template) = &args.ja3_template {
+            info!("Using JA3 template: {}", template);
+            builder = builder.with_ja3_template(template.clone());
         }
+        let connector = builder.build()?;
+        info!("TLS camouflage fingerprint: {}", connector.fingerprint());
     }
 
     // Connect using the appropriate transport
@@ -268,7 +267,7 @@ mod tests {
             "echo_client",
             "--server", "192.168.1.100:8443",
             "--quic",
-            "--ech-stub",
+            "--enable-ech",
             "--ja3-template", "firefox_latest",
             "--message", "Test message",
             "--count", "3",
@@ -279,7 +278,7 @@ mod tests {
         assert_eq!(args.server, "192.168.1.100:8443".parse().unwrap());
         assert!(!args.tcp);
         assert!(args.quic);
-        assert!(args.ech_stub);
+        assert!(args.enable_ech);
         assert_eq!(args.ja3_template, Some("firefox_latest".to_string()));
         assert_eq!(args.message, "Test message");
         assert_eq!(args.count, 3);

--- a/integrations/clients/rust/betanet-htx/examples/README.md
+++ b/integrations/clients/rust/betanet-htx/examples/README.md
@@ -1,0 +1,30 @@
+# HTX Example Programs
+
+This directory contains standalone examples demonstrating HTX network features.
+
+## Echo Client and Server
+
+```
+cargo run --package betanet-htx --example echo_server
+cargo run --package betanet-htx --example echo_client -- --message "hello"
+```
+
+Both examples support TLS camouflage options such as JA3 templates and
+Encrypted Client Hello via the `--enable-ech` flag.
+
+## QUIC DATAGRAM Demo
+
+```
+cargo run --package betanet-htx --example htx_quic_datagram_demo --features quic
+```
+
+Shows HTX over QUIC with DATAGRAM support and TLS camouflage enabled.
+
+## QUIC + MASQUE Demo
+
+```
+cargo run --package betanet-htx --example htx_quic_masque_demo --features quic
+```
+
+Runs a local QUIC server and MASQUE proxy, forwarding UDP traffic through an
+encapsulated tunnel.

--- a/integrations/clients/rust/betanet-htx/examples/htx_quic_masque_demo.rs
+++ b/integrations/clients/rust/betanet-htx/examples/htx_quic_masque_demo.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "quic")]
+
 //! HTX QUIC/H3 + MASQUE Demo
 //!
 //! Demonstrates HTTP/3 over QUIC with MASQUE CONNECT-UDP proxying
@@ -10,20 +12,28 @@
 //! 4. Performance metrics and logging
 
 use std::net::SocketAddr;
-use std::time::{Duration, Instant};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime};
 
 use bytes::Bytes;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tracing::{info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
 
 // Import HTX components
-#[cfg(feature = "quic")]
 use betanet_htx::{
-    masque::{MasqueClient, MasqueProxy, ConnectUdpRequest, MasqueDatagram},
-    quic::{QuicTransport, EchConfig},
+    masque::{ConnectUdpRequest, MasqueDatagram, MasqueProxy},
+    quic::QuicTransport,
     HtxConfig,
 };
+
+use quinn::{Endpoint, ServerConfig, TransportConfig};
+use rcgen::generate_simple_self_signed;
+use rustls::client::{ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
+use rustls::Error as TlsError;
 
 /// Demo configuration
 struct DemoConfig {
@@ -39,8 +49,8 @@ impl Default for DemoConfig {
     fn default() -> Self {
         Self {
             proxy_addr: "127.0.0.1:8080".parse().unwrap(),
-            target_host: "8.8.8.8".to_string(),
-            target_port: 53,
+            target_host: "127.0.0.1".to_string(),
+            target_port: 9999,
             test_payload_size: 512,
             test_iterations: 10,
             enable_ech: true,
@@ -84,22 +94,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = DemoConfig::default();
 
-    // Run the demo
-    #[cfg(feature = "quic")]
-    {
-        run_quic_masque_demo(config).await?;
-    }
-    #[cfg(not(feature = "quic"))]
-    {
-        run_stub_demo(config).await?;
-    }
+    run_quic_masque_demo(config).await?;
 
     Ok(())
 }
 
-#[cfg(feature = "quic")]
 async fn run_quic_masque_demo(config: DemoConfig) -> Result<(), Box<dyn std::error::Error>> {
     info!("📡 Testing QUIC/H3 Transport with MASQUE Proxying");
+
+    // Start local UDP echo server for MASQUE target
+    let target_addr: SocketAddr = format!("{}:{}", config.target_host, config.target_port).parse()?;
+    let echo_handle = tokio::spawn(async move {
+        let socket = UdpSocket::bind(target_addr).await.unwrap();
+        let mut buf = vec![0u8; 65535];
+        loop {
+            if let Ok((len, peer)) = socket.recv_from(&mut buf).await {
+                let _ = socket.send_to(&buf[..len], peer).await;
+            }
+        }
+    });
 
     // Phase 1: QUIC Connection Setup
     info!("\n🔗 Phase 1: QUIC Connection Establishment");
@@ -124,52 +137,28 @@ async fn run_quic_masque_demo(config: DemoConfig) -> Result<(), Box<dyn std::err
     analyze_security_features(&quic_metrics).await?;
 
     info!("\n✅ QUIC/H3 + MASQUE Demo Completed Successfully");
+    echo_handle.abort();
     Ok(())
 }
 
-#[cfg(not(feature = "quic"))]
-async fn run_stub_demo(config: DemoConfig) -> Result<(), Box<dyn std::error::Error>> {
-    info!("⚠️  QUIC feature not enabled - running simulation");
-
-    // Simulate QUIC connection
-    info!("\n🔗 Simulating QUIC Connection...");
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let quic_metrics = ConnectionMetrics {
-        connection_time: Duration::from_millis(50),
-        handshake_time: Duration::from_millis(30),
-        datagram_support: true,
-        max_datagram_size: Some(1200),
-        alpn_protocol: "h3".to_string(),
-        ech_enabled: config.enable_ech,
-    };
-
-    print_quic_metrics(&quic_metrics);
-
-    // Simulate MASQUE proxy
-    info!("\n🌐 Simulating MASQUE Proxy...");
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    let proxy_metrics = ProxyMetrics {
-        sessions_created: config.test_iterations as u64,
-        total_bytes_proxied: (config.test_payload_size * config.test_iterations) as u64,
-        avg_latency: Duration::from_millis(25),
-        success_rate: 100.0,
-    };
-
-    print_masque_metrics(&proxy_metrics);
-
-    // Simulate performance tests
-    info!("\n⚡ Simulating Performance Tests...");
-    simulate_performance_tests(&config).await?;
-
-    info!("\n✅ QUIC/H3 + MASQUE Simulation Completed");
-    Ok(())
-}
-
-#[cfg(feature = "quic")]
 async fn test_quic_connection(config: &DemoConfig) -> Result<ConnectionMetrics, Box<dyn std::error::Error>> {
     let start_time = Instant::now();
+
+    // Generate self-signed certificate for local QUIC server
+    let cert = generate_simple_self_signed(vec!["localhost".to_string()])?;
+    let cert_der = CertificateDer::from(cert.der().to_owned());
+    let key_der = PrivatePkcs8KeyDer::from(cert.serialize_private_key_der());
+    let mut server_config = ServerConfig::with_single_cert(vec![cert_der], key_der.into())?;
+    let mut transport = TransportConfig::default();
+    transport.max_datagram_frame_size(Some(65535));
+    server_config.transport = Arc::new(transport);
+
+    let mut endpoint = Endpoint::server(server_config, config.proxy_addr)?;
+    tokio::spawn(async move {
+        while let Some(conn) = endpoint.accept().await {
+            let _ = conn.await;
+        }
+    });
 
     // Configure HTX for QUIC
     let htx_config = HtxConfig {
@@ -193,27 +182,42 @@ async fn test_quic_connection(config: &DemoConfig) -> Result<ConnectionMetrics, 
     info!("    • ALPN: h3, h3-32");
     info!("    • ECH: {}", if config.enable_ech { "enabled" } else { "disabled" });
 
-    // Attempt QUIC connection
+    // Custom certificate verifier that accepts self-signed certs
+    struct NoVerifier;
+    impl ServerCertVerifier for NoVerifier {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &rustls::pki_types::ServerName<'_>,
+            _scts: &mut dyn Iterator<Item = &[u8]>,
+            _ocsp: &[u8],
+            _now: SystemTime,
+        ) -> Result<ServerCertVerified, TlsError> {
+            Ok(ServerCertVerified::assertion())
+        }
+    }
+
     let handshake_start = Instant::now();
-
-    // In a real implementation, this would connect to an actual QUIC server
-    // For demo purposes, we'll simulate the connection metrics
-    tokio::time::sleep(Duration::from_millis(50)).await; // Simulate connection time
-
+    let verifier = Arc::new(NoVerifier);
+    let mut transport = QuicTransport::connect(config.proxy_addr, &htx_config, Some(verifier)).await?;
     let connection_time = start_time.elapsed();
     let handshake_time = handshake_start.elapsed();
+
+    let datagram_support = transport.has_datagram_support();
+    let max_datagram_size = transport.max_datagram_size();
+    transport.close().await?;
 
     Ok(ConnectionMetrics {
         connection_time,
         handshake_time,
-        datagram_support: true,
-        max_datagram_size: Some(1200),
+        datagram_support,
+        max_datagram_size,
         alpn_protocol: "h3".to_string(),
         ech_enabled: config.enable_ech,
     })
 }
 
-#[cfg(feature = "quic")]
 async fn setup_masque_proxy() -> Result<MasqueProxy, Box<dyn std::error::Error>> {
     info!("  🔧 Initializing MASQUE proxy...");
 
@@ -233,61 +237,54 @@ async fn setup_masque_proxy() -> Result<MasqueProxy, Box<dyn std::error::Error>>
     Ok(proxy)
 }
 
-#[cfg(feature = "quic")]
 async fn test_masque_tunneling(
     config: &DemoConfig,
     proxy: &MasqueProxy,
 ) -> Result<ProxyMetrics, Box<dyn std::error::Error>> {
     info!("  🔄 Testing UDP tunneling through MASQUE...");
+    let connect_request = ConnectUdpRequest {
+        session_id: 1,
+        target_host: config.target_host.clone(),
+        target_port: config.target_port,
+        client_addr: "127.0.0.1:12345".parse().unwrap(),
+    };
+
+    let response = proxy.handle_connect_udp(connect_request).await?;
+    if response.status_code != 200 {
+        return Err("CONNECT-UDP failed".into());
+    }
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    proxy.start_target_receiver(response.session_id, tx).await?;
 
     let mut total_bytes = 0u64;
-    let mut successful_requests = 0u64;
+    let mut success_count = 0u64;
     let mut total_latency = Duration::ZERO;
 
     for i in 0..config.test_iterations {
         let iteration_start = Instant::now();
-
-        // Create CONNECT-UDP request
-        let connect_request = ConnectUdpRequest {
-            session_id: (i + 1) as u64,
-            target_host: config.target_host.clone(),
-            target_port: config.target_port,
-            client_addr: "127.0.0.1:12345".parse().unwrap(),
+        let test_payload = vec![i as u8; config.test_payload_size];
+        let datagram = MasqueDatagram {
+            session_id: response.session_id,
+            context_id: response.context_id.unwrap_or(0),
+            payload: Bytes::from(test_payload),
         };
-
-        // Handle CONNECT-UDP request
-        match proxy.handle_connect_udp(connect_request).await {
-            Ok(response) => {
-                if response.status_code == 200 {
-                    successful_requests += 1;
-
-                    // Simulate UDP traffic
-                    let test_payload = vec![0u8; config.test_payload_size];
-                    let datagram = MasqueDatagram {
-                        session_id: response.session_id,
-                        context_id: response.context_id.unwrap_or(0),
-                        payload: Bytes::from(test_payload),
-                    };
-
-                    if proxy.handle_client_datagram(datagram).await.is_ok() {
-                        total_bytes += config.test_payload_size as u64;
-                    }
-                }
-            }
-            Err(e) => {
-                warn!("MASQUE request failed: {}", e);
-            }
+        proxy.handle_client_datagram(datagram).await?;
+        if let Ok(Some(returned)) = timeout(Duration::from_secs(1), rx.recv()).await {
+            total_bytes += returned.payload.len() as u64;
+            success_count += 1;
+        } else {
+            warn!("No MASQUE response for datagram {}", i + 1);
         }
-
         total_latency += iteration_start.elapsed();
-
-        if (i + 1) % (config.test_iterations / 4) == 0 {
-            info!("    Progress: {}/{} requests", i + 1, config.test_iterations);
-        }
     }
 
-    let success_rate = (successful_requests as f64 / config.test_iterations as f64) * 100.0;
-    let avg_latency = total_latency / config.test_iterations as u32;
+    let success_rate = (success_count as f64 / config.test_iterations as f64) * 100.0;
+    let avg_latency = if config.test_iterations > 0 {
+        total_latency / config.test_iterations as u32
+    } else {
+        Duration::ZERO
+    };
 
     info!("  📊 MASQUE tunnel test results:");
     info!("    • Success rate: {:.1}%", success_rate);
@@ -295,14 +292,13 @@ async fn test_masque_tunneling(
     info!("    • Average latency: {:.2}ms", avg_latency.as_millis());
 
     Ok(ProxyMetrics {
-        sessions_created: successful_requests,
+        sessions_created: 1,
         total_bytes_proxied: total_bytes,
         avg_latency,
         success_rate,
     })
 }
 
-#[cfg(feature = "quic")]
 async fn run_performance_tests(config: &DemoConfig) -> Result<(), Box<dyn std::error::Error>> {
     info!("  🏃 Running performance benchmarks...");
 
@@ -340,20 +336,6 @@ async fn run_performance_tests(config: &DemoConfig) -> Result<(), Box<dyn std::e
     // Test 3: Connection capacity
     info!("    • Connection capacity: 1000 concurrent sessions");
     info!("    • Session lifecycle: 300s timeout with cleanup");
-
-    Ok(())
-}
-
-async fn simulate_performance_tests(config: &DemoConfig) -> Result<(), Box<dyn std::error::Error>> {
-    info!("  🏃 Simulating performance benchmarks...");
-
-    // Simulate performance measurements
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    info!("    • Throughput: 85.5 MB/s");
-    info!("    • Latency (avg/min/max): 12.5ms / 8.2ms / 24.1ms");
-    info!("    • Connection capacity: 1000 concurrent sessions");
-    info!("    • Packet loss: 0.1%");
 
     Ok(())
 }
@@ -421,8 +403,8 @@ mod tests {
     async fn test_demo_config() {
         let config = DemoConfig::default();
         assert_eq!(config.proxy_addr.port(), 8080);
-        assert_eq!(config.target_host, "8.8.8.8");
-        assert_eq!(config.target_port, 53);
+        assert_eq!(config.target_host, "127.0.0.1");
+        assert_eq!(config.target_port, 9999);
     }
 
     #[tokio::test]
@@ -439,5 +421,23 @@ mod tests {
         assert!(metrics.connection_time < Duration::from_millis(100));
         assert!(metrics.datagram_support);
         assert_eq!(metrics.alpn_protocol, "h3");
+    }
+
+    #[tokio::test]
+    async fn test_masque_smoke() {
+        let mut config = DemoConfig::default();
+        config.test_iterations = 1;
+        let target_addr: SocketAddr = format!("{}:{}", config.target_host, config.target_port).parse().unwrap();
+        let echo_handle = tokio::spawn(async move {
+            let socket = UdpSocket::bind(target_addr).await.unwrap();
+            let mut buf = vec![0u8; 65535];
+            if let Ok((len, peer)) = socket.recv_from(&mut buf).await {
+                let _ = socket.send_to(&buf[..len], peer).await;
+            }
+        });
+        let proxy = setup_masque_proxy().await.unwrap();
+        let metrics = test_masque_tunneling(&config, &proxy).await.unwrap();
+        assert_eq!(metrics.sessions_created, 1);
+        echo_handle.abort();
     }
 }


### PR DESCRIPTION
## Summary
- integrate finalized TLS camouflage API in echo client/server examples
- implement real QUIC connection setup and MASQUE UDP tunneling demo
- document and smoke-test examples with README instructions

## Testing
- `cargo test --examples --features quic` *(fails: failed to find a workspace root)*
- `cargo test --manifest-path integrations/bounties/betanet/Cargo.toml --examples` *(partial build, aborted due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d005f17c832cafde78d136a823c0