### PR TITLE
Use secure RNG for mixnode keys and add stats command

### DIFF
--- a/integrations/bounties/betanet/crates/betanet-mixnode/Cargo.toml
+++ b/integrations/bounties/betanet/crates/betanet-mixnode/Cargo.toml
@@ -29,6 +29,7 @@ clap = { workspace = true }
 sysinfo = "0.30"
 chrono = { version = "0.4", features = ["serde"] }
 num_cpus = "1.16"
+tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 # VRF dependencies
 curve25519-dalek = { version = "4.1", optional = true }
@@ -38,7 +39,6 @@ schnorrkel = { version = "0.11", optional = true }
 tokio = { workspace = true, features = ["test-util"] }
 proptest = { workspace = true }
 tempfile = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [features]
 default = ["sphinx", "cover-traffic"]

--- a/integrations/bounties/betanet/crates/betanet-mixnode/src/crypto.rs
+++ b/integrations/bounties/betanet/crates/betanet-mixnode/src/crypto.rs
@@ -76,8 +76,10 @@ pub struct Ed25519Signer {
 impl Ed25519Signer {
     /// Create new signer with random key
     pub fn new() -> Self {
-        // Use a deterministic key for now to avoid RNG compatibility issues
-        let secret_bytes = [42u8; 32]; // Reference implementation: cryptographically secure random generation
+        use rand::RngCore;
+        let mut rng = OsRng;
+        let mut secret_bytes = [0u8; 32];
+        rng.fill_bytes(&mut secret_bytes);
         let secret = SecretKey::from_bytes(&secret_bytes).unwrap();
         let public = Ed25519PublicKey::from(&secret);
         let keypair = Keypair { secret, public };
@@ -132,8 +134,10 @@ pub struct X25519KeyExchange {
 impl X25519KeyExchange {
     /// Create new key exchange with random key
     pub fn new() -> Self {
-        // Use deterministic key for now to avoid RNG compatibility issues
-        let secret_bytes = [42u8; 32]; // Reference implementation: cryptographically secure random generation
+        use rand::RngCore;
+        let mut rng = OsRng;
+        let mut secret_bytes = [0u8; 32];
+        rng.fill_bytes(&mut secret_bytes);
         let secret = StaticSecret::from(secret_bytes);
         Self { secret }
     }

--- a/integrations/bounties/betanet/crates/betanet-mixnode/src/lib.rs
+++ b/integrations/bounties/betanet/crates/betanet-mixnode/src/lib.rs
@@ -11,6 +11,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 use thiserror::Error;
@@ -79,7 +80,7 @@ pub enum MixnodeError {
 pub type Result<T> = std::result::Result<T, MixnodeError>;
 
 /// Mixnode statistics
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct MixnodeStats {
     /// Packets processed
     pub packets_processed: u64,

--- a/integrations/bounties/betanet/crates/betanet-mixnode/src/sphinx.rs
+++ b/integrations/bounties/betanet/crates/betanet-mixnode/src/sphinx.rs
@@ -11,6 +11,8 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use hkdf::Hkdf;
+use rand::rngs::OsRng;
+use rand::RngCore;
 use sha2::{Digest, Sha256};
 use x25519_dalek::{PublicKey, StaticSecret};
 
@@ -284,8 +286,9 @@ pub struct SphinxStats {
 impl SphinxProcessor {
     /// Create new Sphinx processor
     pub fn new() -> Self {
-        // Use deterministic key for now to avoid RNG compatibility issues
-        let private_key_bytes = [42u8; 32]; // Reference implementation: cryptographically secure random generation
+        let mut rng = OsRng;
+        let mut private_key_bytes = [0u8; 32];
+        rng.fill_bytes(&mut private_key_bytes);
         let private_key = StaticSecret::from(private_key_bytes);
         let public_key = PublicKey::from(&private_key);
 

--- a/integrations/clients/rust/betanet-mixnode/Cargo.toml
+++ b/integrations/clients/rust/betanet-mixnode/Cargo.toml
@@ -30,6 +30,7 @@ sysinfo = "0.30"
 chrono = { version = "0.4", features = ["serde"] }
 num_cpus = "1.16"
 crossbeam-queue = "0.3"
+tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 # VRF dependencies
 curve25519-dalek = { version = "4.1", optional = true }
@@ -39,7 +40,6 @@ schnorrkel = { version = "0.11", optional = true }
 tokio = { workspace = true, features = ["test-util"] }
 proptest = { workspace = true }
 tempfile = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [features]
 default = ["sphinx", "cover-traffic"]

--- a/integrations/clients/rust/betanet-mixnode/src/crypto.rs
+++ b/integrations/clients/rust/betanet-mixnode/src/crypto.rs
@@ -76,8 +76,10 @@ pub struct Ed25519Signer {
 impl Ed25519Signer {
     /// Create new signer with random key
     pub fn new() -> Self {
-        // Use a deterministic key for now to avoid RNG compatibility issues
-        let secret_bytes = [42u8; 32]; // Reference implementation: cryptographically secure random generation
+        use rand::RngCore;
+        let mut rng = OsRng;
+        let mut secret_bytes = [0u8; 32];
+        rng.fill_bytes(&mut secret_bytes);
         let secret = SecretKey::from_bytes(&secret_bytes).unwrap();
         let public = Ed25519PublicKey::from(&secret);
         let keypair = Keypair { secret, public };
@@ -132,8 +134,10 @@ pub struct X25519KeyExchange {
 impl X25519KeyExchange {
     /// Create new key exchange with random key
     pub fn new() -> Self {
-        // Use deterministic key for now to avoid RNG compatibility issues
-        let secret_bytes = [42u8; 32]; // Reference implementation: cryptographically secure random generation
+        use rand::RngCore;
+        let mut rng = OsRng;
+        let mut secret_bytes = [0u8; 32];
+        rng.fill_bytes(&mut secret_bytes);
         let secret = StaticSecret::from(secret_bytes);
         Self { secret }
     }

--- a/integrations/clients/rust/betanet-mixnode/src/lib.rs
+++ b/integrations/clients/rust/betanet-mixnode/src/lib.rs
@@ -11,6 +11,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 use thiserror::Error;
@@ -79,7 +80,7 @@ pub enum MixnodeError {
 pub type Result<T> = std::result::Result<T, MixnodeError>;
 
 /// Mixnode statistics
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct MixnodeStats {
     /// Packets processed
     pub packets_processed: u64,

--- a/integrations/clients/rust/betanet-mixnode/src/main.rs
+++ b/integrations/clients/rust/betanet-mixnode/src/main.rs
@@ -3,10 +3,20 @@
 use std::net::SocketAddr;
 
 use clap::{Parser, Subcommand};
-use tracing::info;
-// use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tracing::{info, Level};
+use tracing_subscriber::FmtSubscriber;
 
-use betanet_mixnode::{config::MixnodeConfig, mixnode::StandardMixnode, Mixnode, Result};
+use betanet_mixnode::{
+    config::MixnodeConfig,
+    mixnode::StandardMixnode,
+    packet::Packet,
+    Mixnode,
+    MixnodeError,
+    MixnodeStats,
+    Result,
+};
+use bytes::Bytes;
 
 /// Betanet Mixnode CLI
 #[derive(Parser)]
@@ -62,11 +72,12 @@ enum Commands {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Initialize tracing (simplified)
-    if cli.verbose {
-        // Enable verbose logging (placeholder for now)
-        println!("Verbose logging enabled");
-    }
+    // Initialize tracing subscriber with level based on --verbose flag
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(if cli.verbose { Level::DEBUG } else { Level::INFO })
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("setting default subscriber failed");
 
     match cli.command {
         Commands::Start {
@@ -98,21 +109,41 @@ async fn main() -> Result<()> {
         Commands::Keygen { output } => {
             info!("Generating keypair to {:?}", output);
 
-            // Use a deterministic key for now (Reference implementation: cryptographically secure random generation)
-            let private_key = [42u8; 32];
+            use rand::rngs::OsRng;
+            use rand::RngCore;
+            let mut private_key = [0u8; 32];
+            OsRng.fill_bytes(&mut private_key);
 
-            std::fs::write(output, private_key).map_err(betanet_mixnode::MixnodeError::Io)?;
+            std::fs::write(output, private_key).map_err(MixnodeError::Io)?;
 
             info!("Keypair generated successfully");
         }
 
         Commands::Stats { node } => {
             info!("Querying statistics from {}", node);
-            // This would connect to the node and fetch stats
-            // For now, just print a placeholder
+            let mut stream = tokio::net::TcpStream::connect(node)
+                .await
+                .map_err(MixnodeError::Io)?;
+
+            // Send control packet requesting stats
+            let packet = Packet::control(Bytes::from_static(b"stats"));
+            let request = packet.encode()?;
+            stream.write_all(&request).await.map_err(MixnodeError::Io)?;
+
+            // Read response
+            let mut buf = vec![0u8; 1024];
+            let n = stream.read(&mut buf).await.map_err(MixnodeError::Io)?;
+            let response = Packet::parse(&buf[..n])?;
+            let stats: MixnodeStats =
+                serde_json::from_slice(&response.payload).map_err(|e| MixnodeError::Network(e.to_string()))?;
+
             println!("Statistics for node {}:", node);
-            println!("  Packets processed: N/A");
-            println!("  Uptime: N/A");
+            println!("  Packets processed: {}", stats.packets_processed);
+            println!("  Packets forwarded: {}", stats.packets_forwarded);
+            println!("  Packets dropped: {}", stats.packets_dropped);
+            println!("  Cover traffic sent: {}", stats.cover_traffic_sent);
+            println!("  Avg processing time: {:.2} µs", stats.avg_processing_time_us);
+            println!("  Uptime: {} s", stats.uptime_secs);
         }
     }
 

--- a/integrations/clients/rust/betanet-mixnode/src/sphinx.rs
+++ b/integrations/clients/rust/betanet-mixnode/src/sphinx.rs
@@ -11,6 +11,8 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use hkdf::Hkdf;
+use rand::rngs::OsRng;
+use rand::RngCore;
 use sha2::{Digest, Sha256};
 use x25519_dalek::{PublicKey, StaticSecret};
 
@@ -284,8 +286,9 @@ pub struct SphinxStats {
 impl SphinxProcessor {
     /// Create new Sphinx processor
     pub fn new() -> Self {
-        // Use deterministic key for now to avoid RNG compatibility issues
-        let private_key_bytes = [42u8; 32]; // Reference implementation: cryptographically secure random generation
+        let mut rng = OsRng;
+        let mut private_key_bytes = [0u8; 32];
+        rng.fill_bytes(&mut private_key_bytes);
         let private_key = StaticSecret::from(private_key_bytes);
         let public_key = PublicKey::from(&private_key);
 


### PR DESCRIPTION
## Summary
- generate keys using secure randomness instead of hardcoded bytes
- add tracing subscriber initialization respecting `--verbose`
- implement `Stats` control channel to query live node metrics

## Testing
- `cargo test -p betanet-mixnode`

------
https://chatgpt.com/codex/tasks/task_e_68b8d01272d0832c8da890b46fbbeb83