### PR TITLE
Implement QUIC connect with ECH support and datagram tests

### DIFF
--- a/integrations/bounties/betanet/crates/betanet-htx/Cargo.toml
+++ b/integrations/bounties/betanet/crates/betanet-htx/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 bincode = { workspace = true }
-# rcgen = { version = "0.13", optional = true }
+rcgen = { version = "0.13", optional = true }
 # Transport and multiplexing
 futures = { workspace = true }
 # TLS fingerprint integration (temporarily disabled)
@@ -44,8 +44,8 @@ webpki-roots = { workspace = true }
 base64 = "0.21"
 urlencoding = "2.1"
 hex = "0.4"
-# rcgen = "0.13"
-# trust-dns-resolver = { version = "0.23", optional = true }
+trust-dns-resolver = { version = "0.23", optional = true, default-features = false, features = ["tokio-runtime", "system-config"] }
+once_cell = "1.19"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
@@ -58,7 +58,7 @@ rand_distr = "0.4"
 [features]
 default = ["tcp", "noise-xk"]
 tcp = []
-quic = ["dep:quinn"]
+quic = ["dep:quinn", "dep:rcgen", "dep:trust-dns-resolver"]
 noise-xk = []
 hybrid-kem-stub = []
 tls-fingerprint = []

--- a/integrations/bounties/betanet/crates/betanet-htx/tests/quic_datagram_echo.rs
+++ b/integrations/bounties/betanet/crates/betanet-htx/tests/quic_datagram_echo.rs
@@ -1,0 +1,50 @@
+use betanet_htx::{HtxConfig, Frame};
+use betanet_htx::quic::QuicTransport;
+use bytes::Bytes;
+use quinn::{Endpoint, ServerConfig, TransportConfig};
+use rcgen::generate_simple_self_signed;
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn test_quic_datagram_echo() {
+    // Generate a self-signed certificate for the server
+    let cert = generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+    let cert_der = CertificateDer::from(cert.cert);
+    let key_der = PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+
+    let mut server_config = ServerConfig::with_single_cert(vec![cert_der], key_der.into()).unwrap();
+    let mut transport = TransportConfig::default();
+    transport.max_datagram_frame_size(Some(65535));
+    server_config.transport = Arc::new(transport);
+
+    let mut endpoint = Endpoint::server(server_config, "127.0.0.1:0".parse().unwrap()).unwrap();
+    let server_addr = endpoint.local_addr().unwrap();
+
+    // Echo server task
+    tokio::spawn(async move {
+        if let Some(connecting) = endpoint.accept().await {
+            if let Ok(conn) = connecting.await {
+                if let Ok(data) = conn.read_datagram().await {
+                    let _ = conn.send_datagram(data);
+                }
+                conn.close(0u32.into(), b"done");
+            }
+        }
+    });
+
+    // Client configuration
+    let mut config = HtxConfig::default();
+    config.enable_quic = true;
+    config.enable_tls_camouflage = false;
+    config.alpn_protocols = vec!["h3".to_string()];
+
+    let mut transport = QuicTransport::connect(server_addr, &config).await.unwrap();
+    let frame = Frame::data(1, Bytes::from_static(b"hello")).unwrap();
+    transport.send_datagram(frame.clone()).await.unwrap();
+
+    let received = transport.recv_datagram().await.unwrap().expect("no datagram");
+    assert_eq!(received.payload, frame.payload);
+
+    transport.close().await.unwrap();
+}


### PR DESCRIPTION
## Summary
- implement QUIC client and server connection logic using `quinn`
- add runtime ECH configuration via DNS or file
- support QUIC datagram send/receive and add integration test

## Testing
- `cargo test --features quic --tests` *(fails: build process terminated due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d7264ef4832c9c2d212650273ee4