### PR TITLE
Handle missing dependencies in pretrain script

### DIFF
--- a/core/agent-forge/phases/cognate_pretrain/pretrain_three_models.py
+++ b/core/agent-forge/phases/cognate_pretrain/pretrain_three_models.py
@@ -84,105 +84,11 @@ try:
 except ImportError as e:
     logger.error(f"Import error: {e}")
     logger.error(f"Current sys.path includes: {sys.path[:5]}")  # Show first 5 paths for debugging
-    # NO MORE MOCKS - FAIL HARD TO FORCE REAL FIXES
-    logger.error("NO MORE MOCK IMPLEMENTATIONS - REAL TRAINING MUST WORK!")
-    raise Exception(f"Import failed: {e}. Fix the imports properly!")
-
-    from dataclasses import dataclass
-
-    class MockConfig:
-        def __init__(self, **kwargs):
-            for k, v in kwargs.items():
-                setattr(self, k, v)
-
-    @dataclass
-    class TrainingConfig:
-        # Model architecture
-        model_size: str = "25M"
-        hidden_dim: int = 216
-        num_layers: int = 11
-        num_heads: int = 4
-
-        # Training dynamics
-        t_max_train: int = 16
-        t_min_train: int = 8
-        t_max_infer: int = 6
-        t_min_infer: int = 2
-
-        # Dataset curriculum
-        short_ratio: float = 0.45
-        long_ratio: float = 0.55
-
-        # Hyperparameters
-        batch_size: int = 8
-        learning_rate: float = 2e-4
-        weight_decay: float = 0.1
-        warmup_steps: int = 2000
-        max_steps: int = 50000
-        beta1: float = 0.9
-        beta2: float = 0.95
-
-        # GrokFast settings
-        grokfast_alpha: float = 0.98
-        grokfast_lamb: float = 2.0
-        grokfast_warmup: int = 2000
-
-        # Optimization
-        mixed_precision: bool = True
-        gradient_accumulation_steps: int = 4
-        max_grad_norm: float = 1.0
-
-        # Memory settings
-        memory_bank_size: int = 100000
-        memory_dim: int = 216
-
-        # Directories
-        checkpoint_dir: str = "./checkpoints"
-
-    class CognateDataset:
-        def __init__(self, config, data_files=None, tokenizer=None, split="train"):
-            self.config = config
-            self.data_files = data_files or []
-            self.tokenizer = tokenizer
-            self.split = split
-
-        def __len__(self):
-            return 1000  # Mock dataset size
-
-        def __getitem__(self, idx):
-            return {"input_ids": [1, 2, 3], "labels": [2, 3, 4], "attention_mask": [1, 1, 1]}
-
-    class CognateTrainingPipeline:
-        def __init__(self, config, model, tokenizer):
-            self.config = config
-            self.model = model
-            self.tokenizer = tokenizer
-
-        def train(self, train_dataset, eval_dataset=None, resume_from_checkpoint=None):
-            logger.info("Mock training started")
-            return []
-            self.d_model = 216
-            self.n_layers = 11
-            self.n_heads = 4
-
-    class MockModel:
-        def __init__(self, config):
-            self.config = config
-            self.variant_name = getattr(config, "variant_name", "mock")
-
-        def count_parameters(self):
-            return {"total": 25000000, "accuracy": "100.0%"}
-
-        def state_dict(self):
-            return {"mock": torch.randn(100, 100)}
-
-    class MockDataset:
-        def __init__(self, *args, **kwargs):
-            pass
-
-    CognateConfig = MockConfig
-    Enhanced25MCognate = MockModel
-    CognateDataset = MockDataset
+    raise ImportError(
+        "Required dependencies for Cognate pretraining are missing. "
+        "Install the agent-forge training components (e.g., run `pip install -e .` from the project root). "
+        f"Original error: {e}"
+    ) from e
 
 
 class SyntheticCognateDataset(CognateDataset):

--- a/core/agent_forge/phases/cognate_pretrain/pretrain_three_models.py
+++ b/core/agent_forge/phases/cognate_pretrain/pretrain_three_models.py
@@ -84,106 +84,11 @@ try:
 except ImportError as e:
     logger.error(f"Import error: {e}")
     logger.error(f"Current sys.path includes: {sys.path[:5]}")  # Show first 5 paths for debugging
-    # NO MORE MOCKS - FAIL HARD TO FORCE REAL FIXES
-    logger.error("NO MORE MOCK IMPLEMENTATIONS - REAL TRAINING MUST WORK!")
-    raise Exception(f"Import failed: {e}. Fix the imports properly!")
-
-    from dataclasses import dataclass
-
-    class MockConfig:
-        def __init__(self, **kwargs):
-            for k, v in kwargs.items():
-                setattr(self, k, v)
-
-    @dataclass
-    class TrainingConfig:
-        # Model architecture
-        model_size: str = "25M"
-        vocab_size: int = 32000
-        hidden_dim: int = 216
-        num_layers: int = 11
-        num_heads: int = 4
-
-        # Training dynamics
-        t_max_train: int = 16
-        t_min_train: int = 8
-        t_max_infer: int = 6
-        t_min_infer: int = 2
-
-        # Dataset curriculum
-        short_ratio: float = 0.45
-        long_ratio: float = 0.55
-
-        # Hyperparameters
-        batch_size: int = 8
-        learning_rate: float = 2e-4
-        weight_decay: float = 0.1
-        warmup_steps: int = 2000
-        max_steps: int = 50000
-        beta1: float = 0.9
-        beta2: float = 0.95
-
-        # GrokFast settings
-        grokfast_alpha: float = 0.98
-        grokfast_lamb: float = 2.0
-        grokfast_warmup: int = 2000
-
-        # Optimization
-        mixed_precision: bool = True
-        gradient_accumulation_steps: int = 4
-        max_grad_norm: float = 1.0
-
-        # Memory settings
-        memory_bank_size: int = 100000
-        memory_dim: int = 216
-
-        # Directories
-        checkpoint_dir: str = "./checkpoints"
-
-    class CognateDataset:
-        def __init__(self, config, data_files=None, tokenizer=None, split="train"):
-            self.config = config
-            self.data_files = data_files or []
-            self.tokenizer = tokenizer
-            self.split = split
-
-        def __len__(self):
-            return 1000  # Mock dataset size
-
-        def __getitem__(self, idx):
-            return {"input_ids": [1, 2, 3], "labels": [2, 3, 4], "attention_mask": [1, 1, 1]}
-
-    class CognateTrainingPipeline:
-        def __init__(self, config, model, tokenizer):
-            self.config = config
-            self.model = model
-            self.tokenizer = tokenizer
-
-        def train(self, train_dataset, eval_dataset=None, resume_from_checkpoint=None):
-            logger.info("Mock training started")
-            return []
-            self.d_model = 216
-            self.n_layers = 11
-            self.n_heads = 4
-
-    class MockModel:
-        def __init__(self, config):
-            self.config = config
-            self.variant_name = getattr(config, "variant_name", "mock")
-
-        def count_parameters(self):
-            return {"total": 25000000, "accuracy": "100.0%"}
-
-        def state_dict(self):
-            return {"mock": torch.randn(100, 100)}
-
-    class MockDataset:
-        def __init__(self, *args, **kwargs):
-            pass
-
-    CognateConfig = MockConfig
-    Enhanced25MCognate = MockModel
-    CognateDataset = MockDataset
+    raise ImportError(
+        "Required dependencies for Cognate pretraining are missing. "
+        "Install the agent-forge training components (e.g., run `pip install -e .` from the project root). "
+        f"Original error: {e}"
+    ) from e
 
 
 class SyntheticCognateDataset(CognateDataset):

--- a/tests/agent_forge/test_pretrain_three_models_import_error.py
+++ b/tests/agent_forge/test_pretrain_three_models_import_error.py
@@ -1,0 +1,20 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_pretrain_three_models_missing_dependencies():
+    """The pretrain script should raise a helpful ImportError when deps are missing."""
+    script_path = Path("core/agent_forge/phases/cognate_pretrain/pretrain_three_models.py")
+
+    original_path = list(sys.path)
+    try:
+        spec = importlib.util.spec_from_file_location("pretrain_three_models", script_path)
+        module = importlib.util.module_from_spec(spec)
+        with pytest.raises(ImportError) as excinfo:
+            spec.loader.exec_module(module)
+        assert "install the agent-forge training components" in str(excinfo.value).lower()
+    finally:
+        sys.path[:] = original_path


### PR DESCRIPTION
## Summary
- replace abrupt import failure in `pretrain_three_models.py` with helpful message instructing installation of Agent Forge dependencies
- remove obsolete mock fallback code
- add unit test validating the script's ImportError when dependencies are absent

## Testing
- `pytest tests/agent_forge/test_pretrain_three_models_import_error.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8dd3a2d0c832c81e2c83673a7d320