### PR TITLE
feat(ui): make agent forge endpoints configurable

### DIFF
--- a/ui/web/.env.example
+++ b/ui/web/.env.example
@@ -1,0 +1,4 @@
+VITE_AGENT_FORGE_API_URL=http://localhost:8083
+VITE_AGENT_FORGE_CHAT_API_URL=http://localhost:8084
+VITE_AGENT_FORGE_WS_URL=ws://localhost:8085/ws
+VITE_AGENT_FORGE_AGENT_API_URL=http://localhost:8086

--- a/ui/web/README.md
+++ b/ui/web/README.md
@@ -1,0 +1,24 @@
+# AIVillage Admin Web UI
+
+React-based administrative dashboard for the Agent Forge pipeline.
+
+## Environment Variables
+
+The dashboard reads API endpoints from environment variables. Defaults point to local services for development.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `VITE_AGENT_FORGE_API_URL` | Agent Forge backend API | `http://localhost:8083` |
+| `VITE_AGENT_FORGE_CHAT_API_URL` | Chat/model API | `http://localhost:8084` |
+| `VITE_AGENT_FORGE_WS_URL` | WebSocket endpoint | `ws://localhost:8085/ws` |
+| `VITE_AGENT_FORGE_AGENT_API_URL` | Agent status API | `http://localhost:8086` |
+
+Create a `.env` file in this directory to override any of these values.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+

--- a/ui/web/src/components/admin/AgentForgeControl.tsx
+++ b/ui/web/src/components/admin/AgentForgeControl.tsx
@@ -76,10 +76,14 @@ export const AgentForgeControl: React.FC = () => {
   });
   const [lastPingTime, setLastPingTime] = useState<number>(0);
 
-  const API_BASE = 'http://localhost:8083';
-  const CHAT_API = 'http://localhost:8084';
-  const WS_URL = 'ws://localhost:8085/ws';
-  const AGENT_API = 'http://localhost:8086';
+  const API_BASE =
+    import.meta.env.VITE_AGENT_FORGE_API_URL || 'http://localhost:8083';
+  const CHAT_API =
+    import.meta.env.VITE_AGENT_FORGE_CHAT_API_URL || 'http://localhost:8084';
+  const WS_URL =
+    import.meta.env.VITE_AGENT_FORGE_WS_URL || 'ws://localhost:8085/ws';
+  const AGENT_API =
+    import.meta.env.VITE_AGENT_FORGE_AGENT_API_URL || 'http://localhost:8086';
 
   useEffect(() => {
     // Connect to WebSocket for real-time updates

--- a/ui/web/vite.config.ts
+++ b/ui/web/vite.config.ts
@@ -10,5 +10,7 @@ export default defineConfig({
   build: {
     outDir: 'dist'
   },
-  root: '.'
+  root: '.',
+  // Expose VITE_ prefixed variables to the client
+  envPrefix: 'VITE_'
 })


### PR DESCRIPTION
## Summary
- allow AgentForgeControl to read API, chat, websocket and agent URLs from `VITE_` environment variables with localhost fallbacks
- expose `VITE_` variables in Vite config and provide example `.env`
- document new variables in web UI README

## Testing
- `npm test` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dd40f5cc832c82a488a2f7db30f8