### PR TITLE
Implement QUIC transport connect and datagram tests

### DIFF
--- a/integrations/bounties/betanet/crates/betanet-htx/Cargo.toml
+++ b/integrations/bounties/betanet/crates/betanet-htx/Cargo.toml
@@ -46,7 +46,7 @@ urlencoding = "2.1"
 hex = "0.4"
 # Self-signed certificate generation for tests
 rcgen = "0.13"
-# trust-dns-resolver = { version = "0.23", optional = true }
+trust-dns-resolver = { version = "0.23", optional = true, default-features = false, features = ["tokio-runtime", "system-config"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
@@ -60,7 +60,7 @@ criterion = { version = "0.5", features = ["async"] }
 [features]
 default = ["tcp", "noise-xk"]
 tcp = []
-quic = ["dep:quinn"]
+quic = ["dep:quinn", "dep:trust-dns-resolver"]
 noise-xk = []
 hybrid-kem-stub = []
 tls-fingerprint = []

--- a/integrations/bounties/betanet/crates/betanet-htx/src/lib.rs
+++ b/integrations/bounties/betanet/crates/betanet-htx/src/lib.rs
@@ -134,6 +134,22 @@ pub enum HtxError {
 /// Result type for HTX operations
 pub type Result<T> = std::result::Result<T, HtxError>;
 
+/// Connection abstraction for HTX transports
+#[async_trait::async_trait]
+pub trait HtxConnection: Send + Sync {
+    /// Send raw bytes over the connection
+    async fn send(&mut self, data: &[u8]) -> Result<()>;
+
+    /// Receive bytes from the connection into the provided buffer
+    async fn recv(&mut self, buf: &mut [u8]) -> Result<usize>;
+
+    /// Get the remote peer address
+    fn remote_addr(&self) -> Result<SocketAddr>;
+
+    /// Close the connection
+    async fn close(self) -> Result<()>;
+}
+
 /// HTX configuration
 #[derive(Debug, Clone)]
 pub struct HtxConfig {

--- a/integrations/bounties/betanet/crates/betanet-htx/src/server.rs
+++ b/integrations/bounties/betanet/crates/betanet-htx/src/server.rs
@@ -47,8 +47,13 @@ impl HtxServer {
         #[cfg(feature = "quic")]
         if self.config.enable_quic {
             let config = self.config.clone();
+            let handler_clone = handler.clone();
             tokio::spawn(async move {
-                if let Err(e) = crate::quic::QuicTransport::listen(config, handler).await {
+                if let Err(e) = crate::quic::QuicTransport::listen(config, move |conn| {
+                    handler_clone(Box::new(conn));
+                })
+                .await
+                {
                     error!("QUIC listener error: {}", e);
                 }
             });

--- a/integrations/bounties/betanet/crates/betanet-htx/tests/quic_datagram.rs
+++ b/integrations/bounties/betanet/crates/betanet-htx/tests/quic_datagram.rs
@@ -1,0 +1,42 @@
+#[cfg(feature = "quic")]
+use betanet_htx::{quic::QuicTransport, Frame, HtxConfig};
+#[cfg(feature = "quic")]
+use bytes::Bytes;
+#[cfg(feature = "quic")]
+use tokio::time::{sleep, Duration};
+
+#[cfg(feature = "quic")]
+#[tokio::test]
+async fn quic_datagram_echo() {
+    let mut config = HtxConfig::default();
+    config.enable_tcp = false;
+    config.enable_quic = true;
+    config.listen_addr = "127.0.0.1:9443".parse().unwrap();
+
+    let server_cfg = config.clone();
+    let server = tokio::spawn(async move {
+        QuicTransport::listen(server_cfg, |mut conn| {
+            tokio::spawn(async move {
+                if let Ok(Some(frame)) = conn.recv_datagram().await {
+                    let _ = conn.send_datagram(frame).await;
+                }
+            });
+        })
+        .await
+        .unwrap();
+    });
+
+    // Give server time to start
+    sleep(Duration::from_millis(100)).await;
+
+    let mut client = QuicTransport::connect(config.listen_addr, &config)
+        .await
+        .expect("client connect");
+    let frame = Frame::data(1, Bytes::from_static(b"hello")).unwrap();
+    client.send_datagram(frame.clone()).await.unwrap();
+    let echoed = client.recv_datagram().await.unwrap().expect("no frame");
+    assert_eq!(echoed.payload, frame.payload);
+    client.close().await.unwrap();
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- implement QUIC `connect` and `listen` using quinn with certificate generation and ECH configuration loading
- add datagram echo handling to example server and new integration test

## Testing
- `cargo test -p betanet-htx --features quic --tests` *(fails: no method named `add_trust_anchors`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8de68b610832ca973f00eba6758aa